### PR TITLE
feat(ar): add `ViroSpotLight` and `ViroQuad` to scene

### DIFF
--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -6,8 +6,10 @@ import {
   ViroARTrackingTargets,
   ViroImage,
   ViroMaterials,
+  ViroQuad,
   ViroSound,
   ViroSpatialSound,
+  ViroSpotLight,
   ViroVideo
 } from '@viro-community/react-viro';
 import PropTypes from 'prop-types';
@@ -105,39 +107,35 @@ const ViroSoundAnd3DObject = (item) => {
           {!!object?.mp3 &&
             (object.mp3?.isSpatialSound ? (
               <ViroSpatialSound
-                source={{ uri: object.mp3?.uri }}
+                source={{ uri: object.mp3.uri }}
                 paused={!isStartAnimationAndSound}
                 loop
-                maxDistance={object.mp3?.maxDistance}
-                minDistance={object.mp3?.minDistance}
-                position={object.mp3?.position}
-                rolloffModel={object.mp3?.rolloffModel}
+                maxDistance={object.mp3.maxDistance}
+                minDistance={object.mp3.minDistance}
+                position={object.mp3.position}
+                rolloffModel={object.mp3.rolloffModel}
               />
             ) : (
-              <ViroSound
-                source={{ uri: object.mp3?.uri }}
-                paused={!isStartAnimationAndSound}
-                loop
-              />
+              <ViroSound source={{ uri: object.mp3.uri }} paused={!isStartAnimationAndSound} loop />
             ))}
 
           {!!object?.mp4 && (
             <ViroVideo
               loop
               materials={['chromaKeyFilteredVideo']}
-              position={object.mp4?.position}
-              rotation={object.mp4?.rotation}
-              scale={object.mp4?.scale}
-              source={{ uri: object.mp4?.uri }}
+              position={object.mp4.position}
+              rotation={object.mp4.rotation}
+              scale={object.mp4.scale}
+              source={{ uri: object.mp4.uri }}
             />
           )}
 
           {!!object?.image && (
             <ViroImage
-              position={object.image?.position}
-              rotation={object.image?.rotation}
-              scale={object.image?.scale}
-              source={{ uri: object.image?.uri }}
+              position={object.image.position}
+              rotation={object.image.rotation}
+              scale={object.image.scale}
+              source={{ uri: object.image.uri }}
             />
           )}
         </>
@@ -157,6 +155,7 @@ const ViroSoundAnd3DObject = (item) => {
             onLoadStart={() => setIsObjectLoading(true)}
             onLoadEnd={() => setIsObjectLoading(false)}
             onError={() => alert(texts.augmentedReality.arShowScreen.objectLoadErrorAlert)}
+            shadowCastingBitMask={2}
             animation={{
               loop: true,
               name: object?.animationName,
@@ -164,6 +163,32 @@ const ViroSoundAnd3DObject = (item) => {
             }}
           />
         ))}
+
+      {object?.spot && (
+        <ViroSpotLight
+          direction={object.spot.direction}
+          innerAngle={object.spot.innerAngle}
+          outerAngle={object.spot.outerAngle}
+          position={object.spot.position}
+          shadowMapSize={object.spot.shadowMapSize}
+          shadowOpacity={object.spot.shadowOpacity}
+          castsShadow
+          influenceBitMask={2}
+          shadowFarZ={5}
+          shadowNearZ={2}
+        />
+      )}
+
+      {object?.quad && (
+        <ViroQuad
+          height={object.quad.height}
+          position={object.quad.position}
+          width={object.quad.width}
+          arShadowReceiver
+          lightReceivingBitMask={2}
+          rotation={[-90, 0, 0]}
+        />
+      )}
     </>
   );
 };

--- a/src/helpers/augmentedReality/downloadObject.js
+++ b/src/helpers/augmentedReality/downloadObject.js
@@ -6,6 +6,7 @@ import { DOWNLOAD_TYPE } from './downloadType';
 import { storageNameCreator } from './storageNameCreator';
 
 // function for downloading AR objects
+/* eslint-disable complexity */
 export const downloadObject = async ({ index, data, setData }) => {
   const downloadedData = [...data];
   const dataItem = data[index];
@@ -15,21 +16,28 @@ export const downloadObject = async ({ index, data, setData }) => {
       const {
         chromaKeyFilteredVideo,
         color,
+        direction,
+        height,
         id,
+        innerAngle,
         intensity,
         isSpatialSound,
         maxDistance,
         minDistance,
+        outerAngle,
         physicalWidth,
         position,
         rolloffModel,
         rotation,
         scale,
+        shadowMapSize,
+        shadowOpacity,
         stable,
         temperature,
         title,
         type,
-        uri
+        uri,
+        width
       } = objectItem;
 
       const { directoryName, folderName, storageName } = storageNameCreator({
@@ -71,22 +79,29 @@ export const downloadObject = async ({ index, data, setData }) => {
         downloadedData[index].payload.scenes[sceneIndex].localUris?.push({
           chromaKeyFilteredVideo, // HEX Color Code
           color, // HEX Color Code,
+          direction, // Array [x,y,z]
+          height, // Number
           id,
+          innerAngle: innerAngle && parseInt(innerAngle),
           intensity, // Number
           isSpatialSound, // Boolean
           maxDistance: maxDistance && parseFloat(maxDistance),
           minDistance: minDistance && parseFloat(minDistance),
+          outerAngle: outerAngle && parseInt(outerAngle),
           physicalWidth: physicalWidth && parseFloat(physicalWidth),
           position, // Array [x,y,z]
           rolloffModel, // String (none, linear, or logarithmic)
           rotation, // Array [x,y,z]
           scale, // Array [x,y,z]
-          size,
-          stable,
+          shadowMapSize: shadowMapSize && parseInt(shadowMapSize),
+          shadowOpacity: shadowOpacity && parseFloat(shadowOpacity),
+          size, // Number
+          stable, // Boolean
           temperature, // Number
-          title,
-          type,
-          uri: fileSystemDownload?.uri
+          title, // String
+          type, // String
+          uri: fileSystemDownload?.uri,
+          width // Number
         });
 
         addToStore(storageName, downloadedData[index]);
@@ -98,6 +113,7 @@ export const downloadObject = async ({ index, data, setData }) => {
 
   setData(downloadedData);
 };
+/* eslint-enable complexity */
 
 /**
  * callback function that allows us to see how many bytes per second the file is downloaded

--- a/src/helpers/augmentedReality/objectParser.js
+++ b/src/helpers/augmentedReality/objectParser.js
@@ -22,17 +22,24 @@ export const objectParser = async ({ payload, setObject, setIsLoading, onPress }
     parsedObject[item.type] = {
       chromaKeyFilteredVideo: item?.chromaKeyFilteredVideo,
       color: item?.color,
+      direction: item?.direction,
+      height: item?.height,
+      innerAngle: item?.innerAngle,
       intensity: item?.intensity,
       isSpatialSound: item?.isSpatialSound,
       maxDistance: item?.maxDistance,
       minDistance: item?.minDistance,
+      outerAngle: item?.outerAngle,
       physicalWidth: item?.physicalWidth,
       position: item?.position,
       rolloffModel: item?.rolloffModel,
       rotation: item?.rotation,
       scale: item?.scale,
+      shadowMapSize: item?.shadowMapSize,
+      shadowOpacity: item?.shadowOpacity,
       temperature: item?.temperature,
-      uri: item?.uri
+      uri: item?.uri,
+      width: item?.width
     };
   });
 


### PR DESCRIPTION
- added `ViroSpotLight` component which is required to show a shadow effect under the model
- added `ViroQuad` to create a virtual floor
- added the `arShadowReceiver` prop to `ViroQuad`, which is required for the shadow to mask the model
- added `shadowCastingBitMask` prop to `Viro3DObject` component to show the shadow of the model on the ground
- added new properties to `downloadObject.js` to be able to add the new information needed for `ViroSpotLight` and ViroQuad` to `localUris` to show the shadow
- edited `objectParser.js` to move newly added features to `AugmentedRealityView` screen
- removed the extra checks in the `AugmentedRealityView` screen, as we have already checked that the `object` contains the required information

SVA-565

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode


## Screenshots:

|before|after|
|--|--|
![AugmentedReality_1672767027545](https://user-images.githubusercontent.com/11755668/210410073-67cc6499-80ae-4ad4-8f93-aa7c47d8e6e1.PNG) | ![AugmentedReality_1672766989042](https://user-images.githubusercontent.com/11755668/210410091-707aab96-bb88-4c26-bd83-46e360037b57.PNG)
