### PR TITLE
refactor(accessibility): convert weather forecast to one text

### DIFF
--- a/src/components/weather/DailyWeather.tsx
+++ b/src/components/weather/DailyWeather.tsx
@@ -51,22 +51,22 @@ export const DailyWeather = ({ date, description, icon, temperatures }: Props) =
           </WrapperRow>
           <RegularText />
           <WrapperRow spaceBetween>
-            <View style={styles.dayTimeEntry}>
-              <RegularText>Morgens</RegularText>
-              <RegularText>{morn.toFixed(1)}°C</RegularText>
-            </View>
-            <View style={styles.dayTimeEntry}>
-              <RegularText>Mittags</RegularText>
-              <RegularText>{day.toFixed(1)}°C</RegularText>
-            </View>
-            <View style={styles.dayTimeEntry}>
-              <RegularText>Abends</RegularText>
-              <RegularText>{eve.toFixed(1)}°C</RegularText>
-            </View>
-            <View style={styles.dayTimeEntry}>
-              <RegularText>Nachts</RegularText>
-              <RegularText>{night.toFixed(1)}°C</RegularText>
-            </View>
+            <RegularText center>
+              Morgens{'\n'}
+              {morn.toFixed(1)}°C
+            </RegularText>
+            <RegularText center>
+              Mittags{'\n'}
+              {day.toFixed(1)}°C
+            </RegularText>
+            <RegularText center>
+              Abends{'\n'}
+              {eve.toFixed(1)}°C
+            </RegularText>
+            <RegularText center>
+              Nachts{'\n'}
+              {night.toFixed(1)}°C
+            </RegularText>
           </WrapperRow>
         </WrapperHorizontal>
       </View>

--- a/src/screens/WeatherScreen.js
+++ b/src/screens/WeatherScreen.js
@@ -131,6 +131,7 @@ export const WeatherScreen = () => {
               horizontal
               keyExtractor={hourlyKeyExtractor}
               renderItem={renderHourlyWeather}
+              showsHorizontalScrollIndicator={false}
             />
           </View>
         )}


### PR DESCRIPTION
- changed daily weather forecasts from two text components to one text component to enable `VoiceOver` to read them continuously
- changed `showsHorizontalScrollIndicator` to false to avoid preventing VoiceOver from reading the degree of weather in hourly weather

SVA-885
