### PR TITLE
chore: update snap carousel package

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-native-render-html": "4.2.5",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
-    "react-native-snap-carousel": "~3.9.0",
+    "react-native-snap-carousel": "4.0.0-beta.6",
     "react-native-svg": "12.3.0",
     "react-native-web": "0.17.7",
     "react-native-webview": "11.18.1",


### PR DESCRIPTION
- updated the `react-native-snap-carousel` package to a beta version to remove the `ViewPropTypes` warning and avoid a bug during future updates

SVA-890

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode