### PR TITLE
fix: delete `groupPrice` because the android app crashed

### DIFF
--- a/src/components/screens/PriceCard.js
+++ b/src/components/screens/PriceCard.js
@@ -21,16 +21,8 @@ export const PriceCard = ({ prices }) => (
     <WrapperWrap spaceBetween>
       {!!prices &&
         prices.map((item, index) => {
-          const {
-            category,
-            amount,
-            description,
-            maxChildrenCount,
-            maxAdultCount,
-            groupPrice
-          } = item;
+          const { category, amount, description, maxChildrenCount, maxAdultCount } = item;
           const formattedAmount = priceFormat(amount);
-          const formattedGroupPrice = priceFormat(groupPrice);
 
           return (
             <PriceBox key={index}>
@@ -42,11 +34,6 @@ export const PriceCard = ({ prices }) => (
               {!!formattedAmount && (
                 <BoldText small lightest>
                   {formattedAmount}
-                </BoldText>
-              )}
-              {!!formattedGroupPrice && (
-                <BoldText small lightest>
-                  {formattedGroupPrice}
                 </BoldText>
               )}
               {!!description && (


### PR DESCRIPTION
- deleted `groupPrice` from the code because it caused the Android App to crash. `groupPrice` is a boolean value and cannot be formatted.

SVA-913

* [x] Android portrait mode
* [x] Android landscape mode