### PR TITLE
feat(accessibility): add new labels for input buttons

### DIFF
--- a/src/components/BB-BUS/TextSearch.js
+++ b/src/components/BB-BUS/TextSearch.js
@@ -3,9 +3,11 @@ import React, { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { SearchBar } from 'react-native-elements';
 
-import { colors, normalize } from '../../config';
+import { colors, consts, normalize, texts } from '../../config';
 import { Label } from '../Label';
 import { WrapperHorizontal } from '../Wrapper';
+
+const { a11yLabel } = consts;
 
 export const TextSearch = memo(({ data, setData, label, placeholder }) => {
   return (
@@ -25,8 +27,20 @@ export const TextSearch = memo(({ data, setData, label, placeholder }) => {
         inputStyle={[styles.inputStyle, data.length && styles.marginLeft]}
         leftIconContainerStyle={styles.leftIconContainerStyle}
         rightIconContainerStyle={styles.rightIconContainerStyle}
-        searchIcon={data.length ? null : { color: colors.primary, size: normalize(28) }}
-        clearIcon={{ color: colors.primary, size: normalize(24) }}
+        searchIcon={
+          data.length
+            ? null
+            : {
+                accessibilityLabel: `${texts.accessibilityLabels.searchInputIcons.search} ${a11yLabel.button}`,
+                color: colors.primary,
+                size: normalize(28)
+              }
+        }
+        clearIcon={{
+          accessibilityLabel: `${texts.accessibilityLabels.searchInputIcons.delete} ${a11yLabel.button}`,
+          color: colors.primary,
+          size: normalize(24)
+        }}
       />
     </View>
   );

--- a/src/components/form/InputSecureTextIcon.tsx
+++ b/src/components/form/InputSecureTextIcon.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
 
-import { colors, Icon } from '../../config';
+import { colors, consts, Icon, texts } from '../../config';
+
+const { a11yLabel } = consts;
 
 export const InputSecureTextIcon = ({
   isSecureTextEntry,
@@ -10,7 +12,14 @@ export const InputSecureTextIcon = ({
   isSecureTextEntry: boolean;
   setIsSecureTextEntry: React.Dispatch<React.SetStateAction<boolean>>;
 }) => (
-  <TouchableOpacity onPress={() => setIsSecureTextEntry(!isSecureTextEntry)}>
+  <TouchableOpacity
+    accessibilityLabel={
+      isSecureTextEntry
+        ? `${texts.accessibilityLabels.secureInputIcons.visible} ${a11yLabel.button}`
+        : `${texts.accessibilityLabels.secureInputIcons.invisible} ${a11yLabel.button}`
+    }
+    onPress={() => setIsSecureTextEntry(!isSecureTextEntry)}
+  >
     {isSecureTextEntry ? (
       <Icon.Visible color={colors.darkText} />
     ) : (

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1,6 +1,16 @@
 import appJson from '../../app.json';
 
 export const texts = {
+  accessibilityLabels: {
+    searchInputIcons: {
+      delete: 'Suche löschen',
+      search: 'Suche'
+    },
+    secureInputIcons: {
+      invisible: 'Kennwort verstecken',
+      visible: 'Kennwort sichtbar machen'
+    }
+  },
   appIntro: {
     continue: 'Weiter'
   },


### PR DESCRIPTION
- added `accessibilityLabel` for `searchIcon` and `clearIcon` used in search input for users using `VoiceOver` feature
- added `accessibilityLabel` for the show or hide password button used in the password input for users using the `VoiceOver` feature
- added `accessibilityLabels` section to texts for use in new accessibility features

SVA-899