### PR TITLE
refactor(tabbar): change the full screen max width

### DIFF
--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -95,7 +95,7 @@ export const consts = {
 
   DIMENSIONS: {
     // the max screen size we want to render full screen
-    FULL_SCREEN_MAX_WIDTH: 414
+    FULL_SCREEN_MAX_WIDTH: 428
   },
 
   // the image aspect ratio can be overwritten by a global setting `imageAspectRatio`


### PR DESCRIPTION
- changed the maximum screen length to solve the problem of the icons in the tabbar being aligned to the left side

SBB-5


🔍 in our code, the `FULL_SCREEN_MAX_WIDTH` value we set in our code perceived the devices after a certain size as tablets and shifted the icons in the tabbars to the right side as much as the `normalize(10)` value.

i updated `FULL_SCREEN_MAX_WIDTH` according to the size of current phones and managed to centre the icons in the tab

* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode

## Screenshots:

|iPhone 14 Plus (before)|iPhone 14 Plus (after)|
|--|--|
![Simulator Screen Shot - iPhone 14 Plus - 2023-01-31 at 16 24 43](https://user-images.githubusercontent.com/11755668/215804224-56384ded-26ab-4f39-889f-ec54335eebab.png) | ![Simulator Screen Shot - iPhone 14 Plus - 2023-01-31 at 16 24 23](https://user-images.githubusercontent.com/11755668/215804297-e8048688-89d8-4b04-a668-532cbade075d.png)

|iPhone 14 Pro Max (before)|iPhone 14 Pro Max (after)|
|--|--|
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-31 at 16 24 47](https://user-images.githubusercontent.com/11755668/215804255-a86ebe6d-c421-425e-89cb-065d201cd768.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-31 at 16 24 28](https://user-images.githubusercontent.com/11755668/215804280-6896d549-deaa-4c56-b783-86cc29d512a6.png)

|iPhone 8 (before)|iPhone 8 (after)|
|--|--|
![Simulator Screen Shot - iPhone 8 - 2023-01-31 at 16 24 51](https://user-images.githubusercontent.com/11755668/215804240-b733d997-19ed-47fc-99ff-3cac31bf8152.png) | ![Simulator Screen Shot - iPhone 8 - 2023-01-31 at 16 24 32](https://user-images.githubusercontent.com/11755668/215804265-9bc589d0-d9fb-494d-9bb9-ea0ceedd0ef3.png)
