### PR TITLE
feat(category): make category intro text changeable from server

### DIFF
--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -7,9 +7,7 @@ import { colors, consts, device, texts } from '../config';
 
 import { CategoryListItem } from './CategoryListItem';
 import { LoadingContainer } from './LoadingContainer';
-import { RegularText } from './Text';
 import { Title, TitleContainer, TitleShadow } from './Title';
-import { Wrapper } from './Wrapper';
 
 export class CategoryList extends React.PureComponent {
   keyExtractor = (item, index) => `index${index}-id${item.id}`;
@@ -30,7 +28,7 @@ export class CategoryList extends React.PureComponent {
   };
 
   render() {
-    const { data, navigation, noSubtitle, refreshControl, hasSectionHeader } = this.props;
+    const { data, navigation, noSubtitle, refreshControl, ListHeaderComponent } = this.props;
 
     if (!data?.length) {
       return (
@@ -72,14 +70,7 @@ export class CategoryList extends React.PureComponent {
           />
         )}
         renderSectionHeader={this.renderSectionHeader}
-        ListHeaderComponent={
-          hasSectionHeader &&
-          !!texts.categoryList.intro && (
-            <Wrapper>
-              <RegularText>{texts.categoryList.intro}</RegularText>
-            </Wrapper>
-          )
-        }
+        ListHeaderComponent={ListHeaderComponent}
         stickySectionHeadersEnabled
         refreshControl={refreshControl}
       />
@@ -92,7 +83,8 @@ CategoryList.propTypes = {
   data: PropTypes.array,
   noSubtitle: PropTypes.bool,
   refreshControl: PropTypes.object,
-  hasSectionHeader: PropTypes.bool
+  hasSectionHeader: PropTypes.bool,
+  ListHeaderComponent: PropTypes.object
 };
 
 CategoryList.defaultProps = {

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -18,7 +18,9 @@ import {
   LoadingContainer,
   LocationOverview,
   OptionToggle,
-  SafeAreaViewFlex
+  RegularText,
+  SafeAreaViewFlex,
+  Wrapper
 } from '../components';
 import { colors, consts, texts } from '../config';
 import {
@@ -83,10 +85,11 @@ export const IndexScreen = ({ navigation, route }) => {
   const [topFilter, setTopFilter] = useState(INITIAL_TOP_FILTER);
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const { globalSettings } = useContext(SettingsContext);
-  const { filter = {}, hdvt = {}, settings = {} } = globalSettings;
+  const { filter = {}, hdvt = {}, settings = {}, sections = {} } = globalSettings;
   const { news: showNewsFilter = false, events: showEventsFilter = true } = filter;
   const { events: showVolunteerEvents = false } = hdvt;
   const { calendarToggle = false } = settings;
+  const { categoryListIntroText = texts.categoryList.intro } = sections;
   const [queryVariables, setQueryVariables] = useState(route.params?.queryVariables ?? {});
   const [showCalendar, setShowCalendar] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
@@ -415,6 +418,11 @@ export const IndexScreen = ({ navigation, route }) => {
                           horizontal={false}
                           hasSectionHeader={false}
                         />
+                      )}
+                      {query === QUERY_TYPES.CATEGORIES && !!categoryListIntroText && (
+                        <Wrapper>
+                          <RegularText>{categoryListIntroText}</RegularText>
+                        </Wrapper>
                       )}
                     </>
                   }


### PR DESCRIPTION
- added `categoryListIntroText` to the `sections` section on the server to be able to change the text on the `CategoryList` screen via the server
- added intro text used in `CategoryList` component to `IndexScreen`

SBB-19

## How to test:
To try it out, add the following line to the `sections` section in `globalSettings` on Main-Server.

```
"categoryListIntroText": "Intro Text",
```

* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode
