### PR TITLE
fix(push notification): fix notification switcher switching on and off

### DIFF
--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -43,12 +43,12 @@ renderItem.propTypes = {
   dimensions: PropTypes.object.isRequired
 };
 
-const onActivatePushNotifications = (revert) => {
-  setInAppPermission(true).then((success) => !success && revert());
+const onActivatePushNotifications = () => {
+  setInAppPermission(true).then((success) => !success);
 };
 
-const onDeactivatePushNotifications = (revert) => {
-  setInAppPermission(false).then((success) => !success && revert());
+const onDeactivatePushNotifications = () => {
+  setInAppPermission(false).then((success) => !success);
 };
 
 const TOP_FILTER = {


### PR DESCRIPTION
- deleted the `revert` function in `SettingsScreen` to fix the problem of switcher switching on and off instantly due to the revert function always being `undefined`

SVA-932

⚠️Note: Although notifications are turned off through the application, notifications continue to come. I think this is because the `token` cannot be deleted from the server. ⚠️

## How to test: 
- go to the settings screen and open `Push-Benachrichtigungen`

* [x] Android portrait mode
* [x] iOS portrait mode

## Screen Recordings:

|before|after|
|--|--|
<video src="https://user-images.githubusercontent.com/11755668/219625679-df8adfb6-233f-4c94-87cb-25ff8a06597c.mp4"> | <video src="https://user-images.githubusercontent.com/11755668/219624570-29d90b81-4054-406e-8e6f-b838f6c5bdbc.mp4">


