### PR TITLE
feat: delete the white bar on the edges

### DIFF
--- a/__tests__/components/Wrapper.test.js
+++ b/__tests__/components/Wrapper.test.js
@@ -7,7 +7,6 @@ import {
   Wrapper,
   WrapperHorizontal,
   WrapperVertical,
-  WrapperLandscape,
   WrapperRow,
   WrapperWrap,
   InfoBox,
@@ -27,11 +26,6 @@ describe('testing Wrapper style component', () => {
 
   it('renders WrapperVertical', async () => {
     const tree = renderer.create(<WrapperVertical />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-
-  it('renders WrapperLandscape', async () => {
-    const tree = renderer.create(<WrapperLandscape noFlex />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 

--- a/__tests__/components/__snapshots__/Wrapper.test.js.snap
+++ b/__tests__/components/__snapshots__/Wrapper.test.js.snap
@@ -27,20 +27,6 @@ exports[`testing Wrapper style component renders WrapperHorizontal 1`] = `
 />
 `;
 
-exports[`testing Wrapper style component renders WrapperLandscape 1`] = `
-<View
-  noFlex={true}
-  style={
-    Array [
-      Object {
-        "paddingLeft": "15%",
-        "paddingRight": "15%",
-      },
-    ]
-  }
-/>
-`;
-
 exports[`testing Wrapper style component renders WrapperRow 1`] = `
 <View
   style={

--- a/src/components/BB-BUS/TextBlock.js
+++ b/src/components/BB-BUS/TextBlock.js
@@ -25,7 +25,7 @@ export const TextBlock = ({ bottomDivider, textBlock, openWebScreen }) => {
       initiallyOpen={name.toUpperCase() === 'KURZTEXT'}
       title={name}
     >
-      <WrapperWithOrientation noFlex>
+      <WrapperWithOrientation>
         <Wrapper>
           {!!text && <HtmlView html={trimNewLines(text)} openWebScreen={openWebScreen} />}
           {!!externalLinks?.length &&

--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -67,9 +67,8 @@ const styles = StyleSheet.create({
 const stylesWithProps = ({ horizontal }) => {
   let width = imageWidth();
 
-  if (horizontal || width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH) {
-    // image width should be only 70% when rendering horizontal cards or on wider screens,
-    // as there are 15% padding on each side
+  if (horizontal) {
+    // image width should be only 70% when rendering horizontal cards
     width = width * 0.7;
   }
 
@@ -77,7 +76,6 @@ const stylesWithProps = ({ horizontal }) => {
 
   return StyleSheet.create({
     contentContainer: {
-      alignSelf: 'center',
       width: maxWidth
     },
     image: {

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -24,10 +24,8 @@ export const Checkbox = ({
   const { orientation, dimensions } = useContext(OrientationContext);
   const needLandscapeStyle =
     orientation === 'landscape' || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH;
-
   const headerTitle = title ?? '';
   const rootRouteName = '';
-
   const openWebScreen = useOpenWebScreen(headerTitle, link, rootRouteName);
 
   return (

--- a/src/components/OrientationAwareIcon.tsx
+++ b/src/components/OrientationAwareIcon.tsx
@@ -20,12 +20,12 @@ export const OrientationAwareIcon = (props: Props) => {
     orientation === 'landscape' || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH;
 
   // we need adjustments only on iOS, so otherwise just return the item with the usual props
+  // TODO: is this still needed with Expo 48?
   if (!needLandscapeStyle || !(device.platform === 'ios')) {
     return <Icon {...props} />;
   }
 
   const adjustedSize = size * LANDSCAPE_ADJUSTMENT_FACTOR;
-
   const landscapeIconStyle = { width: adjustedSize };
 
   return (

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import styled, { css } from 'styled-components/native';
 
-import { consts, normalize } from '../config';
+import { consts, device, normalize } from '../config';
 import { OrientationContext } from '../OrientationProvider';
 
 export const Wrapper = styled.View`
@@ -40,6 +40,13 @@ export const WrapperLandscape = styled.View`
     !props.noFlex &&
     css`
       flex: 1;
+    `};
+
+  ${(props) =>
+    props.isPad &&
+    css`
+      padding-left: 0;
+      padding-right: 0;
     `};
 `;
 
@@ -87,7 +94,11 @@ export const WrapperWithOrientation = ({ noFlex, children }) => {
     orientation === 'landscape' || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH;
 
   if (needLandscapeWrapper) {
-    return <WrapperLandscape noFlex={noFlex}>{children}</WrapperLandscape>;
+    return (
+      <WrapperLandscape noFlex={noFlex} isPad={device.isPad}>
+        {children}
+      </WrapperLandscape>
+    );
   }
 
   return children;

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
 import styled, { css } from 'styled-components/native';
 
-import { consts, normalize } from '../config';
-import { OrientationContext } from '../OrientationProvider';
+import { normalize } from '../config';
 
 export const Wrapper = styled.View`
   padding: ${normalize(14)}px;
@@ -30,14 +28,6 @@ export const WrapperHorizontal = styled.View`
 export const WrapperVertical = styled.View`
   padding-bottom: ${normalize(14)}px;
   padding-top: ${normalize(14)}px;
-`;
-
-export const WrapperLandscape = styled.View`
-  ${(props) =>
-    !props.noFlex &&
-    css`
-      flex: 1;
-    `};
 `;
 
 export const WrapperRow = styled.View`
@@ -77,18 +67,7 @@ export const InfoBox = styled(WrapperRow)`
   margin-bottom: ${normalize(5)}px;
 `;
 
-export const WrapperWithOrientation = ({ noFlex, children }) => {
-  const { orientation, dimensions } = useContext(OrientationContext);
-
-  const needLandscapeWrapper =
-    orientation === 'landscape' || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH;
-
-  if (needLandscapeWrapper) {
-    return <WrapperLandscape noFlex={noFlex}>{children}</WrapperLandscape>;
-  }
-
-  return children;
-};
+export const WrapperWithOrientation = ({ children }) => children;
 
 WrapperWithOrientation.displayName = 'WrapperWithOrientation';
 

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import styled, { css } from 'styled-components/native';
 
-import { consts, device, normalize } from '../config';
+import { consts, normalize } from '../config';
 import { OrientationContext } from '../OrientationProvider';
 
 export const Wrapper = styled.View`
@@ -33,20 +33,10 @@ export const WrapperVertical = styled.View`
 `;
 
 export const WrapperLandscape = styled.View`
-  padding-left: 15%;
-  padding-right: 15%;
-
   ${(props) =>
     !props.noFlex &&
     css`
       flex: 1;
-    `};
-
-  ${(props) =>
-    props.isPad &&
-    css`
-      padding-left: 0;
-      padding-right: 0;
     `};
 `;
 
@@ -94,11 +84,7 @@ export const WrapperWithOrientation = ({ noFlex, children }) => {
     orientation === 'landscape' || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH;
 
   if (needLandscapeWrapper) {
-    return (
-      <WrapperLandscape noFlex={noFlex} isPad={device.isPad}>
-        {children}
-      </WrapperLandscape>
-    );
+    return <WrapperLandscape noFlex={noFlex}>{children}</WrapperLandscape>;
   }
 
   return children;

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -70,7 +70,7 @@ export const Map = ({
     otherProps.showsUserLocation ?? !!globalSettings?.settings?.locationService;
 
   return (
-    <View style={[stylesForMap().container, style]}>
+    <View style={[styles.container, style]}>
       <MapView
         initialRegion={initialRegion}
         mapType={device.platform === 'android' ? MAP_TYPES.NONE : MAP_TYPES.STANDARD}
@@ -123,7 +123,7 @@ export const Map = ({
         ))}
       </MapView>
       {isMaximizeButtonVisible && (
-        <TouchableOpacity style={stylesForMap().maximizeMapButton} onPress={onMaximizeButtonPress}>
+        <TouchableOpacity style={styles.maximizeMapButton} onPress={onMaximizeButtonPress}>
           <Icon.ExpandMap size={normalize(18)} />
         </TouchableOpacity>
       )}
@@ -131,39 +131,39 @@ export const Map = ({
   );
 };
 
-/* eslint-disable react-native/no-unused-styles */
-/* this works properly, we do not want that eslint warning */
-// the map should have the same aspect ratio as images.
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    backgroundColor: colors.lightestText,
+    flex: 1,
+    justifyContent: 'center'
+  },
+  maximizeMapButton: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderRadius: 50,
+    bottom: normalize(15),
+    height: normalize(48),
+    justifyContent: 'center',
+    opacity: 0.6,
+    position: 'absolute',
+    right: normalize(15),
+    width: normalize(48),
+    zIndex: 1
+  }
+});
+
+// the map should have the same aspect ratio as images in portrait and a full width on landscape.
 // we need to call the default styles in a method to ensure correct defaults for image aspect ratio,
-// which could be overwritten bei server global settings. otherwise (as default prop) the style
+// which could be overwritten by server global settings. otherwise (as default prop) the style
 // would be set before the overwriting occurred.
 const stylesForMap = () => {
-  const width = imageWidth();
-
   return StyleSheet.create({
-    container: {
-      alignItems: 'center',
-      backgroundColor: colors.lightestText,
-      flex: 1,
-      justifyContent: 'center'
-    },
-    maximizeMapButton: {
-      alignItems: 'center',
-      backgroundColor: colors.surface,
-      borderRadius: 50,
-      bottom: normalize(15),
-      height: normalize(48),
-      justifyContent: 'center',
-      opacity: 0.6,
-      position: 'absolute',
-      right: normalize(15),
-      width: normalize(48),
-      zIndex: 1
-    },
+    // eslint-disable-next-line react-native/no-unused-styles
     map: {
       alignSelf: 'center',
-      height: imageHeight(width),
-      width
+      height: imageHeight(imageWidth()),
+      width: device.width
     }
   });
 };

--- a/src/config/device.js
+++ b/src/config/device.js
@@ -2,6 +2,7 @@ import { Dimensions, Platform } from 'react-native';
 
 export const device = {
   height: Dimensions.get('window').height,
+  isPad: Platform.isPad,
   platform: Platform.OS,
   width: Dimensions.get('window').width
 };

--- a/src/config/device.js
+++ b/src/config/device.js
@@ -2,7 +2,6 @@ import { Dimensions, Platform } from 'react-native';
 
 export const device = {
   height: Dimensions.get('window').height,
-  isPad: Platform.isPad,
   platform: Platform.OS,
   width: Dimensions.get('window').width
 };


### PR DESCRIPTION
- added `isPad` to `device.js` to recognise whether the app is running on a tablet or a phone
- added `isPad` prop to `WrapperLandscape` to overwrite side padding on tablet
  - in this way the white bars on the sides are removed

SBB-6

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode


## Screenshots:

|before|after|
|--|--|
![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-07 at 11 07 08](https://user-images.githubusercontent.com/11755668/223390753-6700b5fd-640d-4adc-bafb-eb9e4d66b74e.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-07 at 11 06 51](https://user-images.githubusercontent.com/11755668/223390770-af62f0a9-18f1-4eca-b8c5-177d19ca77cb.png)
