### PR TITLE
feat(iframe): add iframe plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@apollo/react-hooks": "~3.1.5",
+    "@native-html/iframe-plugin": "^2.6.1",
     "@native-html/table-plugin": "^5.3.1",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/datetimepicker": "6.1.2",

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -1,3 +1,4 @@
+import IframeRenderer, { iframeModel } from '@native-html/iframe-plugin';
 import TableRenderer, {
   cssRulesFromSpecs,
   defaultTableStylesSpecs,
@@ -53,12 +54,18 @@ table {
 }
 `;
 
-const renderers = { table: TableRenderer };
+const renderers = {
+  iframe: IframeRenderer,
+  table: TableRenderer
+};
 
 const htmlConfig = {
   WebView,
   renderers,
-  customHTMLElementModels: { table: tableModel }
+  customHTMLElementModels: {
+    iframe: iframeModel,
+    table: tableModel
+  }
 };
 
 export const HtmlView = memo(({ html, tagsStyles, openWebScreen, width }) => {
@@ -81,6 +88,14 @@ export const HtmlView = memo(({ html, tagsStyles, openWebScreen, width }) => {
       {...htmlConfig}
       renderersProps={{
         a: { onPress: (evt, href) => openLink(href, openWebScreen) },
+        iframe: {
+          scalesPageToFit: true,
+          webViewProps: {
+            // the opacity of the iframe was set to 0.99 to solve the crashing problem on Android
+            // thanks to : https://github.com/meliorence/react-native-render-html/issues/393#issuecomment-1277533605
+            style: { opacity: 0.99 }
+          }
+        },
         table: { cssRules }
       }}
       tagsStyles={{ ...styles.html, ...tagsStyles }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,7 +1559,7 @@
     find-up "^5.0.0"
     js-yaml "^4.1.0"
 
-"@formidable-webview/webshell@2.6.0":
+"@formidable-webview/webshell@2.6.0", "@formidable-webview/webshell@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@formidable-webview/webshell/-/webshell-2.6.0.tgz#64704c0b513206e71b23118b3c9d096f0d545005"
   integrity sha512-FwQQDajg1xs7W3CUiUNJMvdjgLjKLDGzs0XPzoVg0Dunhold1Jg7w5pihUdvVugFlNtkSpXMA+du9QDHE8lmpg==
@@ -1928,6 +1928,16 @@
   dependencies:
     css-to-react-native "^3.0.0"
     csstype "^3.0.8"
+
+"@native-html/iframe-plugin@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@native-html/iframe-plugin/-/iframe-plugin-2.6.1.tgz#5b9c36d9d500f82f0bcf654bc005922df4211158"
+  integrity sha512-PM2vFNT44n/UkCm9+OUn+cNSKgiMjaw7c7/2JnnztHDLVMtPIf52K/86miWNpQpxFoy1ouoLVOvfjFRhoPXjag==
+  dependencies:
+    "@formidable-webview/webshell" "^2.6.0"
+    "@native-html/plugins-core" "1.3.0"
+    "@types/prop-types" "^15.7.4"
+    prop-types "^15.7.2"
 
 "@native-html/plugins-core@1.3.0":
   version "1.3.0"


### PR DESCRIPTION
- integrated the plugin required for `iframe` after the `rn-render-html` update
- added `0.99` value to `iframe`'s opacity to solve the crashing problem on android

SVA-942

[iframe Plugin](https://github.com/native-html/plugins/tree/rnrh/6.x/packages/iframe-plugin#readme)

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode

**Add additional information for testing, if required**

## Screenshots:

|before - ios|after - ios|
|--|--|
![image](https://user-images.githubusercontent.com/11755668/224011388-3310ef7b-08df-41bf-9051-0de455ffdd56.png) | ![image](https://user-images.githubusercontent.com/11755668/224010844-e5033194-2dc9-4355-b516-94565b5c5592.png)

|before - android|after - android|
|--|--|
![Screenshot (09 03 2023 12_34_42)](https://user-images.githubusercontent.com/11755668/224011531-17231fb3-6433-490d-87c3-4f76671c4a08.jpg) | ![Screenshot (09 03 2023 12_31_06)](https://user-images.githubusercontent.com/11755668/224010990-a4919276-ae16-46ee-863b-1607fada7f7e.jpg)