### PR TITLE
fix: fix param errors when navigating between the same pages

### DIFF
--- a/src/navigation/DrawerNavigatorItem.js
+++ b/src/navigation/DrawerNavigatorItem.js
@@ -13,7 +13,10 @@ export const DrawerNavigatorItem = ({ activeRoute, itemInfo, navigation, topDivi
   const accessibilityLabel = itemInfo.params.title;
 
   const handleItemPress = () => {
-    navigation.navigate(itemInfo.screen, itemInfo.params);
+    navigation.navigate(itemInfo.screen, {
+      ...itemInfo.params,
+      subQuery: itemInfo.params.subQuery ?? undefined
+    });
     navigation.closeDrawer();
   };
 


### PR DESCRIPTION
- added `undefined` if there is no `subQuery` object to solve the param error that occurs when navigating between two pages with the same name via the drawer menu

SVA-940


## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode

- open the drawer menu and first go to the `Abfallkalender mit Zwischenseite` screen
- this page is an `HtmlScreen` + multi button page and depends on `subQuery`
- go to the `CMS` screen again via the drawer menu before going to another screen
- this page is also an `HtmlScreen` but without buttons. because `subQuery` is not added in the navigation structure
- since there is no change in the navigation, that is, both screens are `HtmlScreen` pages, the `subQuery` parameters are automatically moved to the `CMS` page
- with the change in the navigation structure, if there is no `subQuery` in the parameters, it is set to `undefined` and in this way the `subQuery` parameter is reset

## Screenshots:

|before (Abfallkalender mit Zwischenseite)|before (CMS)|
|--|--|
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-09 at 16 59 22](https://user-images.githubusercontent.com/11755668/224081041-351f82c1-99fb-4048-9e8e-77636567808b.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-09 at 16 59 25](https://user-images.githubusercontent.com/11755668/224081055-5774536a-6acd-4ef7-aa43-232f12005876.png)

|after (Abfallkalender mit Zwischenseite)|after (CMS)|
|--|--|
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-09 at 16 59 02](https://user-images.githubusercontent.com/11755668/224081219-20d6cfc5-1a8f-4702-b992-4930080f1b88.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-09 at 16 59 05](https://user-images.githubusercontent.com/11755668/224081235-d72e9fe6-9130-4dc6-a03f-f9964c3cf419.png)


