### PR TITLE
feat(accessibility): add accessibility style for version code

### DIFF
--- a/src/components/VersionNumber.js
+++ b/src/components/VersionNumber.js
@@ -1,18 +1,21 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { StyleSheet } from 'react-native';
 
 import appJson from '../../app.json';
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { colors, consts, normalize } from '../config';
 
 import { RegularText } from './Text.js';
 import { Wrapper } from './Wrapper.js';
 
 export const VersionNumber = () => {
+  const { isReduceTransparencyEnabled } = useContext(AccessibilityContext);
+
   return (
     <Wrapper>
       <RegularText
         small
-        style={styles.version}
+        style={[styles.version, isReduceTransparencyEnabled && styles.accessibilityColor]}
         accessibilityLabel={`${consts.a11yLabel.appVersion} ${appJson.expo.version}`}
       >
         Version: {appJson.expo.version}
@@ -22,6 +25,9 @@ export const VersionNumber = () => {
 };
 
 const styles = StyleSheet.create({
+  accessibilityColor: {
+    color: colors.darkText
+  },
   version: {
     color: colors.shadow,
     fontSize: normalize(11),


### PR DESCRIPTION
- changed the color of the version code to `darkText` if the user has activated the `Reduce Transparency` setting via accessibility to increase the contrast difference

SVA-872

## Screenshots:

![IMG_0129](https://user-images.githubusercontent.com/11755668/224991577-5f7846f7-ab98-4b48-8a70-0e10cddaf49a.jpg)

|reduce transparency off|reduce transparency on|
|--|--|
![IMG_0128](https://user-images.githubusercontent.com/11755668/224991624-3ef3d3aa-2836-4cd7-873a-51749cadbb41.PNG) | ![IMG_0130](https://user-images.githubusercontent.com/11755668/224991661-5f35c428-0ec2-482c-a3f4-bf9a4fdd5da9.PNG)
