### PR TITLE
feat(accessibility): change background colour of switch

### DIFF
--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { Platform, Switch as RNSwitch } from 'react-native';
 
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { colors } from '../config';
 
 const trackColor = {
@@ -16,16 +17,20 @@ const thumbColorEnabled = Platform.select({
   ios: colors.lightestText
 });
 
-export const Switch = ({ switchValue, toggleSwitch }) => (
-  <RNSwitch
-    trackColor={trackColor}
-    thumbColor={switchValue ? thumbColorEnabled : thumbColor}
-    ios_backgroundColor={colors.shadow}
-    onValueChange={toggleSwitch}
-    value={switchValue}
-    accessibilityRole="button"
-  />
-);
+export const Switch = ({ switchValue, toggleSwitch }) => {
+  const { isReduceTransparencyEnabled } = useContext(AccessibilityContext);
+
+  return (
+    <RNSwitch
+      trackColor={trackColor}
+      thumbColor={switchValue ? thumbColorEnabled : thumbColor}
+      ios_backgroundColor={isReduceTransparencyEnabled ? colors.overlayRgba : colors.shadow}
+      onValueChange={toggleSwitch}
+      value={switchValue}
+      accessibilityRole="button"
+    />
+  );
+};
 
 Switch.propTypes = {
   switchValue: PropTypes.bool.isRequired,


### PR DESCRIPTION
- changed the `ios_backgroundColor` to `overlayRgba` when `Reduce Transparency` is turned on to achieve a contrast ratio of at least 3:1 between the background of the switch and the background of the application

SVA-873

## Screenshots:

![IMG_0132](https://user-images.githubusercontent.com/11755668/225007602-a3f7996f-9523-43dd-acd1-74202a1e13dc.jpg)

|reduce transparency off|reduce transparency on|
|--|--|
![IMG_0131](https://user-images.githubusercontent.com/11755668/225007644-decda66f-7512-408a-9efa-c732721b197c.PNG) | ![IMG_0133](https://user-images.githubusercontent.com/11755668/225007666-47bc20fe-da0a-488c-8048-f60fba1ee393.PNG)
