### PR TITLE
feat(accessibility): add bold option to all text styles

### DIFF
--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -98,7 +98,7 @@ export const HtmlView = memo(({ html, tagsStyles, openWebScreen, width }) => {
         },
         table: { cssRules }
       }}
-      tagsStyles={{ ...styles.html, ...tagsStyles }}
+      tagsStyles={{ ...styles.html(), ...tagsStyles }}
       emSize={normalize(16)}
       baseStyle={styles.baseFontStyle}
       ignoredStyles={['width', 'height']}

--- a/src/components/HtmlView.js
+++ b/src/components/HtmlView.js
@@ -5,10 +5,11 @@ import TableRenderer, {
   tableModel
 } from '@native-html/table-plugin';
 import PropTypes from 'prop-types';
-import React, { memo } from 'react';
+import React, { memo, useContext } from 'react';
 import HTML from 'react-native-render-html';
 import { WebView } from 'react-native-webview';
 
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { colors, consts, normalize, styles } from '../config';
 import { imageWidth, openLink } from '../helpers';
 
@@ -69,6 +70,8 @@ const htmlConfig = {
 };
 
 export const HtmlView = memo(({ html, tagsStyles, openWebScreen, width }) => {
+  const { isBoldTextEnabled } = useContext(AccessibilityContext);
+
   let calculatedWidth = width !== undefined ? Math.min(imageWidth(), width) : imageWidth();
 
   if (calculatedWidth > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH) {
@@ -98,7 +101,11 @@ export const HtmlView = memo(({ html, tagsStyles, openWebScreen, width }) => {
         },
         table: { cssRules }
       }}
-      tagsStyles={{ ...styles.html(), ...tagsStyles }}
+      tagsStyles={{
+        ...styles.html,
+        ...(isBoldTextEnabled ? styles.htmlBoldTextEnabled : {}),
+        ...tagsStyles
+      }}
       emSize={normalize(16)}
       baseStyle={styles.baseFontStyle}
       ignoredStyles={['width', 'height']}

--- a/src/components/StorySection.js
+++ b/src/components/StorySection.js
@@ -32,7 +32,7 @@ export const StorySection = ({ contentBlock, index, openWebScreen, settings }) =
                   : `<p>${contentBlock.intro}</p>`
               }</div>`
             )}
-            tagsStyles={{ div: { fontFamily: 'bold' } }}
+            tagsStyles={{ div: { fontFamily: 'bold' }, p: { fontFamily: 'bold' } }}
             openWebScreen={openWebScreen}
           />
         </WrapperHorizontal>

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -33,23 +33,32 @@ function parseText(text) {
   return result;
 }
 
-export const Text = ({ children, ...props }) => {
-  return (
-    <RNText {...props}>{typeof children === 'string' ? parseText(children) : children}</RNText>
-  );
-};
-
-export const RegularText = ({ children, ...props }) => {
+export const Text = ({ children, style, italic, ...props }) => {
   const { isBoldTextEnabled } = useContext(AccessibilityContext);
 
-  if (isBoldTextEnabled) {
-    return <BoldText {...props}>{children}</BoldText>;
-  }
-
-  return <RegularTextStyledComponent {...props}>{children}</RegularTextStyledComponent>;
+  /* eslint-disable react-native/no-inline-styles */
+  return (
+    <RNText
+      {...props}
+      style={[
+        ...style,
+        isBoldTextEnabled && { fontFamily: 'bold' },
+        italic && { fontFamily: 'bold-italic' }
+      ]}
+    >
+      {typeof children === 'string' ? parseText(children) : children}
+    </RNText>
+  );
+  /* eslint-enable react-native/no-inline-styles */
 };
 
-const RegularTextStyledComponent = styled(Text)`
+Text.propTypes = {
+  children: PropTypes.node,
+  style: PropTypes.array,
+  italic: PropTypes.bool
+};
+
+export const RegularText = styled(Text)`
   color: ${colors.darkText};
   font-family: regular;
   font-size: ${normalize(16)};
@@ -148,7 +157,7 @@ const RegularTextStyledComponent = styled(Text)`
     `};
 `;
 
-export const BoldText = styled(RegularTextStyledComponent)`
+export const BoldText = styled(RegularText)`
   font-family: bold;
 
   ${(props) =>
@@ -157,11 +166,3 @@ export const BoldText = styled(RegularTextStyledComponent)`
       font-family: bold-italic;
     `};
 `;
-
-Text.propTypes = {
-  children: PropTypes.node
-};
-
-RegularText.propTypes = {
-  children: PropTypes.node
-};

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { Text as RNText } from 'react-native';
 import styled, { css } from 'styled-components/native';
 
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { colors, normalize } from '../config';
 
 // example: S&#322;ubice -> Słubice
@@ -38,7 +39,17 @@ export const Text = ({ children, ...props }) => {
   );
 };
 
-export const RegularText = styled(Text)`
+export const RegularText = ({ children, ...props }) => {
+  const { isBoldTextEnabled } = useContext(AccessibilityContext);
+
+  if (isBoldTextEnabled) {
+    return <BoldText {...props}>{children}</BoldText>;
+  }
+
+  return <RegularTextStyledComponent {...props}>{children}</RegularTextStyledComponent>;
+};
+
+const RegularTextStyledComponent = styled(Text)`
   color: ${colors.darkText};
   font-family: regular;
   font-size: ${normalize(16)};
@@ -137,7 +148,7 @@ export const RegularText = styled(Text)`
     `};
 `;
 
-export const BoldText = styled(RegularText)`
+export const BoldText = styled(RegularTextStyledComponent)`
   font-family: bold;
 
   ${(props) =>
@@ -148,5 +159,9 @@ export const BoldText = styled(RegularText)`
 `;
 
 Text.propTypes = {
+  children: PropTypes.node
+};
+
+RegularText.propTypes = {
   children: PropTypes.node
 };

--- a/src/config/styles/html.js
+++ b/src/config/styles/html.js
@@ -1,107 +1,131 @@
-import { useContext } from 'react';
 import { Dimensions } from 'react-native';
 
-import { AccessibilityContext } from '../../AccessibilityProvider';
 import { imageHeight } from '../../helpers/imageHelper';
 import { colors } from '../colors';
 import { normalize } from '../normalize';
 
-export const html = () => {
-  const { isBoldTextEnabled } = useContext(AccessibilityContext);
+export const html = {
+  p: {
+    color: colors.darkText,
+    fontFamily: 'regular',
+    margin: 0,
+    marginBottom: normalize(16)
+  },
+  a: {
+    color: colors.primary,
+    fontFamily: 'bold',
+    margin: 0,
+    textDecorationLine: 'none'
+  },
+  div: {
+    fontFamily: 'regular'
+  },
+  h1: {
+    color: colors.darkText,
+    fontFamily: 'bold',
+    fontSize: normalize(24),
+    lineHeight: normalize(30),
+    margin: 0,
+    marginBottom: normalize(24)
+  },
+  h2: {
+    color: colors.darkText,
+    fontFamily: 'regular',
+    fontSize: normalize(20),
+    fontWeight: '400',
+    lineHeight: normalize(26),
+    margin: 0,
+    marginBottom: normalize(14)
+  },
+  h3: {
+    color: colors.darkText,
+    fontFamily: 'bold',
+    fontSize: normalize(18),
+    lineHeight: normalize(24),
+    margin: 0
+  },
+  h4: {
+    color: colors.darkText,
+    fontFamily: 'regular',
+    fontSize: normalize(18),
+    fontWeight: '400',
+    lineHeight: normalize(24),
+    margin: 0
+  },
+  h5: {
+    color: colors.darkText,
+    fontFamily: 'regular',
+    fontSize: normalize(16),
+    fontWeight: '400',
+    margin: 0
+  },
+  h6: {
+    color: colors.darkText,
+    fontFamily: 'regular',
+    fontSize: normalize(14),
+    fontWeight: '400',
+    margin: 0
+  },
+  b: {
+    fontFamily: 'bold',
+    margin: 0
+  },
+  strong: {
+    fontFamily: 'bold',
+    margin: 0
+  },
+  ul: {
+    fontFamily: 'regular',
+    margin: 0
+  },
+  ol: {
+    fontFamily: 'regular',
+    margin: 0
+  },
+  img: {
+    alignSelf: 'center',
+    margin: 0
+  },
+  iframe: {
+    alignSelf: 'center',
+    height: imageHeight(Dimensions.get('window').width),
+    margin: 0
+  },
+  em: {
+    fontFamily: 'italic',
+    margin: 0
+  },
+  figure: {
+    margin: 0
+  }
+};
 
-  return {
-    p: {
-      color: colors.darkText,
-      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
-      margin: 0,
-      marginBottom: normalize(16)
-    },
-    a: {
-      color: colors.primary,
-      fontFamily: 'bold',
-      margin: 0,
-      textDecorationLine: 'none'
-    },
-    div: {
-      fontFamily: isBoldTextEnabled ? 'bold' : 'regular'
-    },
-    h1: {
-      color: colors.darkText,
-      fontFamily: 'bold',
-      fontSize: normalize(24),
-      lineHeight: normalize(30),
-      margin: 0,
-      marginBottom: normalize(24)
-    },
-    h2: {
-      color: colors.darkText,
-      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
-      fontSize: normalize(20),
-      fontWeight: '400',
-      lineHeight: normalize(26),
-      margin: 0,
-      marginBottom: normalize(14)
-    },
-    h3: {
-      color: colors.darkText,
-      fontFamily: 'bold',
-      fontSize: normalize(18),
-      lineHeight: normalize(24),
-      margin: 0
-    },
-    h4: {
-      color: colors.darkText,
-      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
-      fontSize: normalize(18),
-      fontWeight: '400',
-      lineHeight: normalize(24),
-      margin: 0
-    },
-    h5: {
-      color: colors.darkText,
-      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
-      fontSize: normalize(16),
-      fontWeight: '400',
-      margin: 0
-    },
-    h6: {
-      color: colors.darkText,
-      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
-      fontSize: normalize(14),
-      fontWeight: '400',
-      margin: 0
-    },
-    b: {
-      fontFamily: 'bold',
-      margin: 0
-    },
-    strong: {
-      fontFamily: 'bold',
-      margin: 0
-    },
-    ul: {
-      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
-      margin: 0
-    },
-    ol: {
-      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
-      margin: 0
-    },
-    img: {
-      alignSelf: 'center',
-      margin: 0
-    },
-    iframe: {
-      alignSelf: 'center',
-      height: imageHeight(Dimensions.get('window').width),
-      margin: 0
-    },
-    em: {
-      fontFamily: isBoldTextEnabled ? 'bold-italic' : 'italic',
-      margin: 0
-    },
-    figure: {
-      margin: 0
-    }
-  };
+export const htmlBoldTextEnabled = {
+  p: {
+    fontFamily: 'bold'
+  },
+  div: {
+    fontFamily: 'bold'
+  },
+  h2: {
+    fontFamily: 'bold'
+  },
+  h4: {
+    fontFamily: 'bold'
+  },
+  h5: {
+    fontFamily: 'bold'
+  },
+  h6: {
+    fontFamily: 'bold'
+  },
+  ul: {
+    fontFamily: 'bold'
+  },
+  ol: {
+    fontFamily: 'bold'
+  },
+  em: {
+    fontFamily: 'bold-italic'
+  }
 };

--- a/src/config/styles/html.js
+++ b/src/config/styles/html.js
@@ -1,13 +1,18 @@
+import { useContext } from 'react';
 import { Dimensions } from 'react-native';
 
+import { AccessibilityContext } from '../../AccessibilityProvider';
+import { imageHeight } from '../../helpers/imageHelper';
 import { colors } from '../colors';
 import { normalize } from '../normalize';
-import { imageHeight } from '../../helpers/imageHelper';
 
 export const html = () => {
+  const { isBoldTextEnabled } = useContext(AccessibilityContext);
+
   return {
     p: {
       color: colors.darkText,
+      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
       margin: 0,
       marginBottom: normalize(16)
     },
@@ -16,6 +21,9 @@ export const html = () => {
       fontFamily: 'bold',
       margin: 0,
       textDecorationLine: 'none'
+    },
+    div: {
+      fontFamily: isBoldTextEnabled ? 'bold' : 'regular'
     },
     h1: {
       color: colors.darkText,
@@ -27,7 +35,7 @@ export const html = () => {
     },
     h2: {
       color: colors.darkText,
-      fontFamily: 'regular',
+      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
       fontSize: normalize(20),
       fontWeight: '400',
       lineHeight: normalize(26),
@@ -43,7 +51,7 @@ export const html = () => {
     },
     h4: {
       color: colors.darkText,
-      fontFamily: 'regular',
+      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
       fontSize: normalize(18),
       fontWeight: '400',
       lineHeight: normalize(24),
@@ -51,14 +59,14 @@ export const html = () => {
     },
     h5: {
       color: colors.darkText,
-      fontFamily: 'regular',
+      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
       fontSize: normalize(16),
       fontWeight: '400',
       margin: 0
     },
     h6: {
       color: colors.darkText,
-      fontFamily: 'regular',
+      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
       fontSize: normalize(14),
       fontWeight: '400',
       margin: 0
@@ -72,9 +80,11 @@ export const html = () => {
       margin: 0
     },
     ul: {
+      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
       margin: 0
     },
     ol: {
+      fontFamily: isBoldTextEnabled ? 'bold' : 'regular',
       margin: 0
     },
     img: {
@@ -87,7 +97,7 @@ export const html = () => {
       margin: 0
     },
     em: {
-      fontFamily: 'italic',
+      fontFamily: isBoldTextEnabled ? 'bold-italic' : 'italic',
       margin: 0
     },
     figure: {

--- a/src/config/styles/html.js
+++ b/src/config/styles/html.js
@@ -4,92 +4,94 @@ import { colors } from '../colors';
 import { normalize } from '../normalize';
 import { imageHeight } from '../../helpers/imageHelper';
 
-export const html = {
-  p: {
-    color: colors.darkText,
-    margin: 0,
-    marginBottom: normalize(16)
-  },
-  a: {
-    color: colors.primary,
-    fontFamily: 'bold',
-    margin: 0,
-    textDecorationLine: 'none'
-  },
-  h1: {
-    color: colors.darkText,
-    fontFamily: 'bold',
-    fontSize: normalize(24),
-    lineHeight: normalize(30),
-    margin: 0,
-    marginBottom: normalize(24)
-  },
-  h2: {
-    color: colors.darkText,
-    fontFamily: 'regular',
-    fontSize: normalize(20),
-    fontWeight: '400',
-    lineHeight: normalize(26),
-    margin: 0,
-    marginBottom: normalize(14)
-  },
-  h3: {
-    color: colors.darkText,
-    fontFamily: 'bold',
-    fontSize: normalize(18),
-    lineHeight: normalize(24),
-    margin: 0
-  },
-  h4: {
-    color: colors.darkText,
-    fontFamily: 'regular',
-    fontSize: normalize(18),
-    fontWeight: '400',
-    lineHeight: normalize(24),
-    margin: 0
-  },
-  h5: {
-    color: colors.darkText,
-    fontFamily: 'regular',
-    fontSize: normalize(16),
-    fontWeight: '400',
-    margin: 0
-  },
-  h6: {
-    color: colors.darkText,
-    fontFamily: 'regular',
-    fontSize: normalize(14),
-    fontWeight: '400',
-    margin: 0
-  },
-  b: {
-    fontFamily: 'bold',
-    margin: 0
-  },
-  strong: {
-    fontFamily: 'bold',
-    margin: 0
-  },
-  ul: {
-    margin: 0
-  },
-  ol: {
-    margin: 0
-  },
-  img: {
-    alignSelf: 'center',
-    margin: 0
-  },
-  iframe: {
-    alignSelf: 'center',
-    height: imageHeight(Dimensions.get('window').width),
-    margin: 0
-  },
-  em: {
-    fontFamily: 'italic',
-    margin: 0
-  },
-  figure: {
-    margin: 0
-  }
+export const html = () => {
+  return {
+    p: {
+      color: colors.darkText,
+      margin: 0,
+      marginBottom: normalize(16)
+    },
+    a: {
+      color: colors.primary,
+      fontFamily: 'bold',
+      margin: 0,
+      textDecorationLine: 'none'
+    },
+    h1: {
+      color: colors.darkText,
+      fontFamily: 'bold',
+      fontSize: normalize(24),
+      lineHeight: normalize(30),
+      margin: 0,
+      marginBottom: normalize(24)
+    },
+    h2: {
+      color: colors.darkText,
+      fontFamily: 'regular',
+      fontSize: normalize(20),
+      fontWeight: '400',
+      lineHeight: normalize(26),
+      margin: 0,
+      marginBottom: normalize(14)
+    },
+    h3: {
+      color: colors.darkText,
+      fontFamily: 'bold',
+      fontSize: normalize(18),
+      lineHeight: normalize(24),
+      margin: 0
+    },
+    h4: {
+      color: colors.darkText,
+      fontFamily: 'regular',
+      fontSize: normalize(18),
+      fontWeight: '400',
+      lineHeight: normalize(24),
+      margin: 0
+    },
+    h5: {
+      color: colors.darkText,
+      fontFamily: 'regular',
+      fontSize: normalize(16),
+      fontWeight: '400',
+      margin: 0
+    },
+    h6: {
+      color: colors.darkText,
+      fontFamily: 'regular',
+      fontSize: normalize(14),
+      fontWeight: '400',
+      margin: 0
+    },
+    b: {
+      fontFamily: 'bold',
+      margin: 0
+    },
+    strong: {
+      fontFamily: 'bold',
+      margin: 0
+    },
+    ul: {
+      margin: 0
+    },
+    ol: {
+      margin: 0
+    },
+    img: {
+      alignSelf: 'center',
+      margin: 0
+    },
+    iframe: {
+      alignSelf: 'center',
+      height: imageHeight(Dimensions.get('window').width),
+      margin: 0
+    },
+    em: {
+      fontFamily: 'italic',
+      margin: 0
+    },
+    figure: {
+      margin: 0
+    }
+  };
 };

--- a/src/config/styles/index.js
+++ b/src/config/styles/index.js
@@ -1,9 +1,10 @@
 import { baseFontStyle } from './baseFontStyle';
-import { html } from './html';
+import { html, htmlBoldTextEnabled } from './html';
 import { markdown } from './markdown';
 
 export const styles = {
   baseFontStyle,
   html,
+  htmlBoldTextEnabled,
   markdown
 };


### PR DESCRIPTION
- edited according to arrow function format to be able to use `useContext` in html style
- updated `RegularText` to arrow function format to be able to replace text using `RegularText` `styled-component` with bold font
- updated `RegularText` to `RegularTextStyledComponent` to use `RegularText` `styled-component`
- updated `styles.html` in `HtmlView` because html style was updated to arrow function format
- added `fontFamily` style for the `p` tag to `StorySection` since the `p` tag is inside the `div` tag and uses the style of the `p` tag as a priority
- added `bold` or `regular` `fontFamily` option to all text using html style according to `isBoldTextEnabled`

SVA-886

## Screenshots:

|before (home screen)|after (home screen)|before (news screen)|after (news screen)|
|--|--|--|--|
![IMG_2724](https://user-images.githubusercontent.com/11755668/225063771-40002921-bd25-4904-9d8d-e73bb11b3278.PNG) | ![IMG_2728](https://user-images.githubusercontent.com/11755668/225063966-fbd5d53d-4f67-4294-94d7-3736c55c83fe.PNG) | ![IMG_2725](https://user-images.githubusercontent.com/11755668/225063808-f4ab2d6f-77f5-4f0d-8c28-e3f83d492d41.PNG) | ![IMG_2729](https://user-images.githubusercontent.com/11755668/225064005-568ac933-041d-4b76-baff-e77828b31268.PNG)

|before (POI screen)|after (POI screen)|before (impressum screen)|after (impressum screen)|
|--|--|--|--|
![IMG_2726](https://user-images.githubusercontent.com/11755668/225063838-e4f29818-1361-4151-8696-f5667674ceea.PNG) | ![IMG_2730](https://user-images.githubusercontent.com/11755668/225064034-3e820d8d-8d9d-4380-93c5-c6d2c2ceda20.PNG) | ![IMG_2727](https://user-images.githubusercontent.com/11755668/225063868-36626ccd-9a14-4a81-a5d9-e881f5f853d3.PNG) | ![IMG_2731](https://user-images.githubusercontent.com/11755668/225064063-31edd035-1687-4877-9013-d147e5ba6ffd.PNG)
