### PR TITLE
feat(accessibility): increase contrast of feedback footer

### DIFF
--- a/src/components/FeedbackFooter.tsx
+++ b/src/components/FeedbackFooter.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 import React, { FC, useContext } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 
+import { AccessibilityContext } from '../AccessibilityProvider';
 import { texts } from '../config';
 import { SettingsContext } from '../SettingsProvider';
 import { ScreenName } from '../types';
@@ -12,13 +13,14 @@ export const FeedbackFooter: FC = () => {
   const navigation = useNavigation();
   // @ts-expect-error settings are not properly typed
   const feedbackFooter = useContext(SettingsContext).globalSettings?.settings?.feedbackFooter;
+  const { isReduceTransparencyEnabled } = useContext(AccessibilityContext);
 
   if (!feedbackFooter) return null;
 
   return (
     <View style={styles.container}>
       <Pressable onPress={() => navigation.navigate(ScreenName.Feedback)} style={styles.button}>
-        <BoldText underline placeholder>
+        <BoldText underline placeholder={!isReduceTransparencyEnabled}>
           {texts.feedbackLink.toUpperCase()}
         </BoldText>
       </Pressable>


### PR DESCRIPTION
- disabled the `placeholder` prop of `FeedbackFooter`'s `BoldText` and increased contrast if `isReduceTransparencyEnabled` is `true`

SBB-27

## Screenshots:

|before|after|
|--|--|
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-15 at 10 51 18](https://user-images.githubusercontent.com/11755668/225272740-b33e4c3c-b8ef-49c7-aa2a-ce8b290241b8.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-15 at 10 51 11](https://user-images.githubusercontent.com/11755668/225272758-94e68bc8-2fa0-4333-8f7e-54184a188f2b.png)
<img width="481" alt="image" src="https://user-images.githubusercontent.com/11755668/225272823-6c984f6d-d8cf-4c83-ba87-a1f7447cd42b.png"> | <img width="479" alt="image" src="https://user-images.githubusercontent.com/11755668/225272936-5b4773c1-33e7-4bbd-90c8-61e49c582c11.png">
