### PR TITLE
feat(accessibility): increase contrast for hourly weather

### DIFF
--- a/src/components/weather/HourlyWeather.tsx
+++ b/src/components/weather/HourlyWeather.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import { AccessibilityContext } from '../../AccessibilityProvider';
 import { colors, normalize } from '../../config';
 import { momentFormat } from '../../helpers';
 import { Image } from '../Image';
@@ -21,11 +22,19 @@ export const HourlyWeather = ({
   temperature,
   time
 }: HourlyWeatherData) => {
+  const { isReduceTransparencyEnabled } = useContext(AccessibilityContext);
   const formattedTime = momentFormat(time * 1000, 'HH:mm', 'x');
 
   return (
-    <View style={[styles.container, isNow && { backgroundColor: colors.lighterPrimary }]}>
-      <RegularText>{formattedTime}</RegularText>
+    <View
+      style={[
+        styles.container,
+        isNow && {
+          backgroundColor: isReduceTransparencyEnabled ? colors.primary : colors.lighterPrimary
+        }
+      ]}
+    >
+      <RegularText lightest={isNow && isReduceTransparencyEnabled}>{formattedTime}</RegularText>
       <Image
         source={{
           uri: `https://openweathermap.org/img/wn/${icon}@2x.png`,
@@ -34,7 +43,9 @@ export const HourlyWeather = ({
         style={styles.icon}
         resizeMode="contain"
       />
-      <RegularText>{temperature.toFixed(1)}°C</RegularText>
+      <RegularText lightest={isNow && isReduceTransparencyEnabled}>
+        {temperature.toFixed(1)}°C
+      </RegularText>
     </View>
   );
 };


### PR DESCRIPTION
- updated the background color to `primary` and `RegularText` to `lightest` if `isReduceTransparencyEnabled` is `true` to increase contrast in the hourly weather section

SBB-24

## Screenshots:

|before|after|
|--|--|
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-15 at 11 32 17](https://user-images.githubusercontent.com/11755668/225283316-17aab8f3-eb3c-4e9f-a670-4fd0e325a9df.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-15 at 11 32 08](https://user-images.githubusercontent.com/11755668/225283345-2facd299-1384-49ef-8067-fac528bbbc7f.png)
|background contrast|background contrast|
<img width="479" alt="image" src="https://user-images.githubusercontent.com/11755668/225282992-237b2f80-f42d-466e-b41c-17f7a08d099b.png"> | <img width="478" alt="image" src="https://user-images.githubusercontent.com/11755668/225283193-055017f0-742a-4dbd-a233-f15b9878f2d5.png">
|text contrast|text contrast|
<img width="480" alt="image" src="https://user-images.githubusercontent.com/11755668/225283095-1020f9cc-3ce5-42b0-9d45-35a2f3ddcf90.png"> | <img width="478" alt="image" src="https://user-images.githubusercontent.com/11755668/225283264-2b7bbd67-7d7d-4ed8-b341-0a53eba708ec.png">
