### PR TITLE
fix: activity indicator showing above when loading image

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -101,7 +101,7 @@ export const Image = ({
         childrenContainerStyle={style || stylesForImage(aspectRatio).defaultStyle}
         containerStyle={containerStyle}
         PlaceholderContent={PlaceholderContent}
-        placeholderStyle={{ backgroundColor: colors.transparent }}
+        placeholderStyle={styles.placeholderStyle}
         accessible={!!sourceProp?.captionText}
         accessibilityLabel={`${sourceProp.captionText ? sourceProp.captionText : ''} ${
           consts.a11yLabel.image
@@ -117,6 +117,13 @@ export const Image = ({
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  placeholderStyle: {
+    backgroundColor: colors.transparent,
+    flex: 1
+  }
+});
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that eslint warning */


### PR DESCRIPTION
- added `flex: 1` to the `placeholderStyle` to solve the problem that the `ActivityIndicator` shown while loading the image file shows at the top of the screen
- added `placeholderStyle` to make the code more readable and keep the same structure

## Screenshots:

|before|after|
|--|--|
![Simulator Screen Shot - iPhone 14 - 2023-03-20 at 12 13 32](https://user-images.githubusercontent.com/11755668/226323954-159fce9c-483c-469e-8b92-d604dcc0cf34.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-20 at 12 13 21](https://user-images.githubusercontent.com/11755668/226323969-17780966-d2c0-4f8f-94aa-c66febd0d5f8.png)
