### PR TITLE
fix: click problem for inactive survey

### DIFF
--- a/src/components/Radiobutton.js
+++ b/src/components/Radiobutton.js
@@ -13,22 +13,18 @@ export const Radiobutton = ({ title, disabled, selected, onPress, containerStyle
         ? texts.accessibilityLabels.checkbox.active
         : texts.accessibilityLabels.checkbox.inactive
     } (${title})`}
-    title={title}
     checked={selected}
+    checkedIcon={<Icon.RadioButtonFilled size={22} style={styles.rightContentContainer} />}
+    containerStyle={[styles.containerStyle, containerStyle]}
+    disabled={disabled}
     onPress={onPress}
     size={normalize(24)}
-    containerStyle={[styles.containerStyle, containerStyle]}
-    accessibilityLabel={`${
-      selected
-        ? texts.accessibilityLabels.checkbox.active
-        : texts.accessibilityLabels.checkbox.inactive
-    } ${title}`}
     textStyle={[
       styles.textStyle,
       selected && styles.textStyleSelected,
       disabled && styles.textStyleDisabled
     ]}
-    checkedIcon={<Icon.RadioButtonFilled size={22} style={styles.rightContentContainer} />}
+    title={title}
     uncheckedIcon={
       <Icon.RadioButtonEmpty
         size={22}

--- a/src/components/survey/SurveyAnswer.tsx
+++ b/src/components/survey/SurveyAnswer.tsx
@@ -60,7 +60,7 @@ export const SurveyAnswer = ({
         <View style={styles.border}>
           <WrapperRow>
             <Wrapper style={styles.radioButtonContainer}>
-              <Radiobutton selected={selected} onPress={onPress} />
+              <Radiobutton selected={selected} disabled={archived} onPress={onPress} />
             </Wrapper>
             <Wrapper style={styles.answerContainer}>
               <BoldText>{getAnswerLabel('de', index)}</BoldText>


### PR DESCRIPTION
- added `disabled` prop so that if a survey is over, the poll options cannot be selected with `RadioButton`
- added `disable` prop to `RadioButton` to prevent clickability
- alphabetised `RadioButton`'s props

SVA-928

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
