### PR TITLE
fix: orientation error on chat screen

### DIFF
--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -1,6 +1,7 @@
 import { Video } from 'expo-av';
 import * as FileSystem from 'expo-file-system';
 import { MediaTypeOptions } from 'expo-image-picker';
+import * as ScreenOrientation from 'expo-screen-orientation';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
@@ -55,6 +56,12 @@ export const Chat = ({
 }) => {
   const [messages, setMessages] = useState(data);
   const [medias, setMedias] = useState([]);
+
+  useEffect(() => {
+    // this screen is set to portrait mode because half of the screen is visible in landscape
+    // mode when viewing pictures in large screen mode
+    ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+  }, []);
 
   useEffect(() => {
     setMessages(data);

--- a/src/screens/volunteer/VolunteerIndexScreen.tsx
+++ b/src/screens/volunteer/VolunteerIndexScreen.tsx
@@ -1,5 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { StackScreenProps } from '@react-navigation/stack';
+import * as ScreenOrientation from 'expo-screen-orientation';
 import React, { useCallback, useState } from 'react';
 import { RefreshControl, StyleSheet } from 'react-native';
 
@@ -66,6 +67,15 @@ export const VolunteerIndexScreen = ({ navigation, route }: StackScreenProps<any
   useFocusEffect(
     useCallback(() => {
       refetch();
+    }, [])
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      if (query === QUERY_TYPES.VOLUNTEER.CONVERSATIONS) {
+        // this is needed because the chat screen is locked to portrait mode
+        ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.DEFAULT);
+      }
     }, [])
   );
 


### PR DESCRIPTION
- added orientation lock to the chat screen to resolve the half-screen display that occurs after turning the screen sideways while viewing any image on the chat screen
- added `useFocusEffect` to `VolunteerIndexScreen`  screen to work when navigating back from  chat page and remove orientation lock

SVA-768

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode
