### PR TITLE
feat: change the opacity of the options in finished surveys

### DIFF
--- a/src/components/survey/SurveyAnswer.tsx
+++ b/src/components/survey/SurveyAnswer.tsx
@@ -14,7 +14,6 @@ import { SurveyText } from './SurveyText';
 
 type Props = {
   archived?: boolean;
-  faded: boolean;
   index: number;
   isMultilingual?: boolean;
   isMultiSelect?: boolean;
@@ -28,7 +27,6 @@ const answerWidth = imageWidth() - (3 * normalize(14) + normalize(24));
 
 export const SurveyAnswer = ({
   archived,
-  faded,
   index,
   isMultilingual,
   isMultiSelect,
@@ -52,11 +50,11 @@ export const SurveyAnswer = ({
     });
   }, [id, setSelection]);
 
-  const fadeStyle = { opacity: faded ? 0.5 : 1 };
+  const opacity = archived ? (selected ? 1 : 0.5) : 1;
 
   return (
     <Touchable disabled={archived} onPress={onPress}>
-      <Wrapper style={[styles.noPaddingBottom, fadeStyle]}>
+      <Wrapper style={[styles.noPaddingBottom, opacity]}>
         <View style={styles.border}>
           <WrapperRow>
             <Wrapper style={styles.radioButtonContainer}>

--- a/src/screens/SurveyDetailScreen.tsx
+++ b/src/screens/SurveyDetailScreen.tsx
@@ -134,7 +134,6 @@ export const SurveyDetailScreen = ({ route }: Props) => {
             {survey.responseOptions.map((responseOption, index) => (
               <SurveyAnswer
                 archived={archived}
-                faded={!!selection.length && !selection.includes(responseOption.id)}
                 index={index}
                 isMultilingual={survey.isMultilingual}
                 isMultiSelect={survey.questionAllowMultipleResponses}


### PR DESCRIPTION
- added opacity instead of `fadeStyle` to set  the opacity of the options of the finished  survey without any user-selected answer
- removed the faded prop in the `SurveyAnswer`  component because the opacity style no longer  depends on the `faded` prop

SVA-928

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode

|active survey|finished and one option selected survey|finished survey with more than one option selected|finished survey with no options selected|
|--|--|--|--|
![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 17 46 45](https://user-images.githubusercontent.com/11755668/227589038-c817eb3b-2f17-4c92-95f8-9af54a82178d.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 17 46 53](https://user-images.githubusercontent.com/11755668/227589055-ea4d76be-9b95-4497-88af-ecc732d276b1.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 17 46 57](https://user-images.githubusercontent.com/11755668/227589086-039747a4-e4bb-4be7-93c9-1c52df9b9d81.png) |![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 17 47 01](https://user-images.githubusercontent.com/11755668/227589103-410aaee5-8afd-4042-bb2e-8452f8867576.png)
