### PR TITLE
feat: change the opacity of the options in finished surveys

### DIFF
--- a/src/components/survey/SurveyAnswer.tsx
+++ b/src/components/survey/SurveyAnswer.tsx
@@ -52,11 +52,17 @@ export const SurveyAnswer = ({
     });
   }, [id, setSelection]);
 
-  const fadeStyle = { opacity: faded ? 0.5 : 1 };
+  let opacity = 1;
+
+  if (archived) {
+    opacity = selected ? 1 : 0.5;
+  } else if (faded) {
+    opacity = 0.5;
+  }
 
   return (
     <Touchable disabled={archived} onPress={onPress}>
-      <Wrapper style={[styles.noPaddingBottom, fadeStyle]}>
+      <Wrapper style={[styles.noPaddingBottom, { opacity }]}>
         <View style={styles.border}>
           <WrapperRow>
             <Wrapper style={styles.radioButtonContainer}>


### PR DESCRIPTION
- added opacity instead of `fadeStyle` to set  the opacity of the options of the finished  survey without any user-selected answer

SVA-928

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode

|active survey|finished and one option selected survey|finished survey with more than one option selected|finished survey with no options selected|
|--|--|--|--|
![image](https://user-images.githubusercontent.com/11755668/227871500-e88d607f-d14a-45ff-a2cb-3354438c1c77.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 17 46 53](https://user-images.githubusercontent.com/11755668/227589055-ea4d76be-9b95-4497-88af-ecc732d276b1.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 17 46 57](https://user-images.githubusercontent.com/11755668/227589086-039747a4-e4bb-4be7-93c9-1c52df9b9d81.png) |![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 17 47 01](https://user-images.githubusercontent.com/11755668/227589103-410aaee5-8afd-4042-bb2e-8452f8867576.png)
