### PR TITLE
fix: notification problem for android

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -8,7 +8,13 @@ import { namespace, secrets } from './config';
  * we need to divide Date.now() by 1000, which otherwise would return miliseconds.
  */
 const isTokenValid = async () => {
-  const accessTokenExpireTime = await SecureStore.getItemAsync('ACCESS_TOKEN_EXPIRE_TIME');
+  let accessTokenExpireTime = null;
+  try {
+    accessTokenExpireTime = await SecureStore.getItemAsync('ACCESS_TOKEN_EXPIRE_TIME');
+  } catch (e) {
+    // this only throws if they reinstall on android
+    await SecureStore.deleteItemAsync('ACCESS_TOKEN_EXPIRE_TIME');
+  }
 
   if (!accessTokenExpireTime) return false;
 

--- a/src/helpers/volunteerHelper.ts
+++ b/src/helpers/volunteerHelper.ts
@@ -28,7 +28,16 @@ export const storeVolunteerAuthToken = (authToken?: string) => {
   }
 };
 
-export const volunteerAuthToken = () => SecureStore.getItemAsync(VOLUNTEER_AUTH_TOKEN);
+export const volunteerAuthToken = async () => {
+  let authToken = null;
+  try {
+    authToken = await SecureStore.getItemAsync(VOLUNTEER_AUTH_TOKEN);
+  } catch (error) {
+    SecureStore.deleteItemAsync(VOLUNTEER_AUTH_TOKEN);
+  }
+
+  return authToken;
+};
 
 export const storeVolunteerUserData = (userData?: {
   id: number;
@@ -54,11 +63,21 @@ export const volunteerUserData = async (): Promise<{
   currentUserGuId: string | null;
   currentUserContentContainerId: string | null;
 }> => {
-  const currentUserId = await SecureStore.getItemAsync(VOLUNTEER_CURRENT_USER_ID);
-  const currentUserGuId = await SecureStore.getItemAsync(VOLUNTEER_CURRENT_USER_GUID);
-  const currentUserContentContainerId = await SecureStore.getItemAsync(
-    VOLUNTEER_CURRENT_USER_CONTENT_CONTAINER_ID
-  );
+  let currentUserId = null;
+  let currentUserGuId = null;
+  let currentUserContentContainerId = null;
+  try {
+    currentUserId = await SecureStore.getItemAsync(VOLUNTEER_CURRENT_USER_ID);
+    currentUserGuId = await SecureStore.getItemAsync(VOLUNTEER_CURRENT_USER_GUID);
+    currentUserContentContainerId = await SecureStore.getItemAsync(
+      VOLUNTEER_CURRENT_USER_CONTENT_CONTAINER_ID
+    );
+  } catch (e) {
+    // this only throws if they reinstall on android
+    await SecureStore.deleteItemAsync(VOLUNTEER_CURRENT_USER_ID);
+    await SecureStore.deleteItemAsync(VOLUNTEER_CURRENT_USER_GUID);
+    await SecureStore.deleteItemAsync(VOLUNTEER_CURRENT_USER_CONTENT_CONTAINER_ID);
+  }
 
   return {
     currentUserId,

--- a/src/pushNotifications/PermissionHandling.ts
+++ b/src/pushNotifications/PermissionHandling.ts
@@ -60,10 +60,9 @@ export const initializePushPermissions = async () => {
   }
 };
 
+// https://docs.expo.dev/versions/latest/sdk/notifications/#expopushtokenoptions
 const registerForPushNotificationsAsync = async () => {
-  const { data: token } = await Notifications.getExpoPushTokenAsync({
-    experienceId: `@${Constants.manifest?.owner || 'ikusei'}/${Constants.manifest?.slug}`
-  });
+  const { data: token } = await Notifications.getExpoPushTokenAsync();
 
   return token;
 };

--- a/src/pushNotifications/PermissionHandling.ts
+++ b/src/pushNotifications/PermissionHandling.ts
@@ -65,6 +65,13 @@ const registerForPushNotificationsAsync = async () => {
     experienceId: `@${Constants.manifest?.owner || 'ikusei'}/${Constants.manifest?.slug}`
   });
 
+  return token;
+};
+
+export const handleSystemPermissions = async (): Promise<boolean> => {
+  // Push notifications do not work properly with simulators/emulators
+  if (!Constants.isDevice) return false;
+
   if (device.platform === 'android') {
     Notifications.setNotificationChannelAsync('default', {
       name: 'default',
@@ -73,13 +80,6 @@ const registerForPushNotificationsAsync = async () => {
       lightColor: parseColorToHex(colors.primary) ?? '#ffffff' // fall back to white if we can't make sense of the color value
     });
   }
-
-  return token;
-};
-
-export const handleSystemPermissions = async (): Promise<boolean> => {
-  // Push notifications do not work properly with simulators/emulators
-  if (!Constants.isDevice) return false;
 
   const { status: existingStatus } = await Notifications.getPermissionsAsync();
 


### PR DESCRIPTION
- added `setNotificationChannelAsync` function to `handleSystemPermissions`
  function because it is necessary to create a notification channel before creating
  a token with android 13

SVA-1000

Expo Doc. : https://docs.expo.dev/versions/latest/sdk/notifications/
<img width="997" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/285b8bfe-940c-4bae-90e8-4ad0ba82dad9">


## How to test:
* [x] Android