### PR TITLE
fix(feedback): checbox appearing above input

### DIFF
--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -11,15 +11,16 @@ import { BoldText, RegularText } from './Text';
 import { WrapperHorizontal } from './Wrapper';
 
 export const Checkbox = ({
-  title,
   boldTitle,
-  onPress,
-  checkedIcon,
-  uncheckedIcon,
-  checked,
   center = undefined,
+  checked,
+  checkedIcon,
+  containerStyle,
   link = undefined,
   linkDescription = undefined,
+  onPress,
+  title,
+  uncheckedIcon,
   ...props
 }) => {
   const { orientation, dimensions } = useContext(OrientationContext);
@@ -56,7 +57,11 @@ export const Checkbox = ({
       onPress={onPress}
       checkedIcon={checkedIcon}
       checked={checked}
-      containerStyle={[styles.containerStyle, needLandscapeStyle && styles.containerStyleLandscape]}
+      containerStyle={[
+        styles.containerStyle,
+        needLandscapeStyle && styles.containerStyleLandscape,
+        containerStyle
+      ]}
       uncheckedIcon={uncheckedIcon}
       textStyle={styles.titleStyle}
       checkedColor={colors.primary}
@@ -83,16 +88,17 @@ const styles = StyleSheet.create({
 });
 
 Checkbox.propTypes = {
-  title: PropTypes.string.isRequired,
   boldTitle: PropTypes.bool,
-  onPress: PropTypes.func.isRequired,
-  link: PropTypes.string,
-  checkedIcon: PropTypes.string,
-  uncheckedIcon: PropTypes.string,
-  disabled: PropTypes.bool,
-  checked: PropTypes.bool,
   center: PropTypes.bool,
-  linkDescription: PropTypes.string
+  checked: PropTypes.bool,
+  checkedIcon: PropTypes.string,
+  containerStyle: PropTypes.object,
+  disabled: PropTypes.bool,
+  link: PropTypes.string,
+  linkDescription: PropTypes.string,
+  onPress: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  uncheckedIcon: PropTypes.string
 };
 
 CheckBox.defaultProps = {

--- a/src/screens/FeedbackScreen.js
+++ b/src/screens/FeedbackScreen.js
@@ -147,6 +147,7 @@ export const FeedbackScreen = () => {
               render={({ onChange, value }) => (
                 <Checkbox
                   boldTitle
+                  containerStyle={styles.checkboxContainerStyle}
                   title={texts.feedbackScreen.inputsLabel.checkbox + ' *'}
                   checkedIcon="check-square-o"
                   checkedColor={colors.accent}
@@ -176,6 +177,9 @@ export const FeedbackScreen = () => {
 };
 
 const styles = StyleSheet.create({
+  checkboxContainerStyle: {
+    marginTop: normalize(30)
+  },
   containerStyle: {
     marginBottom: normalize(30)
   },


### PR DESCRIPTION
- added `marginTop` to the `Checkbox` with `checkboxContainerStyle` because the checkbox appears above the input
- added `containerStyle` prop to checkbox
- sorted checkbox's props alphabetically

SVA-1029

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode


## Screenshots:

|before|after|
|--|--|
![Screenshot_20230530-165208](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/edafacde-3465-422b-8771-acb34f864462) | ![Screenshot_20230530-165228](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/70c7a2fb-5a00-49e1-83bf-f0c0088355ea) 

|before|after|
|--|--|
![Screenshot_20230530-165216](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/50a88e60-75a1-40c2-b514-1c8c9b488d1c) | ![Screenshot_20230530-165221](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/2b9d80e9-b6a1-4001-8f62-9f0e566854be)
