### PR TITLE
feat(calendar): add a list under the event calendar

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,16 +1,23 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import moment from 'moment';
 import 'moment/locale/de';
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
+import { useQuery } from 'react-apollo';
+import { ActivityIndicator } from 'react-native';
 import { CalendarProps, Calendar as RNCalendar } from 'react-native-calendars';
 import BasicDay, { BasicDayProps } from 'react-native-calendars/src/calendar/day/basic';
 import { DateData } from 'react-native-calendars/src/types';
 
+import { SettingsContext } from '../SettingsProvider';
 import { colors, consts, texts } from '../config';
+import { parseListItemsFromQuery } from '../helpers';
 import { setupLocales } from '../helpers/calendarHelper';
-import { QUERY_TYPES } from '../queries';
+import { QUERY_TYPES, getQuery } from '../queries';
 import { ScreenName, Calendar as TCalendar } from '../types';
 
+import { EmptyMessage } from './EmptyMessage';
+import { ListComponent } from './ListComponent';
+import { LoadingContainer } from './LoadingContainer';
 import { renderArrow } from './calendarArrows';
 
 const { ROOT_ROUTE_NAMES } = consts;
@@ -36,14 +43,14 @@ const MAX_DOTS_PER_DAY = 5;
 
 setupLocales();
 
-const getMarkedDates = (data?: any[]) => {
+const getMarkedDates = (data?: any[], dotCount: number = MAX_DOTS_PER_DAY, selectedDay: string) => {
   const markedDates: CalendarProps['markedDates'] = {};
 
   data?.forEach((item) => {
     if (
       !!item.listDate &&
       (!markedDates?.[item?.listDate]?.dots ||
-        markedDates?.[item?.listDate]?.dots?.length < MAX_DOTS_PER_DAY)
+        markedDates?.[item?.listDate]?.dots?.length < dotCount)
     ) {
       markedDates[item?.listDate] = {
         marked: true,
@@ -55,11 +62,9 @@ const getMarkedDates = (data?: any[]) => {
     }
   });
 
-  const today = moment().format('YYYY-MM-DD');
-
   // highlight today
-  markedDates[today] = {
-    ...(markedDates[today] ?? {}),
+  markedDates[selectedDay] = {
+    ...(markedDates[selectedDay] ?? {}),
     selected: true,
     selectedColor: colors.lighterPrimary
   };
@@ -69,10 +74,38 @@ const getMarkedDates = (data?: any[]) => {
 
 export const Calendar = ({ query, queryVariables, calendarData, isLoading, navigation }: Props) => {
   const contentContainerId = queryVariables?.contentContainerId;
+  const today = moment().format('YYYY-MM-DD');
+  const { globalSettings } = useContext(SettingsContext);
+  const { settings = {} } = globalSettings;
+  const { eventCalendar = {} } = settings;
+  const { dotCount, subList = false } = eventCalendar;
+
+  const [queryVariableWithDateRange, setQueryVariableWithDateRange] = useState<any>({
+    queryVariables,
+    dateRange: [today, today]
+  });
+  const [markedDates, setMarkedDates] = useState<CalendarProps['markedDates']>(
+    getMarkedDates(calendarData, dotCount, today)
+  );
+
+  const { data, loading } = useQuery(getQuery(QUERY_TYPES.EVENT_RECORDS), {
+    variables: queryVariableWithDateRange,
+    skip: !subList
+  });
 
   const onDayPress = useCallback(
     (day: DateData) => {
       if (query === QUERY_TYPES.EVENT_RECORDS) {
+        if (subList) {
+          setQueryVariableWithDateRange({
+            ...queryVariables,
+            dateRange: [day.dateString, day.dateString]
+          });
+          setMarkedDates(getMarkedDates(calendarData, dotCount, day.dateString));
+
+          return;
+        }
+
         return navigation.push(ScreenName.Index, {
           title: texts.homeTitles.events,
           query,
@@ -91,25 +124,53 @@ export const Calendar = ({ query, queryVariables, calendarData, isLoading, navig
     [navigation, query, queryVariables, calendarData, contentContainerId]
   );
 
+  const buildListItems = useCallback(
+    (data: DateData) => parseListItemsFromQuery(query, data, { queryVariableWithDateRange }),
+    [query, queryVariableWithDateRange]
+  );
+
   return (
-    <RNCalendar
-      dayComponent={DayComponent}
-      onDayPress={onDayPress}
-      displayLoadingIndicator={isLoading}
-      markedDates={getMarkedDates(calendarData)}
-      markingType="multi-dot"
-      renderArrow={renderArrow}
-      firstDay={1}
-      theme={{
-        todayTextColor: colors.primary,
-        indicatorColor: colors.primary,
-        dotStyle: {
-          borderRadius: DOT_SIZE / 2,
-          height: DOT_SIZE,
-          width: DOT_SIZE
-        }
-      }}
-      enableSwipeMonths
-    />
+    <>
+      <RNCalendar
+        dayComponent={DayComponent}
+        onDayPress={onDayPress}
+        displayLoadingIndicator={isLoading}
+        markedDates={markedDates}
+        markingType="multi-dot"
+        renderArrow={renderArrow}
+        firstDay={1}
+        theme={{
+          todayTextColor: colors.primary,
+          indicatorColor: colors.primary,
+          dotStyle: {
+            borderRadius: DOT_SIZE / 2,
+            height: DOT_SIZE,
+            width: DOT_SIZE
+          }
+        }}
+        enableSwipeMonths
+      />
+
+      {subList && (
+        <ListComponent
+          data={buildListItems(data)}
+          horizontal={false}
+          ListEmptyComponent={
+            loading ? (
+              <LoadingContainer>
+                <ActivityIndicator color={colors.accent} />
+              </LoadingContainer>
+            ) : (
+              <EmptyMessage title={texts.empty.list} />
+            )
+          }
+          navigation={navigation}
+          query={query}
+          queryVariables={queryVariables}
+          sectionByDate
+          showBackToTop
+        />
+      )}
+    </>
   );
 };


### PR DESCRIPTION
- added `ListComponent` to show event list under calendar
- added `globalSettings` to set whether to show the list and how many dots to show in the calendar
- added event query to show the events of the selected day in the calendar in the list if the `subList` value in `globalSettings` is `true`
- added to update the `queryVariable` instead of redirecting to the `Index` screen after clicking a day in the calendar if the `subList` value is set to true on the `globalSettings`
- added as prop instead of `selectedDay` variable in `getMarkedDates` function to mark the selected day in calendar
- added `buildListItems` function to properly parse the selected day's event data in the list
- added `dotCount` and overridden `MAX_DOTS_PER_DAY` if there is `dotCount` value in `globalSettings` to show the desired number of dot in the calendar
- added `dateRange` to `queryVariables` to show the events of that day in the list under the calendar when the calendar on the event page is activated

SVA-665

## How to test:
* [x] Android portrait mode
* [x] iOS portrait mode
* [x] Android landscape mode
* [x] iOS landscape mode

add the following code to `globalSettings` to try this feature

```
  "settings": {
    "eventCalendar": {
      "maxDotPerDay": 1,
      "subList": true
    },
  }
```

## Screenshots:

|before|after|after|
|--|--|--|
![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-02 at 12 59 22](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/1bdb90d7-6821-4962-b80b-6353a9154eae) | ![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-02 at 12 58 08](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/7f109121-7414-43a5-ab07-b352f5eea448) | ![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-02 at 12 58 35](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/2cb06217-7b3a-4467-88e9-3a585c5a33ce)

