### PR TITLE
fix(waste calendar): the type problem in the waste calendar reminder

### DIFF
--- a/src/components/wasteCalendar/WasteReminderSettings.tsx
+++ b/src/components/wasteCalendar/WasteReminderSettings.tsx
@@ -142,7 +142,13 @@ export const WasteReminderSettings = ({
     async (street: string) => {
       setLoading(true);
       setError(false);
-      const storedSettings = await getReminderSettings();
+
+      // replace null values with empty strings for city and zip in storedSettings to prevent validation issues
+      const storedSettings = (await getReminderSettings()).map((setting: ReminderSettingJson) => ({
+        ...setting,
+        city: setting.city ?? '',
+        zip: setting.zip ?? ''
+      }));
 
       if (!areValidReminderSettings(storedSettings)) {
         setError(true);

--- a/src/jsonValidation/reminderSettingsValidation.ts
+++ b/src/jsonValidation/reminderSettingsValidation.ts
@@ -1,18 +1,8 @@
 import _isObjectLike from 'lodash/isObjectLike';
 
-import { ReminderSettings } from '../types';
+import { ReminderSettingJson, ReminderSettings } from '../types';
 
 import { isArrayOfType } from './basicTypeValidation';
-
-type ReminderSettingJson = {
-  city: string;
-  id: number;
-  notify_at: string;
-  notify_days_before: number;
-  notify_for_waste_type: string;
-  street: string;
-  zip: string;
-};
 
 const isValidReminderSetting = (data: unknown): data is ReminderSettingJson => {
   if (!_isObjectLike(data)) {

--- a/src/types/WasteCalendar.ts
+++ b/src/types/WasteCalendar.ts
@@ -4,6 +4,16 @@ export type ReminderSettings = {
   reminderTime: Date;
 };
 
+export type ReminderSettingJson = {
+  city: string;
+  id: number;
+  notify_at: string;
+  notify_days_before: number;
+  notify_for_waste_type: string;
+  street: string;
+  zip: string;
+};
+
 export type WasteTypeData = {
   [key: string]: {
     color: string;


### PR DESCRIPTION
- updated the types of `city` and `zip` before validation to prevent them
  from coming from the server with different types
- added to `WasteCalendar` types to use `ReminderSettingJson` from anywhere

SVA-1028

It was not possible to create a new reminder because of a previously saved reminder. The reason for this problem is that the types here are different from what we expected.

**Difference between data**
|with `city` & `zip`|without `city` & `zip`|
|--|--|
<img width="368" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/02098f5a-b9c6-4f18-99c6-4eddb565cc58"> | <img width="459" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/06517c97-c943-4ac4-883d-cca169ee0b74">
