### PR TITLE
fix: remove spaces in the link

### DIFF
--- a/src/helpers/linkHelper.js
+++ b/src/helpers/linkHelper.js
@@ -14,7 +14,7 @@ import * as Linking from 'expo-linking';
  */
 function ensureProtocol(link) {
   const protocolRegExpMatch = link.match(/^https?:|tel:|mailto:|maps:|geo:/);
-  let linkWithProtocol = link;
+  let linkWithProtocol = link.replaceAll(' ', '');
 
   if (!protocolRegExpMatch) {
     linkWithProtocol = `http://${link}`;


### PR DESCRIPTION
- deleted spaces in links because the links could not be opened by the application due to spaces in some links

SVA-1036
