### PR TITLE
feat: change input border color

### DIFF
--- a/src/components/form/Input.tsx
+++ b/src/components/form/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { useController, UseControllerOptions } from 'react-hook-form';
 import { StyleSheet } from 'react-native';
 import { Input as RNEInput, InputProps } from 'react-native-elements';
@@ -6,6 +6,7 @@ import { Input as RNEInput, InputProps } from 'react-native-elements';
 import { colors, consts, device, Icon, normalize } from '../../config';
 import { Label } from '../Label';
 import { BoldText } from '../Text';
+import { AccessibilityContext } from '../../AccessibilityProvider';
 
 const { a11yLabel } = consts;
 
@@ -39,6 +40,8 @@ export const Input = ({
   containerStyle,
   ...furtherProps
 }: Props) => {
+  const { isReduceTransparencyEnabled } = useContext(AccessibilityContext);
+
   const { field } = useController({
     control,
     name,
@@ -116,6 +119,7 @@ export const Input = ({
         hidden && styles.inputContainerHidden,
         isValid && styles.inputContainerSuccess,
         !isValid && !!errorMessage && styles.inputContainerError,
+        isReduceTransparencyEnabled && styles.inputAccessibilityBorderContrast,
         inputContainerStyle
       ]}
       rightIconContainerStyle={styles.rightIconContainer}
@@ -146,6 +150,9 @@ const styles = StyleSheet.create({
   },
   row: {
     width: '47%'
+  },
+  inputAccessibilityBorderContrast: {
+    borderColor: colors.darkText
   },
   inputContainer: {
     borderBottomWidth: normalize(1),


### PR DESCRIPTION
- added the `inputAccessibilityBorderContrast` style so that the borders of inputs have a better contrast ratio with the background after turning on `Reduce Transparency` in accessibility settings

SBB-29

## How to test:
* [x] iOS portrait mode
* [x] iOS landscape mode


## Screenshots:

|Reduce Transparency off|Reduce Transparency on|
|--|--|
![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-13 at 16 24 10](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/68ec7a39-4da2-4566-8551-30f7bf284a2a) | ![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-13 at 16 24 15](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/0cb3605e-4fe9-49d4-92e9-e260d2f36474)
