### PR TITLE
refactor: fix accessibility labels

### DIFF
--- a/src/components/IndexFilterWrapperAndList.js
+++ b/src/components/IndexFilterWrapperAndList.js
@@ -21,7 +21,7 @@ export const IndexFilterWrapperAndList = ({ filter, setFilter }) => {
         data={filter}
         renderItem={({ item }) => (
           <Touchable
-            accessibilityLabel={`(${item.title}) ${a11yLabel.drop} (${
+            accessibilityLabel={`(${item.title}) ${a11yLabel.tabs} (${
               item.selected
                 ? texts.accessibilityLabels.tabs.active
                 : texts.accessibilityLabels.tabs.inactive

--- a/src/components/ListSettingsItem.js
+++ b/src/components/ListSettingsItem.js
@@ -60,8 +60,8 @@ export const ListSettingsItem = ({ item }) => {
         {Object.values(LIST_TYPES).map((listType) => {
           const activeTabAccessibilityLabel =
             listType === listTypeForQuery
-              ? texts.accessibilityLabels.tabs.active
-              : texts.accessibilityLabels.tabs.inactive;
+              ? texts.accessibilityLabels.menuItem.active
+              : texts.accessibilityLabels.menuItem.inactive;
 
           return (
             <ListItem

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -10,6 +10,10 @@ export const texts = {
       closed: 'geschlossen',
       open: 'geöffnet'
     },
+    menuItem: {
+      active: 'aktiviert',
+      inactive: 'nicht aktiviert'
+    },
     searchInputIcons: {
       delete: 'Suche löschen',
       search: 'Suche'


### PR DESCRIPTION
- added `menuItem` instead of tabs `AccessibilityLabel` in `ListSettingsItem` to make it more understandable
- replaced `a11yLabel.drop` in `IndexFilterWrapperAndList` with `a11yLabel.tabs` because it was `undefined`

SBB-55
