### PR TITLE
feat: integrate custom links for android

### DIFF
--- a/app.json
+++ b/app.json
@@ -74,7 +74,8 @@
           "initialOrientation": "PORTRAIT"
         }
       ],
-      "sentry-expo"
+      "sentry-expo",
+      "./config-plugins/withAndroidMailQueriesAndWhatsappPackage"
     ]
   }
 }

--- a/config-plugins/withAndroidMailQueriesAndWhatsappPackage.js
+++ b/config-plugins/withAndroidMailQueriesAndWhatsappPackage.js
@@ -1,0 +1,43 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { withAndroidManifest } = require('@expo/config-plugins');
+
+function addIntentToQuery({ mod, intent }) {
+  const copyMod = { ...mod };
+  if (!copyMod.modResults.manifest.queries) {
+    copyMod.modResults.manifest.queries = [{ intent: [] }];
+  } else if (!copyMod.modResults.manifest.queries[0]) {
+    copyMod.modResults.manifest.queries = [];
+  }
+
+  copyMod.modResults.manifest.queries.push({
+    ...(!intent.dataScheme && { package: [{ $: { 'android:name': intent.actionName } }] }),
+    ...(intent.dataScheme && {
+      intent: {
+        action: [{ $: { 'android:name': intent.actionName } }],
+        data: [{ $: { 'android:scheme': intent.dataScheme } }]
+      }
+    })
+  });
+
+  return copyMod;
+}
+
+const withAndroidMailQueriesAndWhatsappPackage = (config) => {
+  const mod = withAndroidManifest(config, (mod) => {
+    let modified = addIntentToQuery({
+      mod,
+      intent: { actionName: 'android.intent.action.SENDTO', dataScheme: 'mailto' }
+    });
+
+    modified = addIntentToQuery({
+      mod,
+      intent: { actionName: 'com.whatsapp' }
+    });
+
+    return modified;
+  });
+
+  return mod;
+};
+
+module.exports = withAndroidMailQueriesAndWhatsappPackage;


### PR DESCRIPTION
- added `withAndroidMailQueriesAndWhatsappPackage` config for `mailto:` and `whatsapp:` custom link in webview to work on Android devices

SVA-1047

In order to run any custom link inside the webview, it is necessary to update the native files of Android. With Expo config-plugins, I updated the AndroidManifest.xml file in the Android folder (android/app/src/main/AndroidManifest.xml) so that the application can be redirected with `mailto:` and` whatsapp:` links.

I got help from the following issue.
[React-Native Issue](https://github.com/facebook/react-native/issues/30909)

To try it out:
1. select branch and run `yarn prebuild` command
2. connect the android device to the computer with the cable, run the `yarn android -d` command and select your device
3. while waiting for the build to finish, perform the following actions
4. change the `settings` prop of the `StorySection` component in `NewsItem.js` as follows.
```
settings={{ displayOnlySummary: 'true', onlySummaryLinkText: 'Weiterlesen' }}
```
5. after the build process is successfully completed, follow these steps
6. then enter the news "Test News mit Link"
7. click on the "Weiterlesen" button
8. you will see links for mail and whatsapp on the page that opens. you can try whether the feature works with these links.