### PR TITLE
fix: autocomplete list not closing problem

### DIFF
--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -347,7 +347,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
             data={filteredCities}
             disableFullscreenUI
             flatListProps={{
-              height: dimensions.height - normalize(170),
+              height: inputValueCitySelected ? undefined : dimensions.height - normalize(170),
               keyboardShouldPersistTaps: 'handled',
               renderItem: inputValueCitySelected ? null : renderSuggestionCities
             }}


### PR DESCRIPTION
- updated `height` in `flatListProps` to `undefined` if city is selected to fix a bug where the `AutoComplete` list would remain open after a city search because `height` had not changed

SVA-833

|before|after|
|--|--|
![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-29 at 16 14 28](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/163ebe20-dcdd-4e71-bb1d-22e373acbf71) | ![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-29 at 16 14 15](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/42794889-5784-4f6a-a41c-6a780d277428)
