### PR TITLE
feat(opening times): dates with parsed TMB year

### DIFF
--- a/__tests__/helpers/openingHoursHelper.test.ts
+++ b/__tests__/helpers/openingHoursHelper.test.ts
@@ -1,4 +1,4 @@
-import { getReadableDay, isOpen } from '../../src/helpers';
+import { TMB_YEAR_TO_PARSE, dateWithCorrectYear, getReadableDay, isOpen } from '../../src/helpers';
 import { OpeningHour } from '../../src/types';
 
 const FAKE_NOW_DATE = new Date();
@@ -11,6 +11,20 @@ const weekday = getReadableDay(FAKE_NOW_DATE);
 
 const isOpenWithFakeTimeDateTime = (openingHours: OpeningHour[]) =>
   isOpen(openingHours, FAKE_NOW_DATE);
+
+describe('testing correct year for date for TMB data', () => {
+  it('not adjusted year for a date in 2022', () => {
+    expect(dateWithCorrectYear('2022-05-19')).toEqual(new Date('2022-05-19'));
+  });
+
+  it('adjusted year for a date in the year that should be parsed', () => {
+    const currentYear = FAKE_NOW_DATE.getFullYear();
+
+    expect(dateWithCorrectYear(`${TMB_YEAR_TO_PARSE}-03-09`)).toEqual(
+      new Date(`${currentYear}-03-09`)
+    );
+  });
+});
 
 describe('testing the opening times handling', () => {
   it('single opening intervals work as expected', () => {
@@ -83,7 +97,8 @@ describe('testing the opening times handling', () => {
     expect(
       isOpenWithFakeTimeDateTime([
         {
-          open: false
+          open: false,
+          weekday
         }
       ])
     ).toEqual({ open: false });
@@ -91,7 +106,8 @@ describe('testing the opening times handling', () => {
     expect(
       isOpenWithFakeTimeDateTime([
         {
-          open: true
+          open: true,
+          weekday
         }
       ])
     ).toEqual({ open: true });
@@ -236,7 +252,7 @@ describe('testing the opening times handling', () => {
     ).toEqual({ open: false, timeDiff: 120 });
   });
 
-  it.only('currently open, with random entry without time and weekday', () => {
+  it('currently open, with random entry without time and weekday', () => {
     expect(
       isOpenWithFakeTimeDateTime([
         {

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -5,4 +5,5 @@ import { setUpTests } from 'react-native-reanimated/lib/reanimated2/jestUtils';
 
 jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 jest.mock('@viro-community/react-viro', () => ({ ViroMaterials: {} }));
+jest.mock('expo-linking', () => ({ createURL: jest.fn() }));
 setUpTests();

--- a/src/components/screens/OpeningTimesCard.js
+++ b/src/components/screens/OpeningTimesCard.js
@@ -4,7 +4,7 @@ import { View, StyleSheet } from 'react-native';
 import styled from 'styled-components/native';
 
 import { normalize, colors } from '../../config';
-import { momentFormat } from '../../helpers';
+import { TMB_YEAR_TO_PARSE, momentFormat } from '../../helpers';
 import { BoldText, RegularText } from '../Text';
 import { Wrapper, WrapperRow } from '../Wrapper';
 
@@ -27,7 +27,13 @@ export const OpeningTimesCard = ({ openingHours }) => (
     {!!openingHours &&
       openingHours.map((item, index) => {
         const { weekday, timeFrom, timeTo, dateFrom, dateTo, description, open } = item;
-        const returnFormatDate = 'DD.MM.YYYY';
+        // if `dateFrom` and `dateTo` are from year that should be parsed, set flag to true
+        const withoutYear =
+          dateFrom &&
+          dateTo &&
+          dateFrom.includes(TMB_YEAR_TO_PARSE) &&
+          dateTo.includes(TMB_YEAR_TO_PARSE);
+        const returnFormatDate = withoutYear ? 'DD.MM' : 'DD.MM.YYYY';
 
         return (
           <View key={index} style={index !== openingHours.length - 1 ? styles.divider : null}>

--- a/src/helpers/openingHoursHelper.ts
+++ b/src/helpers/openingHoursHelper.ts
@@ -47,12 +47,39 @@ const dateIsWithinInterval = (date: Date, start?: Date, end?: Date) => {
   return true;
 };
 
-const isOpeningTimeForDate = (info: OpeningHour, date: Date) =>
-  dateIsWithinInterval(
+export const TMB_YEAR_TO_PARSE = '1970';
+
+export const dateWithCorrectYear = (dateString?: string) => {
+  if (!dateString) {
+    return new Date();
+  }
+
+  if (dateString.startsWith(TMB_YEAR_TO_PARSE)) {
+    const currentYear = new Date().getFullYear();
+    const newDateString = dateString.replace(/^(\d{4})/, currentYear.toString());
+
+    return new Date(newDateString);
+  }
+
+  return new Date(dateString);
+};
+
+const isOpeningTimeForDate = (info: OpeningHour, date: Date) => {
+  const dateFrom = dateWithCorrectYear(info.dateFrom);
+  const dateTo = dateWithCorrectYear(info.dateTo);
+
+  // if `dateFrom` is after `dateTo`, increase the year of `dateTo` by one so that ranges
+  // like 01.10. - 01.04. result in 01.10.2021 - 01.04.2022 instead of 01.10.2021 - 01.04.2021
+  if (info.dateFrom && info.dateTo && dateFrom > dateTo) {
+    dateTo.setFullYear(dateTo.getFullYear() + 1);
+  }
+
+  return dateIsWithinInterval(
     date,
-    info.dateFrom ? moment(new Date(info.dateFrom)).startOf('day').toDate() : undefined,
-    info.dateTo ? moment(new Date(info.dateTo)).endOf('day').toDate() : undefined
+    info.dateFrom ? moment(dateFrom).startOf('day').toDate() : undefined,
+    info.dateTo ? moment(dateTo).endOf('day').toDate() : undefined
   );
+};
 
 const getTodayWithTime = (time: string) => {
   return moment(time, 'HH:mm').toDate();


### PR DESCRIPTION
In the future, TMB pois will have adjusted dates for specific cases, being returned from the main server with year 1970. This way we can identify them to adjust checking opening time and rendering.

|before|after|
|---|---|
|![Simulator Screen Shot - iPhone 12 - 2023-07-03 at 17 20 55](https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/2ef71428-5466-4953-81b5-70adb3dd61f1)|![Simulator Screen Shot - iPhone 12 - 2023-07-03 at 17 18 41](https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/2f49e93b-2780-44be-8c5d-a01bef4bf0b3)|

In order to test with the POI Eiscafé "Zur Postmeile" you need to set the `TMB_YEAR_TO_PARSE` to 2020.

SVA-985