### PR TITLE
fix: a space error between two inputs

### DIFF
--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -351,6 +351,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
               keyboardShouldPersistTaps: 'handled',
               renderItem: inputValueCitySelected ? null : renderSuggestionCities
             }}
+            hideResults={inputValueCitySelected}
             listStyle={styles.autoCompleteList}
             onChangeText={(text) => {
               setInputValueCitySelected(false);


### PR DESCRIPTION
- added not to show the results if `inputValueCitySelected` is `true` to the city `Autocomplete` component to solve the problem of the space between the two inputs that occurs if there are more suggestions related to the selected city name after a place is selected from the city input

SVA-833

## How to test:
* [x] Android
* [x] iOS

|Android before|Android after|Android before|Android after|
|--|--|--|--|
![Screenshot_20230704-112858](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/25b7eac5-4bf2-4ef4-8918-d8e3988fc7b6) | ![Screenshot_20230704-112802](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/7fb0a369-3131-43c3-afe6-de8bb538ac17) | ![Screenshot_20230704-112903](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/2754ee28-7e62-41c5-ac8b-9b102cd571a9) | ![Screenshot_20230704-112808](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/55976f72-0aa5-4829-b844-12ad7b3a4988)



|iOS before|iOS after|iOS before|iOS after|
|--|--|--|--|
![IMG_4106](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/4aa6ac21-9f0d-4b94-a4c9-59ad596e0cd1) | ![IMG_4108](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/65a6b62b-7541-40ae-8048-793266cf3d1d) | ![IMG_4107](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/6c214102-dcff-4501-aeaa-f0f11861b33b) | ![IMG_4109](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/b5f02af8-abbf-42f4-a3c9-7e1011d3a5ae)


