### PR TITLE
fix: android crash

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -6,22 +6,22 @@
     "production": {
       "node": "16.13.0",
       "yarn": "1.22.19",
-      "releaseChannel": "production"
+      "channel": "production"
     },
     "preview": {
       "extends": "production",
-      "releaseChannel": "preview",
+      "channel": "preview",
       "distribution": "internal"
     },
     "development": {
       "extends": "production",
-      "releaseChannel": "development",
+      "channel": "development",
       "distribution": "internal",
       "developmentClient": true
     },
     "development-simulator": {
       "extends": "production",
-      "releaseChannel": "development",
+      "channel": "development",
       "distribution": "internal",
       "developmentClient": true,
       "ios": {


### PR DESCRIPTION
- updated `releaseChannel` in `eas.json` to `channel` so that the `expo-updates` package can work

SVA-1091

even if we don't use the `expo-updates` package, it needs to be configured to prevent the application from crashing on android.
in order for the expo-updates package to work with eas, the `releaseChannel` in `eas.json` had to be replaced with `channel`.
expo doc.: https://docs.expo.dev/build/updates/
expo doc.: https://docs.expo.dev/eas-update/eas-cli/?redirected

**channel**: The channel is a name we can give to multiple builds to identify them easily. [Learn more](https://docs.expo.dev/eas-update/how-it-works/?redirected)
This field only applies to the EAS Update service, if your project still uses Classic Updates then use the [releaseChannel](https://docs.expo.dev/build-reference/eas-json/#releasechannel) field instead.

**releaseChannel**: Name of the release channel for the expo-updates package. [Learn more](https://docs.expo.dev/archive/classic-updates/release-channels/)
If you do not specify a channel, your binary will pull releases from the default channel. If you do not use expo-updates in your project then this property will have no effect.
This field only applies to the Classic Update service; if you use EAS Update, use the [channel](https://docs.expo.dev/build-reference/eas-json/#channel) field instead.

after this update, the following line needs to be added to `app.json` when creating a build for the application.
```
"updates": { "url": "https://u.expo.dev/projectId" }
```