### PR TITLE
fix: optimise augmented reality

### DIFF
--- a/src/components/augmentedReality/AugmentedRealityView.js
+++ b/src/components/augmentedReality/AugmentedRealityView.js
@@ -15,8 +15,10 @@ import {
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect } from 'react';
 
-import { colors, texts } from '../../config';
+import { colors, consts, device, texts } from '../../config';
 import { SettingsContext } from '../../SettingsProvider';
+
+const { GB_TO_BYTES } = consts;
 
 export const AugmentedRealityView = ({ sceneNavigator }) => {
   const {
@@ -100,6 +102,8 @@ const ViroSoundAnd3DObject = (item) => {
     });
   }
 
+  const isMore2GBRam = device.totalMemory > GB_TO_BYTES[2];
+
   return (
     <>
       {!isObjectLoading && (
@@ -164,7 +168,7 @@ const ViroSoundAnd3DObject = (item) => {
           />
         ))}
 
-      {object?.spot && (
+      {object?.spot && isMore2GBRam && (
         <ViroSpotLight
           direction={object.spot.direction}
           innerAngle={object.spot.innerAngle}
@@ -179,7 +183,7 @@ const ViroSoundAnd3DObject = (item) => {
         />
       )}
 
-      {object?.quad && (
+      {object?.quad && isMore2GBRam && (
         <ViroQuad
           height={object.quad.height}
           position={object.quad.position}

--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -102,6 +102,13 @@ export const consts = {
     FULL_SCREEN_MAX_WIDTH: 428
   },
 
+  // this section has been added to optimise AR on low RAM devices and to prevent some features of AR from being used
+  GB_TO_BYTES: {
+    1: 1073741824,
+    2: 2147483648,
+    3: 3221225472
+  },
+
   // the image aspect ratio can be overwritten by a global setting `imageAspectRatio`
   // from the server in src/index.js
   IMAGE_ASPECT_RATIO: {

--- a/src/config/device.js
+++ b/src/config/device.js
@@ -1,7 +1,9 @@
 import { Dimensions, Platform } from 'react-native';
+import { totalMemory } from 'expo-device';
 
 export const device = {
   height: Dimensions.get('window').height,
   platform: Platform.OS,
+  totalMemory,
   width: Dimensions.get('window').width
 };


### PR DESCRIPTION
- added `totalMemory` value to `device.js` to see the `RAM` information of the device and used `totalMemory` in `expo-device` package
- added `GB_TO_BYTES` section to `consts.js` because the `totalMemory` property gives us RAM in bytes and therefore we need to know gb in bytes
- removed `spot` and `quad` (shadow) to optimise AR for devices with less than 2 gb of RAM

SVA-1073

|iPhone 7 (shadowless and spotless)|iPhone 13 Pro Max (shaded and spotlighted)|
|--|--|
<img width="288" alt="AugmentedReality_1690986499031" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/e099793d-526f-4017-9c50-27354d33306e"> | ![AugmentedReality_1690986693770](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/c2a6f678-834b-4028-ac54-fba178d69870)

