### PR TITLE
feat(opening times): respect `useYear` instead of 1970-hack

### DIFF
--- a/__tests__/helpers/openingHoursHelper.test.ts
+++ b/__tests__/helpers/openingHoursHelper.test.ts
@@ -1,4 +1,4 @@
-import { TMB_YEAR_TO_PARSE, dateWithCorrectYear, getReadableDay, isOpen } from '../../src/helpers';
+import { dateWithCorrectYear, getReadableDay, isOpen } from '../../src/helpers';
 import { OpeningHour } from '../../src/types';
 
 const FAKE_NOW_DATE = new Date();
@@ -14,15 +14,13 @@ const isOpenWithFakeTimeDateTime = (openingHours: OpeningHour[]) =>
 
 describe('testing correct year for date for TMB data', () => {
   it('not adjusted year for a date in 2022', () => {
-    expect(dateWithCorrectYear('2022-05-19')).toEqual(new Date('2022-05-19'));
+    expect(dateWithCorrectYear('2022-05-19', true)).toEqual(new Date('2022-05-19'));
   });
 
   it('adjusted year for a date in the year that should be parsed', () => {
     const currentYear = FAKE_NOW_DATE.getFullYear();
 
-    expect(dateWithCorrectYear(`${TMB_YEAR_TO_PARSE}-03-09`)).toEqual(
-      new Date(`${currentYear}-03-09`)
-    );
+    expect(dateWithCorrectYear('2020-03-09', false)).toEqual(new Date(`${currentYear}-03-09`));
   });
 });
 

--- a/src/components/screens/OpeningTimesCard.js
+++ b/src/components/screens/OpeningTimesCard.js
@@ -4,7 +4,7 @@ import { View, StyleSheet } from 'react-native';
 import styled from 'styled-components/native';
 
 import { normalize, colors } from '../../config';
-import { TMB_YEAR_TO_PARSE, momentFormat } from '../../helpers';
+import { momentFormat } from '../../helpers';
 import { BoldText, RegularText } from '../Text';
 import { Wrapper, WrapperRow } from '../Wrapper';
 
@@ -26,14 +26,17 @@ export const OpeningTimesCard = ({ openingHours }) => (
   <Wrapper>
     {!!openingHours &&
       openingHours.map((item, index) => {
-        const { weekday, timeFrom, timeTo, dateFrom, dateTo, description, open } = item;
-        // if `dateFrom` and `dateTo` are from year that should be parsed, set flag to true
-        const withoutYear =
-          dateFrom &&
-          dateTo &&
-          dateFrom.includes(TMB_YEAR_TO_PARSE) &&
-          dateTo.includes(TMB_YEAR_TO_PARSE);
-        const returnFormatDate = withoutYear ? 'DD.MM' : 'DD.MM.YYYY';
+        const {
+          weekday,
+          timeFrom,
+          timeTo,
+          dateFrom,
+          dateTo,
+          description,
+          open,
+          useYear = false
+        } = item;
+        const returnFormatDate = useYear ? 'DD.MM.YYYY' : 'DD.MM';
 
         return (
           <View key={index} style={index !== openingHours.length - 1 ? styles.divider : null}>

--- a/src/helpers/openingHoursHelper.ts
+++ b/src/helpers/openingHoursHelper.ts
@@ -47,26 +47,24 @@ const dateIsWithinInterval = (date: Date, start?: Date, end?: Date) => {
   return true;
 };
 
-export const TMB_YEAR_TO_PARSE = '1970';
-
-export const dateWithCorrectYear = (dateString?: string) => {
+export const dateWithCorrectYear = (dateString?: string, useYear?: boolean) => {
   if (!dateString) {
     return new Date();
   }
 
-  if (dateString.startsWith(TMB_YEAR_TO_PARSE)) {
-    const currentYear = new Date().getFullYear();
-    const newDateString = dateString.replace(/^(\d{4})/, currentYear.toString());
-
-    return new Date(newDateString);
+  if (useYear) {
+    return new Date(dateString);
   }
 
-  return new Date(dateString);
+  const currentYear = new Date().getFullYear();
+  const newDateString = dateString.replace(/^(\d{4})/, currentYear.toString());
+
+  return new Date(newDateString);
 };
 
 const isOpeningTimeForDate = (info: OpeningHour, date: Date) => {
-  const dateFrom = dateWithCorrectYear(info.dateFrom);
-  const dateTo = dateWithCorrectYear(info.dateTo);
+  const dateFrom = dateWithCorrectYear(info.dateFrom, info.useYear ?? false);
+  const dateTo = dateWithCorrectYear(info.dateTo, info.useYear ?? false);
 
   // if `dateFrom` is after `dateTo`, increase the year of `dateTo` by one so that ranges
   // like 01.10. - 01.04. result in 01.10.2021 - 01.04.2022 instead of 01.10.2021 - 01.04.2021

--- a/src/queries/pointsOfInterest.js
+++ b/src/queries/pointsOfInterest.js
@@ -75,6 +75,7 @@ export const GET_POINTS_OF_INTEREST = gql`
         open
         dateFrom
         dateTo
+        useYear
       }
       webUrls {
         id
@@ -165,6 +166,7 @@ export const GET_POINT_OF_INTEREST = gql`
         dateFrom
         dateTo
         description
+        useYear
       }
       operatingCompany {
         id

--- a/src/types/OpeningHour.ts
+++ b/src/types/OpeningHour.ts
@@ -4,5 +4,6 @@ export type OpeningHour = {
   open: boolean | null;
   timeFrom?: string;
   timeTo?: string;
+  useYear: boolean | null;
   weekday?: 'Sonntag' | 'Montag' | 'Dienstag' | 'Mittwoch' | 'Donnerstag' | 'Freitag' | 'Samstag';
 };


### PR DESCRIPTION
the main server removed the 1970-hack and introduced a `useYear` flag, that we will be able to use in order to render without the year if false

SVA-985

| `useYear = true`| `useYear = false`|
|---|---|
| ![image](https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/fe81a658-ccdf-49fd-8d57-44f57a224ccc) | ![image](https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/41e98d63-5cf5-4aa9-9c44-128086ec4679) |