### PR TITLE
refactor: reduce auth refreshs

### DIFF
--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useState } from 'react';
 import { Query } from 'react-apollo';
 import { ActivityIndicator, RefreshControl, ScrollView } from 'react-native';
 
-import { auth } from '../auth';
 import {
   EventRecord,
   LoadingContainer,
@@ -92,10 +91,6 @@ export const DetailScreen = ({ navigation, route }) => {
   if (!query || !queryVariables || !queryVariables.id) return null;
 
   const refreshTime = useRefreshTime(`${query}-${queryVariables.id}`, getRefreshInterval(query));
-
-  useEffect(() => {
-    isConnected && auth();
-  }, []);
 
   useRootRouteByCategory(details, navigation);
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { FlatList, RefreshControl } from 'react-native';
 
-import { auth } from '../auth';
 import {
   About,
   ConnectedImagesCarousel,
@@ -204,10 +203,6 @@ export const HomeScreen = ({ navigation, route }) => {
   );
 
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.HOME);
-
-  useEffect(() => {
-    isConnected && auth();
-  }, []);
 
   const refresh = () => {
     setRefreshing(true);

--- a/src/screens/HtmlScreen.js
+++ b/src/screens/HtmlScreen.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { RefreshControl, ScrollView } from 'react-native';
 
-import { auth } from '../auth';
 import {
   EmptyMessage,
   HtmlView,
@@ -35,10 +34,6 @@ export const HtmlScreen = ({ navigation, route }) => {
     type: 'html',
     refreshTimeKey: `${query}-${queryVariables.name}`
   });
-
-  useEffect(() => {
-    isConnected && auth();
-  }, []);
 
   // NOTE: we cannot use the `useMatomoTrackScreenView` hook here, as we need the `title` dependency
   useEffect(() => {

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -7,7 +7,6 @@ import { Query, useQuery } from 'react-apollo';
 import { ActivityIndicator, RefreshControl, View } from 'react-native';
 import { Divider } from 'react-native-elements';
 
-import { auth } from '../auth';
 import {
   Button,
   Calendar,
@@ -267,10 +266,6 @@ export const IndexScreen = ({ navigation, route }) => {
   if (showMap || showCalendar || sortByDistance || filterByOpeningTimes) {
     delete queryVariables.limit;
   }
-
-  useEffect(() => {
-    isConnected && auth();
-  }, []);
 
   useEffect(() => {
     // we want to ensure when changing from one index screen to another, for example from


### PR DESCRIPTION
- reduced `auth()` refreshs by calling the `auth()` function when the app returns to the foreground from the background or from the inactive `AppState` by checking the apps `AppState` globally through `App.js`
- `auth()` function is already being called at every app start from the closed state in `src/index.js`
- removed now unnecessary and before insufficient `auth()` calls and related imports from `DetailsScreen.js`, `HomeScreen.js`, `HtmlScreen.js`, `IndexScreen.js`

SBB-91