### PR TITLE
fix: event list showing only 15 events

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -53,7 +53,7 @@ const renderItem = ({ item }) => {
       params: {
         title,
         query: QUERY_TYPES.EVENT_RECORDS,
-        queryVariables: { limit: 15, order: 'listDate_ASC' },
+        queryVariables: { order: 'listDate_ASC' },
         rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS
       }
     },


### PR DESCRIPTION
- removed the limit value in `queryVariables` to fix the issue of not showing more than 15 events in the event list

SVA-1114

---
the `useIsFocused()` hook in `IndexScreen` was causing the query on the event page to constantly re-run, and since the limit value was set to 15 in `queryVariables`, no more than 15 events could be listed in the list. To fix this issue, `{ limit: 15, ... }` in `HomeScreen` has been removed.

this is a temporary code update for now. A more detailed code update may need to be investigated.