### PR TITLE
feat: add query variables that can be set from the server for the event

### DIFF
--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -27,8 +27,9 @@ export const EventWidget = ({ text, additionalProps }: WidgetProps) => {
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
 
-  const queryVariables: { dateRange?: string[]; order: string } = {
+  const queryVariables: { dateRange?: string[]; limit?: number; order: string } = {
     dateRange: [currentDate, currentDate],
+    limit: additionalProps?.limit || 15,
     order: 'listDate_ASC'
   };
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -171,7 +171,7 @@ export const HomeScreen = ({ navigation, route }) => {
     buttonEvents = texts.homeButtons.events,
     limitEvents = 15,
     limitNews = 15,
-    limitPOI = 15
+    limitPointsOfInterestAndTours = 15
   } = sections;
   const { events: showVolunteerEvents = false } = hdvt;
   const [refreshing, setRefreshing] = useState(false);
@@ -240,7 +240,7 @@ export const HomeScreen = ({ navigation, route }) => {
     {
       buttonTitle: buttonPointsOfInterestAndTours,
       fetchPolicy,
-      limit: limitPOI,
+      limit: limitPointsOfInterestAndTours,
       navigate: 'CATEGORIES_INDEX',
       navigation,
       query: QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS,

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -29,6 +29,7 @@ const renderItem = ({ item }) => {
     buttonTitle,
     categoriesNews,
     fetchPolicy,
+    limit,
     navigate,
     navigation,
     query,
@@ -53,7 +54,7 @@ const renderItem = ({ item }) => {
       params: {
         title,
         query: QUERY_TYPES.EVENT_RECORDS,
-        queryVariables: { limit: 15, order: 'listDate_ASC' },
+        queryVariables: { limit, order: 'listDate_ASC' },
         rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS
       }
     },
@@ -64,7 +65,7 @@ const renderItem = ({ item }) => {
       indexCategoryIds,
       rootRouteName = ROOT_ROUTE_NAMES.NEWS_ITEMS
     }) => {
-      const queryVariables = { limit: 15 };
+      const queryVariables = { limit };
 
       if (indexCategoryIds?.length) {
         queryVariables.categoryIds = indexCategoryIds;
@@ -167,7 +168,10 @@ export const HomeScreen = ({ navigation, route }) => {
     headlinePointsOfInterestAndTours = texts.homeTitles.pointsOfInterest,
     buttonPointsOfInterestAndTours = texts.homeButtons.pointsOfInterest,
     headlineEvents = texts.homeTitles.events,
-    buttonEvents = texts.homeButtons.events
+    buttonEvents = texts.homeButtons.events,
+    limitEvents = 15,
+    limitNews = 15,
+    limitPOI = 15
   } = sections;
   const { events: showVolunteerEvents = false } = hdvt;
   const [refreshing, setRefreshing] = useState(false);
@@ -227,6 +231,7 @@ export const HomeScreen = ({ navigation, route }) => {
     {
       categoriesNews,
       fetchPolicy,
+      limit: limitNews,
       navigation,
       query: QUERY_TYPES.NEWS_ITEMS,
       queryVariables: { limit: 3, excludeDataProviderIds },
@@ -235,6 +240,7 @@ export const HomeScreen = ({ navigation, route }) => {
     {
       buttonTitle: buttonPointsOfInterestAndTours,
       fetchPolicy,
+      limit: limitPOI,
       navigate: 'CATEGORIES_INDEX',
       navigation,
       query: QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS,
@@ -245,6 +251,7 @@ export const HomeScreen = ({ navigation, route }) => {
     {
       buttonTitle: buttonEvents,
       fetchPolicy,
+      limit: limitEvents,
       navigate: 'EVENT_RECORDS_INDEX',
       navigation,
       query: QUERY_TYPES.EVENT_RECORDS,

--- a/src/types/WidgetProps.ts
+++ b/src/types/WidgetProps.ts
@@ -7,5 +7,6 @@ export type WidgetProps = {
     noFilterByDailyEvents?: boolean;
     staticContentName?: string;
     staticContentTitle?: string;
+    limit?: number;
   };
 };

--- a/src/types/WidgetProps.ts
+++ b/src/types/WidgetProps.ts
@@ -1,12 +1,12 @@
 export type WidgetProps = {
-  text?: string;
   additionalProps?: {
     dataProviderId?: string;
     iconName?: string;
+    limit?: number;
     noCount?: boolean;
     noFilterByDailyEvents?: boolean;
     staticContentName?: string;
     staticContentTitle?: string;
-    limit?: number;
   };
+  text?: string;
 };


### PR DESCRIPTION
- added editing the `queryVariables` `limit` in `IndexScreen` for all sections shown in `HomeScreen` via `globalSettings`
- added default limit value of all sections as 15
- added `queryVariables` limit when going to the event screen via widget
- added default limit value as 15 on the event screen navigated using widget
- added `limit` to `WidgetProps` to prevent type error

SVA-1119

---

make the following adjustments to the `globalSettings` to try the feature.

the `queryVariables` required to go to the Event screen with the "Alle Veranstaltungen anzeigen" button on the `HomeScreen`
```
"sections": {
    ...
    "limitEvents": 20,
    "limitNews": 20,
    "limitPOI": 20
    ...
  },
```

to go to the Event screen with the widget `queryVariables`
```
{
  "widgetName": "event",
  "additionalProps": {
   ...
    "limit": 20
    ...
  }
},
```