### PR TITLE
refactor: ability to switch navigation through server config

### DIFF
--- a/src/SettingsProvider.js
+++ b/src/SettingsProvider.js
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types';
-import React, { createContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 
 export const SettingsContext = createContext({
   globalSettings: {
     filter: {},
+    hdvt: {},
+    navigation: {},
     sections: {},
     settings: {},
     widgets: [],
-    hdvt: {}
   }
 });
 

--- a/src/config/navigation/config.ts
+++ b/src/config/navigation/config.ts
@@ -1,52 +1,64 @@
 import * as Linking from 'expo-linking';
+import { useContext } from 'react';
 
+import { SettingsContext } from '../../SettingsProvider';
 import { NavigatorConfig, ScreenName } from '../../types';
 
-// import { tabNavigatorConfig } from './tabConfig';
+import { tabNavigatorConfig } from './tabConfig';
 
-// export const navigatorConfig: NavigatorConfig = {
-//   type: 'tab',
-//   config: tabNavigatorConfig
-// };
+let navigatorConfig: NavigatorConfig;
+let linkingConfig: any;
 
-// const index = 2;
+const { globalSettings } = useContext(SettingsContext);
 
-// export const linkingConfig = {
-//   prefixes: [Linking.createURL('/')],
-//   config: {
-//     screens: {
-//       // For tab navigation choose the preferred tab by its position in the config array
-//       [`Stack${index}`]: {
-//         // The initialRouteName has to be the initial route of the chosen stack
-//         // (Home for drawer navigation, and whatever is specified in the tab config for tab navigation)
-//         initialRouteName: navigatorConfig.config.tabConfigs[index].stackConfig.initialRouteName,
-//         screens: {
-//           [ScreenName.EncounterUserDetail]: 'encounter',
-//           [ScreenName.Home]: '*'
-//         }
-//       }
-//     }
-//   }
-// };
+if (globalSettings.navigation != 'drawer') {
+  const index = 2;
 
-export const navigatorConfig: NavigatorConfig = {
-  type: 'drawer'
-};
+  navigatorConfig = {
+    type: 'tab',
+    config: tabNavigatorConfig
+  };
 
-export const linkingConfig = {
-  prefixes: [Linking.createURL('/')],
-  config: {
-    screens: {
-      // For tab navigation choose the preferred tab by its position in the config array: AppStack -> `Stack${index}`
-      AppStack: {
-        // The initialRouteName has to be the initial route of the chosen stack
-        // (Home for drawer navigation, and whatever is specified in the tab config for tab navigation)
-        initialRouteName: ScreenName.Home,
-        screens: {
-          [ScreenName.EncounterUserDetail]: 'encounter',
-          [ScreenName.Home]: '*'
+  linkingConfig = {
+    prefixes: [Linking.createURL('/')],
+    config: {
+      screens: {
+        // For tab navigation choose the preferred tab by its position in the config array
+        [`Stack${index}`]: {
+          // The initialRouteName has to be the initial route of the chosen stack
+          // (Home for drawer navigation, and whatever is specified in the tab config for tab navigation)
+          initialRouteName: navigatorConfig.config.tabConfigs[index].stackConfig.initialRouteName,
+          screens: {
+            [ScreenName.EncounterUserDetail]: 'encounter',
+            [ScreenName.Home]: '*'
+          }
         }
       }
     }
-  }
-};
+  };
+} else {
+  navigatorConfig = {
+    type: 'drawer'
+  };
+
+  linkingConfig = {
+    prefixes: [Linking.createURL('/')],
+    config: {
+      screens: {
+        // For tab navigation choose the preferred tab by its position in the config array: AppStack -> `Stack${index}`
+        AppStack: {
+          // The initialRouteName has to be the initial route of the chosen stack
+          // (Home for drawer navigation, and whatever is specified in the tab config for tab navigation)
+          initialRouteName: ScreenName.Home,
+          screens: {
+            [ScreenName.EncounterUserDetail]: 'encounter',
+            [ScreenName.Home]: '*'
+          }
+        }
+      }
+    }
+  };
+}
+
+export { linkingConfig, navigatorConfig };
+

--- a/src/config/navigation/config.ts
+++ b/src/config/navigation/config.ts
@@ -1,3 +1,4 @@
+import { LinkingOptions } from '@react-navigation/native';
 import * as Linking from 'expo-linking';
 import { useContext } from 'react';
 
@@ -7,7 +8,13 @@ import { NavigatorConfig, ScreenName } from '../../types';
 import { tabNavigatorConfig } from './tabConfig';
 
 let navigatorConfig: NavigatorConfig;
-let linkingConfig: any;
+const linkingConfig: LinkingOptions = {
+  prefixes: [Linking.createURL('/')]
+};
+const screens = {
+  [ScreenName.EncounterUserDetail]: 'encounter',
+  [ScreenName.Home]: '*'
+};
 
 const { globalSettings } = useContext(SettingsContext);
 
@@ -19,20 +26,14 @@ if (globalSettings.navigation != 'drawer') {
     config: tabNavigatorConfig
   };
 
-  linkingConfig = {
-    prefixes: [Linking.createURL('/')],
-    config: {
-      screens: {
-        // For tab navigation choose the preferred tab by its position in the config array
-        [`Stack${index}`]: {
-          // The initialRouteName has to be the initial route of the chosen stack
-          // (Home for drawer navigation, and whatever is specified in the tab config for tab navigation)
-          initialRouteName: navigatorConfig.config.tabConfigs[index].stackConfig.initialRouteName,
-          screens: {
-            [ScreenName.EncounterUserDetail]: 'encounter',
-            [ScreenName.Home]: '*'
-          }
-        }
+  linkingConfig.config = {
+    screens: {
+      // For tab navigation choose the preferred tab by its position in the config array
+      [`Stack${index}`]: {
+        // The initialRouteName has to be the initial route of the chosen stack:
+        // whatever is specified in the tab config for tab navigation
+        initialRouteName: navigatorConfig.config.tabConfigs[index].stackConfig.initialRouteName,
+        screens
       }
     }
   };
@@ -41,24 +42,16 @@ if (globalSettings.navigation != 'drawer') {
     type: 'drawer'
   };
 
-  linkingConfig = {
-    prefixes: [Linking.createURL('/')],
-    config: {
-      screens: {
-        // For tab navigation choose the preferred tab by its position in the config array: AppStack -> `Stack${index}`
-        AppStack: {
-          // The initialRouteName has to be the initial route of the chosen stack
-          // (Home for drawer navigation, and whatever is specified in the tab config for tab navigation)
-          initialRouteName: ScreenName.Home,
-          screens: {
-            [ScreenName.EncounterUserDetail]: 'encounter',
-            [ScreenName.Home]: '*'
-          }
-        }
+  linkingConfig.config = {
+    screens: {
+      AppStack: {
+        // The initialRouteName has to be the initial route of the chosen stack:
+        // Home for drawer navigation
+        initialRouteName: ScreenName.Home,
+        screens
       }
     }
   };
 }
 
 export { linkingConfig, navigatorConfig };
-


### PR DESCRIPTION
- added the logic to switch the navigation type between drawer and tabbar through the server config
- added `navigation: {}` to `SettingsProvider.js` to extract the navigation type from the server config
- added `useSettingsContext` to `SettingsProvider.js` to get the navigation type in `config.ts`

SVA-1117


**Add additional information for testing, if required**
- if you want to quickly switch between the tab and drawer navigation without editing the server config file edit in `src/config/navigation/config.ts`, line 14, `!= "drawer"` to the desired option