### PR TITLE
feat: add setting to show or hide filter by opening times

### DIFF
--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -105,7 +105,10 @@ export const IndexScreen = ({ navigation, route }) => {
     eventLocations: showEventLocationsFilter = false
   } = filter;
   const { events: showVolunteerEvents = false } = hdvt;
-  const { calendarToggle = false } = settings;
+  const {
+    calendarToggle = false,
+    showFilterByOpeningTimes = true
+  } = settings;
   const {
     categoryListIntroText = texts.categoryList.intro,
     categoryListFooter,
@@ -359,6 +362,13 @@ export const IndexScreen = ({ navigation, route }) => {
             onToggle={() => setFilterByOpeningTimes((value) => !value)}
             value={filterByOpeningTimes}
           />
+          {showFilterByOpeningTimes && (
+            <OptionToggle
+              label={texts.pointOfInterest.filterByOpeningTime}
+              onToggle={() => setFilterByOpeningTimes((value) => !value)}
+              value={filterByOpeningTimes}
+            />
+          )}
           <Divider />
         </View>
       )}


### PR DESCRIPTION
There is a new global setting that allows hiding the filter for opening times, which results in an index screen without that:

![Simulator Screen Shot - iPhone 12 - 2023-08-17 at 10 40 58](https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/6ee4eaba-0e13-4293-964c-5a5c88af50ae)

SVA-1127