### PR TITLE
feat: add ability for a factor to size tiles

### DIFF
--- a/src/components/screens/Service.tsx
+++ b/src/components/screens/Service.tsx
@@ -29,10 +29,11 @@ export const Service = ({
   hasDiagonalGradientBackground?: boolean;
 }) => {
   const { globalSettings } = useContext(SettingsContext);
-  const isPersonalizable = globalSettings?.settings?.personalizedTiles || false;
+  const { settings = {} } = globalSettings;
+  const { personalizedTiles = false, tileSizeFactor = 1 } = settings;
   const navigation = useNavigation<StackNavigationProp<any>>();
   const { isLoading, tiles, onDragEnd, onToggleVisibility } = usePersonalizedTiles(
-    isPersonalizable,
+    personalizedTiles,
     data,
     isEditMode,
     staticJsonName
@@ -54,17 +55,18 @@ export const Service = ({
   const renderItem = useCallback(
     (item: TServiceTile, index: number) => (
       <ServiceTile
-        key={index + (item.title || item.accessibilityLabel)}
-        item={item}
-        isEditMode={isEditMode}
         draggableId={item.title || item.accessibilityLabel}
-        onToggleVisibility={onToggleVisibility}
         hasDiagonalGradientBackground={hasDiagonalGradientBackground}
+        isEditMode={isEditMode}
+        item={item}
+        key={index + (item.title || item.accessibilityLabel)}
+        onToggleVisibility={onToggleVisibility}
+        tileSizeFactor={tileSizeFactor}
       />
     ),
     [isEditMode, hasDiagonalGradientBackground]
   );
-  const toggler = globalSettings?.settings?.personalizedTiles && (
+  const toggler = personalizedTiles && (
     <View style={styles.toggler}>
       <TouchableOpacity onPress={onPress}>
         <RegularText lightest={hasDiagonalGradientBackground} center small underline>

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -15,30 +15,33 @@ export type TServiceTile = {
   icon: string;
   iconName?: ComponentProps<typeof IconSet>['name'];
   image: string;
+  isVisible?: boolean;
   params?: any;
   routeName: string;
   tile?: string;
+  tileSizeFactor?: number;
   title: string;
-  isVisible?: boolean;
 };
 
 /* eslint-disable complexity */
 export const ServiceTile = ({
-  item,
-  isEditMode = false,
   draggableId,
+  hasDiagonalGradientBackground = false,
+  isEditMode = false,
+  item,
   onToggleVisibility,
-  hasDiagonalGradientBackground = false
+  tileSizeFactor = 1
 }: {
-  item: TServiceTile;
-  isEditMode?: boolean;
   draggableId: string;
+  hasDiagonalGradientBackground?: boolean;
+  isEditMode?: boolean;
+  item: TServiceTile;
   onToggleVisibility: (
     toggleableId: string,
     isVisible: boolean,
     setIsVisible: (isVisible: boolean) => void
   ) => void;
-  hasDiagonalGradientBackground?: boolean;
+  tileSizeFactor?: number;
 }) => {
   const navigation = useNavigation<StackNavigationProp<any>>();
   const { orientation, dimensions } = useContext(OrientationContext);
@@ -83,7 +86,12 @@ export const ServiceTile = ({
               source={{ uri: item.icon || item.tile }}
               style={[
                 styles.serviceImage,
-                !!item.tile && stylesWithProps({ orientation, safeAreaInsets }).bigTile
+                !!item.tile &&
+                  stylesWithProps({
+                    tileSizeFactor,
+                    orientation,
+                    safeAreaInsets
+                  }).bigTile
               ]}
               PlaceholderContent={null}
               resizeMode="contain"
@@ -136,9 +144,11 @@ const styles = StyleSheet.create({
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
 const stylesWithProps = ({
+  tileSizeFactor = 1,
   orientation,
   safeAreaInsets
 }: {
+  tileSizeFactor?: number;
   orientation: string;
   safeAreaInsets: EdgeInsets;
 }) => {
@@ -153,7 +163,7 @@ const stylesWithProps = ({
 
   return StyleSheet.create({
     bigTile: {
-      height: tileSize,
+      height: tileSize * tileSizeFactor,
       marginBottom: 0,
       width: tileSize
     }


### PR DESCRIPTION
- if tiles are not 1:1 aspect ratio, we can now have a factor to properly size them
- `tileSizeFactor` can be set through `settings` in global settings

|without factor|with factor|
|---|---|
|<img width="376" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/b073f7d4-e917-4d3a-bc89-115644615ea0">|<img width="376" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/22dd57d2-d43d-4fb4-b68d-0b1603a17356">|

MQGB-27