### PR TITLE
fix: prevent the open only switcher from being duplicated

### DIFF
--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -357,11 +357,6 @@ export const IndexScreen = ({ navigation, route }) => {
       {query === QUERY_TYPES.POINTS_OF_INTEREST && (
         <View>
           <IndexFilterWrapperAndList filter={topFilter} setFilter={setTopFilter} />
-          <OptionToggle
-            label={texts.pointOfInterest.filterByOpeningTime}
-            onToggle={() => setFilterByOpeningTimes((value) => !value)}
-            value={filterByOpeningTimes}
-          />
           {showFilterByOpeningTimes && (
             <OptionToggle
               label={texts.pointOfInterest.filterByOpeningTime}


### PR DESCRIPTION
- deleted the component that is not shown according to the `showFilterByOpeningTimes` control to fix the problem of the switcher appearing twice after `showFilterByOpeningTimes` is set to `true` in `globalSettings`

SVA-1127

## Screenshots:

|before - showFilterByOpeningTimes:true|after - showFilterByOpeningTimes: true|before - showFilterByOpeningTimes: false|after - showFilterByOpeningTimes: false|
|--|--|--|--|
![Simulator Screenshot - iPhone 14 - 2023-08-21 at 15 22 25](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/12b4bb15-23de-4b36-b725-604155859156) | ![Simulator Screenshot - iPhone 14 - 2023-08-21 at 15 22 31](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/03b1f15d-d212-4999-a9c8-e93314b123bc) | ![Simulator Screenshot - iPhone 14 - 2023-08-21 at 15 22 31](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/d0888df1-28bc-4bb5-87f2-37ae3d9cd361) | ![Simulator Screenshot - iPhone 14 - 2023-08-21 at 15 24 13](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/7c373261-b9eb-40f7-a3b5-906f1b2ddfa0)
