### PR TITLE
refactor: change navigation structure

### DIFF
--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -255,7 +255,12 @@ export const defaultStackConfig = ({
     },
     {
       routeName: ScreenName.Index,
-      screenComponent: IndexScreen
+      screenComponent: IndexScreen,
+      // NOTE: is used as initial screen for the points of interest tab
+      inititalParams: {
+        title: texts.screenTitles.pointsOfInterest,
+        query: QUERY_TYPES.CATEGORIES
+      }
     },
     {
       routeName: ScreenName.Lunch,

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -71,6 +71,7 @@ import {
 import { ScreenName, StackConfig } from '../../types';
 import { consts } from '../consts';
 import { texts } from '../texts';
+import { QUERY_TYPES } from '../../queries';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -229,6 +230,15 @@ export const defaultStackConfig = ({
           />
         )
       })
+    },
+    {
+      routeName: ScreenName.Events,
+      screenComponent: IndexScreen,
+      inititalParams: {
+        title: texts.screenTitles.events,
+        query: QUERY_TYPES.EVENT_RECORDS,
+        queryVariables: { limit: 15, order: 'listDate_ASC' }
+      }
     },
     {
       routeName: ScreenName.Form,

--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -42,25 +42,6 @@ const serviceTabConfig: TabConfig = {
   }
 };
 
-const companyTabConfig: TabConfig = {
-  stackConfig: defaultStackConfig({
-    initialRouteName: ScreenName.Company,
-    isDrawer: false
-  }),
-  tabOptions: {
-    tabBarLabel: texts.tabBarLabel.company,
-    tabBarIcon: ({ color }: TabBarIconProps) => (
-      <OrientationAwareIcon
-        color={color}
-        Icon={Icon.Company}
-        landscapeStyle={{ marginRight: -normalize(4), marginTop: 0 }}
-        size={normalize(26)}
-        style={{ marginTop: normalize(3) }}
-      />
-    )
-  }
-};
-
 const aboutTabConfig: TabConfig = {
   stackConfig: defaultStackConfig({
     initialRouteName: ScreenName.About,
@@ -85,5 +66,5 @@ export const tabNavigatorConfig: TabNavigatorConfig = {
   inactiveTintColor: colors.primary,
   activeBackgroundColor: colors.surface,
   inactiveBackgroundColor: colors.surface,
-  tabConfigs: [homeTabConfig, serviceTabConfig, companyTabConfig, aboutTabConfig]
+  tabConfigs: [homeTabConfig, serviceTabConfig, aboutTabConfig]
 };

--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -54,6 +54,20 @@ const pointOfInterestTabConfig: TabConfig = {
     )
   }
 };
+
+const eventsTabConfig: TabConfig = {
+  stackConfig: defaultStackConfig({
+    initialRouteName: ScreenName.Events,
+    isDrawer: false
+  }),
+  tabOptions: {
+    tabBarLabel: texts.tabBarLabel.events,
+    tabBarIcon: ({ color }: TabBarIconProps) => (
+      <OrientationAwareIcon color={color} Icon={Icon.Calendar} size={normalize(24)} />
+    )
+  }
+};
+
 const aboutTabConfig: TabConfig = {
   stackConfig: defaultStackConfig({
     initialRouteName: ScreenName.About,
@@ -78,5 +92,11 @@ export const tabNavigatorConfig: TabNavigatorConfig = {
   inactiveTintColor: colors.primary,
   activeBackgroundColor: colors.surface,
   inactiveBackgroundColor: colors.surface,
-  tabConfigs: [homeTabConfig, serviceTabConfig, pointOfInterestTabConfig, aboutTabConfig]
+  tabConfigs: [
+    homeTabConfig,
+    serviceTabConfig,
+    pointOfInterestTabConfig,
+    eventsTabConfig,
+    aboutTabConfig
+  ]
 };

--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -42,6 +42,18 @@ const serviceTabConfig: TabConfig = {
   }
 };
 
+const pointOfInterestTabConfig: TabConfig = {
+  stackConfig: defaultStackConfig({
+    initialRouteName: ScreenName.Index,
+    isDrawer: false
+  }),
+  tabOptions: {
+    tabBarLabel: texts.tabBarLabel.pointsOfInterest,
+    tabBarIcon: ({ color }: TabBarIconProps) => (
+      <OrientationAwareIcon color={color} Icon={Icon.Location} size={normalize(30)} />
+    )
+  }
+};
 const aboutTabConfig: TabConfig = {
   stackConfig: defaultStackConfig({
     initialRouteName: ScreenName.About,
@@ -66,5 +78,5 @@ export const tabNavigatorConfig: TabNavigatorConfig = {
   inactiveTintColor: colors.primary,
   activeBackgroundColor: colors.surface,
   inactiveBackgroundColor: colors.surface,
-  tabConfigs: [homeTabConfig, serviceTabConfig, aboutTabConfig]
+  tabConfigs: [homeTabConfig, serviceTabConfig, pointOfInterestTabConfig, aboutTabConfig]
 };

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -943,13 +943,13 @@ export const texts = {
     }
   },
   tabBarLabel: {
+    about: 'Mehr',
+    company: 'Unternehmen',
     events: 'Events',
     home: 'Übersicht',
     pointsOfInterest: 'POI',
     service: 'Service',
-    company: 'Unternehmen',
-    volunteer: 'Ehrenamt',
-    about: 'Mehr'
+    volunteer: 'Ehrenamt'
   },
   tour: {
     description: 'Beschreibung',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -789,6 +789,7 @@ export const texts = {
     home: appJson.expo.name,
     mapView: 'Kartenansicht',
     routePlanner: 'Routenplaner bbnavi',
+    pointsOfInterest: 'Orte und Touren',
     service: appJson.expo.name,
     settings: 'Einstellungen',
     survey: 'Umfrage',
@@ -942,6 +943,7 @@ export const texts = {
   },
   tabBarLabel: {
     home: 'Übersicht',
+    pointsOfInterest: 'POI',
     service: 'Service',
     company: 'Unternehmen',
     volunteer: 'Ehrenamt',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -785,6 +785,7 @@ export const texts = {
       home: 'Consul'
     },
     encounterHome: 'Mitfahrbank',
+    events: 'Veranstaltungen',
     feedback: 'Feedback',
     home: appJson.expo.name,
     mapView: 'Kartenansicht',
@@ -942,6 +943,7 @@ export const texts = {
     }
   },
   tabBarLabel: {
+    events: 'Events',
     home: 'Übersicht',
     pointsOfInterest: 'POI',
     service: 'Service',

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -30,6 +30,7 @@ export enum ScreenName {
   EncounterRegistration = 'EncounterRegistration',
   EncounterScanner = 'EncounterScanner',
   EncounterUserDetail = 'EncounterUserDetail',
+  Events = 'Events',
   Feedback = 'Feedback',
   Form = 'Form',
   Home = 'Home',


### PR DESCRIPTION
- deleted `companyTabConfig` tab navigation as we don't need it
- added `pointOfInterest` screen as the 3rd tab because we want to see it in tab navigation
- added `EventScreen` as the 4rd tab because we want to see it in tab navigation
- updated `texts.js` to show the title and tab name of `EventScreen` and `pointsOfInterest` screens
- sorted `tabBarLabel` alphabetically to improve readability

SVA-1116

to try this feature, please update the codes in `config.ts` according to the tab navigation structure
## Screenshots:

|before|after|POI Screen|EventScreen|
|--|--|--|--|
![Simulator Screenshot - iPhone 14 - 2023-08-23 at 12 46 59](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/344eee3c-5785-4928-bdd6-2bfd5f7a350a) | ![Simulator Screenshot - iPhone 14 - 2023-08-23 at 12 41 07](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/fcb761a3-c3a1-4c34-8125-08b986a6d114) | ![Simulator Screenshot - iPhone 14 - 2023-08-23 at 12 41 11](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/4a72a87d-5073-4d49-97a1-d9aee5a06608) | ![Simulator Screenshot - iPhone 14 - 2023-08-23 at 12 41 14](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/e6a61c80-e810-4357-be82-e81c72ff711b)
