### PR TITLE
feature: add poi preview in full screen map

### DIFF
--- a/src/components/HeaderLeft.tsx
+++ b/src/components/HeaderLeft.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { colors, consts, Icon, normalize } from '../config';
 
-export const HeaderLeft = ({ onPress }: StackHeaderLeftButtonProps) =>
+export const HeaderLeft = ({ onPress, backImage }: StackHeaderLeftButtonProps) =>
   onPress ? (
     <View>
       <TouchableOpacity
@@ -12,7 +12,7 @@ export const HeaderLeft = ({ onPress }: StackHeaderLeftButtonProps) =>
         accessibilityLabel={consts.a11yLabel.backIcon}
         accessibilityHint={consts.a11yLabel.backIconHint}
       >
-        <Icon.ArrowLeft color={colors.lightestText} style={styles.icon} />
+        {backImage ? backImage : <Icon.ArrowLeft color={colors.lightestText} style={styles.icon} />}
       </TouchableOpacity>
     </View>
   ) : null;

--- a/src/components/POIMapView.tsx
+++ b/src/components/POIMapView.tsx
@@ -1,0 +1,72 @@
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+
+import { colors, device, normalize } from '../config';
+import { QUERY_TYPES } from '../queries';
+import { ScreenName } from '../types';
+
+import { Image } from './Image';
+import { RegularText } from './Text';
+import { Wrapper } from './Wrapper';
+
+type Props = {
+  details: any;
+  id: string;
+  images?: { sourceUrl: { url: string } }[];
+  query: string;
+  title: string;
+};
+
+export const POIMapView = ({ item }: { item: Props }) => {
+  const { title, images, details, id } = item;
+  const navigation = useNavigation();
+
+  return (
+    <View style={{ width: device.width }}>
+      <Wrapper>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate(ScreenName.Detail, {
+              details: { ...details, title },
+              query: QUERY_TYPES.POINT_OF_INTEREST,
+              queryVariables: { id }
+            })
+          }
+          style={styles.container}
+        >
+          {!!images && images.length > 0 && (
+            <View>
+              <Image
+                source={{ uri: images[0]?.sourceUrl.url }}
+                borderRadius={normalize(12)}
+                containerStyle={{ width: normalize(96), height: normalize(96) }}
+              />
+            </View>
+          )}
+          <View style={styles.textContainer}>
+            <RegularText numberOfLines={3}>{title}</RegularText>
+          </View>
+        </TouchableOpacity>
+      </Wrapper>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    backgroundColor: colors.lighterPrimary,
+    borderRadius: normalize(12),
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    width: '100%'
+  },
+  textContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: normalize(16),
+    height: normalize(96)
+  }
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -68,6 +68,7 @@ export * from './NewsSectionPlaceholder';
 export * from './Offer';
 export * from './OptionToggle';
 export * from './OrientationAwareIcon';
+export * from './POIMapView';
 export * from './PreviewSection';
 export * from './Radiobutton';
 export * from './Results';

--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -29,6 +29,7 @@ type Props = {
     dataProvider?: string;
   };
   route: RouteProp<any, never>;
+  showPOIsFullScreenMap?: boolean;
 };
 
 // FIXME: with our current setup the data that we receive from a query is not typed
@@ -63,7 +64,8 @@ export const LocationOverview = ({
   filterByOpeningTimes,
   navigation,
   queryVariables,
-  route
+  route,
+  showPOIsFullScreenMap
 }: Props) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const [selectedPointOfInterest, setSelectedPointOfInterest] = useState<string>();

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useRef } from 'react';
-import { StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { FlatList, StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
 import MapView, { LatLng, MAP_TYPES, Marker, Polyline, Region, UrlTile } from 'react-native-maps';
 import { SvgXml } from 'react-native-svg';
 
@@ -7,6 +7,7 @@ import { colors, device, Icon, normalize } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
 import { SettingsContext } from '../../SettingsProvider';
 import { MapMarker } from '../../types';
+import { POIMapView } from '../POIMapView';
 
 type Props = {
   geometryTourData?: LatLng[];
@@ -18,6 +19,7 @@ type Props = {
   onMapPress?: () => void;
   onMarkerPress?: (arg0?: string) => void;
   onMaximizeButtonPress?: () => void;
+  showPOIsFullScreenMap?: boolean;
   showsUserLocation?: boolean;
   style?: StyleProp<ViewStyle>;
 };
@@ -26,7 +28,7 @@ const MARKER_ICON_SIZE = normalize(40);
 
 export const Map = ({
   geometryTourData,
-  isMaximizeButtonVisible,
+  isMaximizeButtonVisible = false,
   isMultipleMarkersMap = false,
   locations,
   mapCenterPosition,
@@ -34,6 +36,7 @@ export const Map = ({
   onMapPress,
   onMarkerPress,
   onMaximizeButtonPress,
+  showPOIsFullScreenMap,
   style,
   ...otherProps
 }: Props) => {
@@ -41,12 +44,16 @@ export const Map = ({
   const { settings = {} } = globalSettings;
   const { zoomLevelForMaps = {}, locationService = {} } = settings;
 
+  // state to keep track of the currently active marker
+  const [activeMarker, setActiveMarker] = useState(null);
+
   const showsUserLocation = otherProps.showsUserLocation ?? !!locationService;
   const zoom = isMultipleMarkersMap
     ? zoomLevelForMaps.multipleMarkers
     : zoomLevelForMaps.singleMarker;
 
   const refForMapView = useRef<MapView>(null);
+  const flatListRef = useRef<FlatList>(null);
   // LATITUDE_DELTA handles the zoom, see: https://github.com/react-native-maps/react-native-maps/issues/2129#issuecomment-457056572
   const LATITUDE_DELTA = zoom || 0.0922;
   // example for longitude delta: https://github.com/react-native-maps/react-native-maps/blob/0.30.x/example/examples/DisplayLatLng.js#L18
@@ -73,6 +80,37 @@ export const Map = ({
       longitude: locations[0].position.longitude
     };
   }
+
+  // ref function to handle changes in the viewable items of the FlatList
+  // it sets the activeMarker state to the ID of the first viewable item
+  const onViewableItemsChanged = useRef(({ viewableItems }) => {
+    const firstViewableItem = viewableItems[0]?.item;
+    if (firstViewableItem) {
+      setActiveMarker(firstViewableItem.id);
+    }
+  }).current;
+
+  // useEffect to handle changes in activeMarker
+  // it animates the map to focus on the coordinates of the active marker
+  useEffect(() => {
+    if (activeMarker && refForMapView.current) {
+      const marker = locations?.find((loc) => loc.id === activeMarker);
+
+      if (marker) {
+        const { latitude, longitude } = marker.position;
+
+        refForMapView.current.animateToRegion(
+          {
+            latitude,
+            longitude,
+            latitudeDelta: LATITUDE_DELTA,
+            longitudeDelta: LONGITUDE_DELTA
+          },
+          500
+        );
+      }
+    }
+  }, [activeMarker]);
 
   return (
     <View style={[styles.container, style]}>
@@ -120,6 +158,14 @@ export const Map = ({
             onPress={() => {
               if (onMarkerPress) {
                 onMarkerPress(marker.id);
+
+                // find the index of the clicked marker in the locations array
+                const index = locations?.findIndex((loc) => loc.id === marker.id);
+
+                // if the index is found and is valid, scroll the FlatList to that index
+                if (index && index !== -1) {
+                  flatListRef.current?.scrollToIndex({ index, animated: true });
+                }
               }
             }}
           >
@@ -127,10 +173,37 @@ export const Map = ({
           </Marker>
         ))}
       </MapView>
+
       {isMaximizeButtonVisible && (
         <TouchableOpacity style={styles.maximizeMapButton} onPress={onMaximizeButtonPress}>
           <Icon.ExpandMap size={normalize(18)} />
         </TouchableOpacity>
+      )}
+
+      {showPOIsFullScreenMap && (
+        <FlatList
+          data={locations}
+          getItemLayout={(data, index) => ({
+            length: device.width,
+            offset: device.width * index,
+            index
+          })}
+          horizontal
+          keyExtractor={(item) => item.id}
+          onScrollToIndexFailed={(info) => {
+            const wait = new Promise((resolve) => setTimeout(resolve, 500));
+            wait.then(() => {
+              flatListRef.current?.scrollToIndex({ index: info.index, animated: true });
+            });
+          }}
+          onViewableItemsChanged={onViewableItemsChanged}
+          pagingEnabled
+          ref={flatListRef}
+          renderItem={({ item }) => <POIMapView item={item} />}
+          showsHorizontalScrollIndicator={false}
+          snapToAlignment="center"
+          style={styles.poiList}
+        />
       )}
     </View>
   );
@@ -139,7 +212,7 @@ export const Map = ({
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
-    backgroundColor: colors.lightestText,
+    backgroundColor: colors.surface,
     flex: 1,
     justifyContent: 'center'
   },
@@ -155,6 +228,10 @@ const styles = StyleSheet.create({
     right: normalize(15),
     width: normalize(48),
     zIndex: 1
+  },
+  poiList: {
+    position: 'absolute',
+    bottom: 0
   }
 });
 

--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -2,7 +2,7 @@ import { useIsFocused } from '@react-navigation/native';
 import _sortBy from 'lodash/sortBy';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useLayoutEffect, useState } from 'react';
 import { Query, useQuery } from 'react-apollo';
 import { ActivityIndicator, RefreshControl, View } from 'react-native';
 import { Divider } from 'react-native-elements';
@@ -15,6 +15,7 @@ import {
   CategoryList,
   DropdownHeader,
   EmptyMessage,
+  HeaderLeft,
   IndexFilterWrapperAndList,
   IndexMapSwitch,
   ListComponent,
@@ -25,7 +26,7 @@ import {
   SafeAreaViewFlex,
   Wrapper
 } from '../components';
-import { colors, consts, texts } from '../config';
+import { colors, consts, Icon, normalize, texts } from '../config';
 import {
   graphqlFetchPolicy,
   isOpen,
@@ -108,6 +109,7 @@ export const IndexScreen = ({ navigation, route }) => {
   const {
     calendarToggle = false,
     showFilterByOpeningTimes = true,
+    showPOIsFullScreenMap = false,
     switchBetweenListAndMap = SWITCH_BETWEEN_LIST_AND_MAP.TOP_FILTER
   } = settings;
   const {
@@ -367,6 +369,40 @@ export const IndexScreen = ({ navigation, route }) => {
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
 
+  useLayoutEffect(() => {
+    if (query === QUERY_TYPES.POINTS_OF_INTEREST && showMap) {
+      navigation.setOptions({
+        headerLeft: () => (
+          <HeaderLeft
+            onPress={() => {
+              const selectedFilter = filterType.find((entry) => entry.selected);
+              const updatedFilter = filterType.map((entry) => {
+                if (entry.id !== selectedFilter.id) {
+                  entry.selected = true;
+                } else {
+                  entry.selected = false;
+                }
+                return entry;
+              });
+
+              setFilterType(updatedFilter);
+            }}
+            backImage={
+              <Icon.Close
+                color={colors.lightestText}
+                style={{ paddingHorizontal: normalize(14) }}
+              />
+            }
+          />
+        )
+      });
+    } else {
+      navigation.setOptions({
+        headerLeft: () => <HeaderLeft onPress={() => navigation.goBack()} />
+      });
+    }
+  }, [query, showMap]);
+
   return (
     <SafeAreaViewFlex>
       {query === QUERY_TYPES.POINTS_OF_INTEREST &&
@@ -396,6 +432,7 @@ export const IndexScreen = ({ navigation, route }) => {
             ...queryVariables,
             limit: undefined
           }}
+          showPOIsFullScreenMap={showPOIsFullScreenMap}
         />
       ) : (
         <Query
@@ -616,9 +653,10 @@ export const IndexScreen = ({ navigation, route }) => {
           }}
         </Query>
       )}
-      {query === QUERY_TYPES.POINTS_OF_INTEREST && (
-        <IndexMapSwitch filter={filterType} setFilter={setFilterType} />
-      )}
+      {query === QUERY_TYPES.POINTS_OF_INTEREST &&
+        filterType.find((i) => i.selected && i.title === 'Listenansicht') && (
+          <IndexMapSwitch filter={filterType} setFilter={setFilterType} />
+        )}
     </SafeAreaViewFlex>
   );
 };


### PR DESCRIPTION
- added `zoomLevelForMaps` and `locationService` from settings to the `Map` component for configurable zoom and location features
- introduced `activeMarker` state to keep track of the currently selected map marker
- added `onViewableItemsChanged` ref function to update `activeMarker` based on viewable items in a `FlatList`
- updated `useEffect` to animate map focus based on the `activeMarker`
- extended marker `onPress` to scroll the `FlatList` to the clicked marker
- included a `FlatList` to display points of interest when `showPOIsFullScreenMap` is true
- created a new `POIMapView` component to display points of interest in a `FlatList`
- included image and text display within a touchable area
- added navigation to detail screen on touch
- extended the `mapToMapMarkers` function to include images, title, and details in the returned object for better map marker information
- added `showPOIsFullScreenMap` prop to the `Map` component to conditionally adjust map height
- introduced `stylesWithProps` function to dynamically set map height based on `navigationType`
- added `selectedPointOfInterest` state to manage selected points of interest
- added `showPOIsFullScreenMap` to `settings` object with default value as false
- added `useLayoutEffect` to conditionally set `headerLeft` based on query and `showMap`
- added close icon as `backImage` when query is points of interest and `showMap` is true
- passed `showPOIsFullScreenMap` prop to `LocationOverview` component
- modified condition for rendering `IndexMapSwitch` based on selected `filterType`
- added the `showPOIsFullScreenMap` prop to the `LocationOverview` component to allow control over the display of POIs on a full screen map
- added `backImage` prop to `HeaderLeft` component
- modified the `TouchableOpacity` to conditionally render `backImage` or default `Icon.ArrowLeft`

MQGB-34

To make this feature available, add the following code to the `settings` section in `globalSettings` on the main server.

```
"showPOIsFullScreenMap": true
```
## Screenshots:

### Drawer navigation:
|list|map|map|
|--|--|--|
![Simulator Screenshot - iPhone 14 Pro - 2023-08-28 at 17 47 53](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/9d591355-85c4-4d14-a23f-ff6ffe7733e2) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-28 at 17 47 57](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/7bd91ad5-f65b-49e3-9c33-a67274982331) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-28 at 17 48 06](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/28d17ffe-9eeb-4575-b30b-120f4e75f59c)

### Tab navigation:
|list|map|map|
|--|--|--|
![Simulator Screenshot - iPhone 14 Pro - 2023-08-28 at 17 48 54](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/c34e8aea-d758-4d9e-892f-760fdf87298e) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-28 at 17 48 58](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/37ab7a02-a941-4de0-a820-01cfe1287991) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-28 at 17 49 05](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/e396e100-753e-4efc-97ae-69321ab2eda3)
