### PR TITLE
feat: add dynamic intro content for points of interest list

### DIFF
--- a/src/screens/IndexScreen.js
+++ b/src/screens/IndexScreen.js
@@ -15,6 +15,7 @@ import {
   CategoryList,
   DropdownHeader,
   EmptyMessage,
+  HtmlView,
   IndexFilterWrapperAndList,
   ListComponent,
   LoadingContainer,
@@ -37,6 +38,7 @@ import {
   useOpenWebScreen,
   usePermanentFilter,
   usePosition,
+  useStaticContent,
   useTrackScreenViewAsync,
   useVolunteerData
 } from '../hooks';
@@ -105,15 +107,13 @@ export const IndexScreen = ({ navigation, route }) => {
     eventLocations: showEventLocationsFilter = false
   } = filter;
   const { events: showVolunteerEvents = false } = hdvt;
-  const {
-    calendarToggle = false,
-    showFilterByOpeningTimes = true
-  } = settings;
+  const { calendarToggle = false, showFilterByOpeningTimes = true } = settings;
   const {
     categoryListIntroText = texts.categoryList.intro,
     categoryListFooter,
     categoryTitles,
-    eventListIntro
+    eventListIntro,
+    poiListIntro
   } = sections;
   const [queryVariables, setQueryVariables] = useState(route.params?.queryVariables ?? {});
   const [showCalendar, setShowCalendar] = useState(false);
@@ -145,6 +145,15 @@ export const IndexScreen = ({ navigation, route }) => {
       [QUERY_TYPES.EVENT_RECORDS]: showEventsFilter,
       [QUERY_TYPES.NEWS_ITEMS]: showNewsFilter
     }[query];
+  const htmlContentName =
+    query === QUERY_TYPES.POINTS_OF_INTEREST && poiListIntro?.[queryVariables.category];
+
+  const { data: htmlContent } = useStaticContent({
+    name: htmlContentName,
+    type: 'html',
+    refreshTimeKey: `${query}-${queryVariables.category}`,
+    skip: !htmlContentName
+  });
 
   const openWebScreenUrl = eventListIntro?.url || categoryListFooter?.url;
   const openWebScreen = useOpenWebScreen(title, openWebScreenUrl);
@@ -526,6 +535,11 @@ export const IndexScreen = ({ navigation, route }) => {
                       {query === QUERY_TYPES.CATEGORIES && !!categoryListIntroText && (
                         <Wrapper>
                           <RegularText>{categoryListIntroText}</RegularText>
+                        </Wrapper>
+                      )}
+                      {!!htmlContent && (
+                        <Wrapper>
+                          <HtmlView html={htmlContent} />
                         </Wrapper>
                       )}
                     </>


### PR DESCRIPTION
- added `poiListIntro` to the destructured `sections` object to fetch intro text for points of interest
- introduced `htmlContentName` and `htmlContent` to fetch and display HTML content conditionally for points of interest
- modified `ListComponent` to include the new HTML content as a header when displaying points of interest

to be able to try this feature, please edit the `sections` section in `globalSettings` as follows.

```
"poiListIntro": {
  "Bildung": "noticeboardMainContent"
},
```

the key in the object of `poiListIntro` must belong to a category. In this way, if you go to the correct poi category screen, the html content here will be automatically displayed above the poi list. then you should create the htmlContent that we named here on the main server.

SBB-110

## Screenshots:

|bildung category with html|burgen category without html|
|--|--|
![Simulator Screenshot - iPhone 14 - 2023-08-31 at 12 52 42](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/efcf3a45-c78b-4025-bb09-be831c105e17) | ![image](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/7115f816-364b-4493-b1e7-8a598ec2ffc1)