### PR TITLE
refactor:  additional changes for react navigation 6.x

### DIFF
--- a/src/navigation/AppStackNavigator.tsx
+++ b/src/navigation/AppStackNavigator.tsx
@@ -5,19 +5,20 @@ import { StackConfig } from '../types';
 
 const Stack = createStackNavigator<Record<string, { title: string } | undefined>>();
 
-export const getStackNavigator = (stackConfig: StackConfig) => () => (
-  <Stack.Navigator
-    initialRouteName={stackConfig.initialRouteName}
-    screenOptions={stackConfig.screenOptions}
-  >
-    {stackConfig.screenConfigs.map((screenConfig) => (
-      <Stack.Screen
-        key={screenConfig.routeName}
-        name={screenConfig.routeName}
-        component={screenConfig.screenComponent}
-        options={screenConfig.screenOptions}
-        initialParams={screenConfig.inititalParams}
-      />
-    ))}
-  </Stack.Navigator>
-);
+export const getStackNavigator = (stackConfig: StackConfig) => () =>
+  (
+    <Stack.Navigator
+      initialRouteName={stackConfig.initialRouteName}
+      screenOptions={stackConfig.screenOptions}
+    >
+      {stackConfig.screenConfigs.map((screenConfig) => (
+        <Stack.Screen
+          key={screenConfig.routeName}
+          name={screenConfig.routeName}
+          component={screenConfig.screenComponent}
+          options={screenConfig.screenOptions}
+          initialParams={screenConfig.inititalParams}
+        />
+      ))}
+    </Stack.Navigator>
+  );

--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -1,14 +1,14 @@
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import _isEmpty from 'lodash/isEmpty';
 import _reduce from 'lodash/reduce';
-import React, { useEffect, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { device, texts } from '../config';
 import { defaultStackConfig } from '../config/navigation';
 import { useStaticContent } from '../hooks';
 import { ScreenName } from '../types';
+import { OrientationContext } from '../OrientationProvider';
 
 import { getStackNavigator } from './AppStackNavigator';
 import { CustomDrawerContentComponent } from './CustomDrawerContentComponent';
@@ -83,6 +83,7 @@ const Drawer = createDrawerNavigator();
 
 export const DrawerNavigator = () => {
   const { loading, drawerRoutes } = useDrawerRoutes();
+  const { orientation } = useContext(OrientationContext);
 
   if (loading) return <LoadingSpinner loading />;
 
@@ -96,20 +97,15 @@ export const DrawerNavigator = () => {
         />
       )}
       screenOptions={{
-        drawerPosition:"right",
+        drawerPosition: 'right',
+        drawerStyle: {
+          width: orientation === 'landscape' ? device.height * 0.8 : device.width * 0.8
+        },
         headerShown: false
       }}
-      drawerStyle={styles.drawerContainer}
-      drawerType={device.platform === 'ios' ? 'slide' : 'front'}
       initialRouteName="AppStack"
     >
       <Drawer.Screen name="AppStack" component={AppStackNavigator} />
     </Drawer.Navigator>
   );
 };
-
-const styles = StyleSheet.create({
-  drawerContainer: {
-    width: device.width > device.height ? device.height * 0.8 : device.width * 0.8
-  }
-});


### PR DESCRIPTION
- moved styles to `drawerStyle` inside `screenOptions` of the Drawer in `DrawerNavigator.tsx`
  and refactored with orientation provider
- removed `drawerType` of the Drawer in `DrawerNavigator.tsx`,
  since the default for iOS is now set to `slide` and to `front` for other plattforms:
  https://reactnavigation.org/docs/drawer-navigator/#drawertype
- linted `AppStackNavigator.tsx`

SVA-1130