### PR TITLE
refactor(map icons): use from `Icon` to be flexible

### DIFF
--- a/src/components/Disturber.tsx
+++ b/src/components/Disturber.tsx
@@ -63,7 +63,7 @@ export const Disturber = ({ navigation, publicJsonFile }: Props) => {
       try {
         const disturberComplete = await readFromStore(publicJsonFile);
 
-        if (closestItem?.id.toString() !== disturberComplete) {
+        if (closestItem?.id && closestItem.id.toString() !== disturberComplete) {
           setIsVisible(true);
         }
       } catch (e) {

--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -3,18 +3,17 @@ import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { useQuery } from 'react-apollo';
 
-import { colors, consts, texts } from '../../config';
-import { checkDownloadedData, navigationToArtworksDetailScreen } from '../../helpers';
-import { location, locationIconAnchor } from '../../icons';
-import { getQuery, QUERY_TYPES } from '../../queries';
 import { SettingsContext } from '../../SettingsProvider';
+import { consts, texts } from '../../config';
+import { checkDownloadedData, navigationToArtworksDetailScreen } from '../../helpers';
+import { QUERY_TYPES, getQuery } from '../../queries';
 import { ScreenName } from '../../types';
 import { Button } from '../Button';
 import { IndexFilterWrapperAndList } from '../IndexFilterWrapperAndList';
 import { LoadingSpinner } from '../LoadingSpinner';
-import { Map } from '../map';
-import { Wrapper } from '../Wrapper';
 import { SectionHeader } from '../SectionHeader';
+import { Wrapper } from '../Wrapper';
+import { Map } from '../map';
 
 import { ARModal } from './ARModal';
 import { ARObjectList } from './ARObjectList';
@@ -173,8 +172,6 @@ const mapToMapMarkers = (data) =>
       if (!latitude || !longitude) return undefined;
 
       return {
-        icon: location(colors.primary),
-        iconAnchor: locationIconAnchor,
         id: item.id.toString(),
         position: {
           latitude,

--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -9,8 +9,6 @@ import { NetworkContext } from '../../NetworkProvider';
 import { SettingsContext } from '../../SettingsProvider';
 import { Icon, colors, normalize, texts } from '../../config';
 import { graphqlFetchPolicy, isOpen, parseListItemsFromQuery } from '../../helpers';
-import * as Icons from '../../icons';
-import { location, locationIconAnchor } from '../../icons';
 import { QUERY_TYPES, getQuery } from '../../queries';
 import { MapMarker } from '../../types';
 import { LoadingContainer } from '../LoadingContainer';
@@ -46,25 +44,8 @@ const mapToMapMarkers = (pointsOfInterest: any): MapMarker[] | undefined => {
 
         if (!latitude || !longitude) return undefined;
 
-        let icon = location;
-
-        if (item.category?.iconName) {
-          // remove location and locationIconAnchor from Icons for proper type perspective to all
-          // the other icons
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { location: _l, locationIconAnchor: _lia, ...OtherIcons } = Icons;
-          const iconName = item.category.iconName as keyof typeof OtherIcons;
-
-          // only use the icon if it is available from our icons
-          if (Object.keys(OtherIcons).includes(iconName)) {
-            icon = OtherIcons[iconName] as (color: any) => string;
-          }
-        }
-
         return {
-          icon: icon(colors.primary),
-          activeIcon: icon(colors.accent),
-          iconAnchor: locationIconAnchor,
+          iconName: item.category.iconName,
           id: item.id,
           position: {
             latitude,

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useRef, useState } from 'react';
+import _upperFirst from 'lodash/upperFirst';
+import React, { useContext, useRef } from 'react';
 import { StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
 import MapView, { LatLng, MAP_TYPES, Marker, Polyline, Region, UrlTile } from 'react-native-maps';
-import { SvgXml } from 'react-native-svg';
 
 import { colors, device, Icon, normalize } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
@@ -15,7 +15,7 @@ type Props = {
   locations?: MapMarker[];
   mapCenterPosition?: { latitude: number; longitude: number };
   mapStyle?: StyleProp<ViewStyle>;
-  onMapPress?: () => void;
+  onMapPress?: ({ nativeEvent }: { nativeEvent?: any }) => void;
   onMarkerPress?: (arg0?: string) => void;
   onMaximizeButtonPress?: () => void;
   selectedMarker?: string;
@@ -24,6 +24,18 @@ type Props = {
 };
 
 const MARKER_ICON_SIZE = normalize(40);
+
+const MapIcon = ({
+  iconColor,
+  iconName = 'location'
+}: {
+  iconColor?: string;
+  iconName?: string;
+}) => {
+  const MarkerIcon = Icon[_upperFirst(iconName) as keyof typeof Icon];
+
+  return <MarkerIcon color={iconColor} size={MARKER_ICON_SIZE} />;
+};
 
 export const Map = ({
   geometryTourData,
@@ -116,16 +128,16 @@ export const Map = ({
         )}
         {locations?.map((marker, index) => (
           <Marker
+            centerOffset={marker.iconAnchor || { x: 0, y: -(MARKER_ICON_SIZE / 2) }}
+            coordinate={marker.position}
             identifier={marker.id}
             key={`${index}-${marker.id}`}
-            coordinate={marker.position}
             onPress={() => onMarkerPress?.(marker.id)}
             zIndex={selectedMarker && marker.id === selectedMarker ? 1010 : 1}
           >
-            <SvgXml
-              xml={selectedMarker && marker.id === selectedMarker ? marker.activeIcon : marker.icon}
-              width={MARKER_ICON_SIZE}
-              height={MARKER_ICON_SIZE}
+            <MapIcon
+              iconColor={selectedMarker && marker.id === selectedMarker ? colors.accent : undefined}
+              iconName={marker.iconName ? marker.iconName : undefined}
             />
           </Marker>
         ))}

--- a/src/components/oParl/Location.tsx
+++ b/src/components/oParl/Location.tsx
@@ -2,8 +2,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { isString } from 'lodash';
 import React from 'react';
 
-import { colors, texts } from '../../config';
-import { location, locationIconAnchor } from '../../icons';
+import { texts } from '../../config';
 import { isFeature, isFeatureCollection, isMultiPoint, isPoint } from '../../jsonValidation';
 import { LocationData, MapMarker } from '../../types';
 import { Map } from '../map';
@@ -28,8 +27,6 @@ const getMapMarkers = (geoJson: unknown): MapMarker[] => {
   if (isPoint(geoJson) && geoJson.coordinates.length > 1) {
     return [
       {
-        icon: location(colors.primary),
-        iconAnchor: locationIconAnchor,
         position: {
           latitude: geoJson.coordinates[1],
           longitude: geoJson.coordinates[0]
@@ -42,8 +39,6 @@ const getMapMarkers = (geoJson: unknown): MapMarker[] => {
     return coordinates
       .filter((entry) => entry.length > 1)
       .map((entry) => ({
-        icon: location(colors.primary),
-        iconAnchor: locationIconAnchor,
         position: {
           latitude: entry[1],
           longitude: entry[0]

--- a/src/components/screens/AvailableVehicles.tsx
+++ b/src/components/screens/AvailableVehicles.tsx
@@ -50,7 +50,7 @@ export const AvailableVehicles = ({
     );
   }
 
-  const CategoryIcon = Icon[_upperFirst(iconName)];
+  const CategoryIcon = Icon[_upperFirst(iconName) as keyof typeof Icon];
 
   return (
     <>

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -3,10 +3,9 @@ import React, { useContext } from 'react';
 import { View } from 'react-native';
 
 import { NetworkContext } from '../../NetworkProvider';
-import { colors, consts, texts } from '../../config';
+import { consts, texts } from '../../config';
 import { matomoTrackingString } from '../../helpers';
 import { useMatomoTrackScreenView, useOpenWebScreen } from '../../hooks';
-import { location, locationIconAnchor } from '../../icons';
 import { Button } from '../Button';
 import { DataProviderButton } from '../DataProviderButton';
 import { DataProviderNotice } from '../DataProviderNotice';
@@ -144,8 +143,6 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
           <Map
             locations={[
               {
-                icon: location(colors.primary),
-                iconAnchor: locationIconAnchor,
                 position: { latitude, longitude }
               }
             ]}

--- a/src/components/screens/TimeTables.tsx
+++ b/src/components/screens/TimeTables.tsx
@@ -27,7 +27,7 @@ export const TimeTables = ({
   travelTimes: TimeTableProps[];
   iconName: keyof typeof Icon;
 }) => {
-  const CategoryIcon = Icon[_upperFirst(iconName)];
+  const CategoryIcon = Icon[_upperFirst(iconName) as keyof typeof Icon];
   const today: string | number = new Date().toISOString();
 
   return (

--- a/src/components/screens/consul/Proposals/ProposalDetail.js
+++ b/src/components/screens/consul/Proposals/ProposalDetail.js
@@ -8,7 +8,6 @@ import { colors, Icon, normalize, texts } from '../../../../config';
 import { ConsulClient } from '../../../../ConsulClient';
 import { getConsulUser } from '../../../../helpers';
 import { useOpenWebScreen } from '../../../../hooks';
-import { location, locationIconAnchor } from '../../../../icons';
 import { QUERY_TYPES } from '../../../../queries';
 import { ADD_COMMENT_TO_PROPOSAL, PUBLISH_PROPOSAL } from '../../../../queries/consul';
 import { ScreenName } from '../../../../types';
@@ -172,8 +171,6 @@ export const ProposalDetail = ({ data, refetch, route, navigation }) => {
           <Map
             locations={[
               {
-                icon: location(colors.primary),
-                iconAnchor: locationIconAnchor,
                 position: { latitude, longitude }
               }
             ]}

--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -3,10 +3,9 @@ import React, { useState } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 import Collapsible from 'react-native-collapsible';
 
-import { colors, normalize, texts } from '../../config';
+import { normalize, texts } from '../../config';
 import { geoLocationToLocationObject } from '../../helpers';
 import { useLocationSettings, useSystemPermission } from '../../hooks';
-import { ownLocation, ownLocationIconAnchor } from '../../icons';
 import { Button } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { Map } from '../map';
@@ -16,8 +15,7 @@ import { Touchable } from '../Touchable';
 import { Wrapper } from '../Wrapper';
 
 export const baseLocationMarker = {
-  icon: ownLocation(colors.accent),
-  iconAnchor: ownLocationIconAnchor
+  iconName: 'ownLocation'
 };
 
 export const getLocationMarker = (locationObject) => ({

--- a/src/config/Icon.tsx
+++ b/src/config/Icon.tsx
@@ -33,6 +33,7 @@ import {
   oParlCalendar,
   oParlOrganizations,
   oParlPeople,
+  ownLocation,
   pen,
   phone,
   routePlanner,
@@ -92,7 +93,7 @@ const NamedIcon = ({
   name,
   size = normalize(26),
   style
-}: IconProps & { name: ComponentProps<typeof IconSet>['name'] }) => {
+}: IconProps & { name?: ComponentProps<typeof IconSet>['name'] }) => {
   return (
     <View style={style} hitSlop={getHitSlops(size)}>
       <IconSet name={name} size={size} color={color} style={iconStyle} />
@@ -144,6 +145,7 @@ export const Icon = {
   OParlCalendar: (props: IconProps) => <SvgIcon xml={oParlCalendar} {...props} />,
   OParlOrganizations: (props: IconProps) => <SvgIcon xml={oParlOrganizations} {...props} />,
   OParlPeople: (props: IconProps) => <SvgIcon xml={oParlPeople} {...props} />,
+  OwnLocation: (props: IconProps) => <SvgIcon xml={ownLocation} {...props} />,
   Pause: (props: IconProps) => <NamedIcon name="pause" {...props} />,
   Pen: (props: IconProps) => <SvgIcon xml={pen} {...props} />,
   Phone: (props: IconProps) => <SvgIcon xml={phone} {...props} />,

--- a/src/icons/location.js
+++ b/src/icons/location.js
@@ -10,5 +10,3 @@ export const location = (color) => `
     </g>
   </svg>
 `;
-
-export const locationIconAnchor = { x: 9, y: 20 };

--- a/src/icons/ownLocation.js
+++ b/src/icons/ownLocation.js
@@ -7,5 +7,3 @@ export const ownLocation = (color) => `
       </g>
   </svg>
 `;
-
-export const ownLocationIconAnchor = { x: 6, y: 22 };

--- a/src/screens/ConstructionSiteDetailScreen.js
+++ b/src/screens/ConstructionSiteDetailScreen.js
@@ -17,7 +17,6 @@ import { LoadingSpinner } from '../components/LoadingSpinner';
 import { colors, consts, normalize, texts } from '../config';
 import { momentFormat } from '../helpers';
 import { useConstructionSites, useMatomoTrackScreenView } from '../hooks';
-import { location as locationIcon, locationIconAnchor } from '../icons';
 
 const { MATOMO_TRACKING } = consts;
 
@@ -136,8 +135,6 @@ export const ConstructionSiteDetailScreen = ({ route }) => {
           <Map
             locations={[
               {
-                icon: locationIcon(colors.primary),
-                iconAnchor: locationIconAnchor,
                 position: {
                   latitude: location.lat,
                   longitude: location.lon

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -1,13 +1,12 @@
 import { Point } from 'react-native-maps';
 
 export type MapMarker = {
+  iconAnchor?: Point;
+  iconName?: string;
+  id?: string;
   position: {
     latitude: number;
     longitude: number;
   };
-  icon: any;
-  activeIcon: any;
-  iconAnchor?: Point;
-  id?: string;
   title?: string;
 };


### PR DESCRIPTION
- changed to render a map icon from our icon library instead of fixed location svg icons
- created `MapIcon` with default `'location'` as icon to be able to remove all occurrences across the code base where the location icon was set
- added `anchor` in `MapMarker` that was missing until now, to properly position icons on map with pin point at the bottom of location icons
  - removed icon anchor const exports as we do not need them individually
- added `OwnLocation` in our `Icon` library to be accessible with `Icon[_upperFirst(iconName)]`
- fixed type issues with `Icon[_upperFirst(iconName) as keyof typeof Icon]`

MQGB-34