### PR TITLE
fix: solve detail screen rerender problem

### DIFF
--- a/src/components/screens/TimeTables.tsx
+++ b/src/components/screens/TimeTables.tsx
@@ -1,4 +1,5 @@
 import _upperFirst from 'lodash/upperFirst';
+import moment from 'moment';
 import React, { Fragment } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Divider, ListItem } from 'react-native-elements';
@@ -28,7 +29,7 @@ export const TimeTables = ({
   iconName: keyof typeof Icon;
 }) => {
   const CategoryIcon = Icon[_upperFirst(iconName)];
-  const today: string | number = new Date().toISOString();
+  const today: string = moment().format('ddd, DD.MM.YYY');
 
   return (
     <>
@@ -36,7 +37,7 @@ export const TimeTables = ({
 
       <Wrapper style={styles.noPadding}>
         <BoldText small>
-          {texts.pointOfInterest.today} {momentFormat(today, 'ddd, DD.MM.YYYY')}
+          {texts.pointOfInterest.today} {today}
         </BoldText>
       </Wrapper>
 

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -85,7 +85,7 @@ export const DetailScreen = ({ navigation, route }) => {
   const query = route.params?.query ?? '';
   const queryVariables = route.params?.queryVariables ?? {};
   const details = route.params?.details ?? {};
-  const date = new Date().toISOString();
+  const [today] = useState(new Date().toISOString());
 
   const [refreshing, setRefreshing] = useState(false);
 
@@ -118,7 +118,7 @@ export const DetailScreen = ({ navigation, route }) => {
   return (
     <Query
       query={getQuery(query)}
-      variables={{ id: queryVariables.id, date }}
+      variables={{ id: queryVariables.id, date: today }}
       fetchPolicy={fetchPolicy}
     >
       {({ data, loading, refetch }) => {


### PR DESCRIPTION
- fixed the `date` value with state, which causes the `DetailScreen` to re-render when the location information is active
- renamed `date` to `today` for clarity
- created today value in `TimeTables` with moment to ensure code integrity

MQGB-54