### PR TITLE
feat: add more information in the preview

### DIFF
--- a/src/components/TextListItem.tsx
+++ b/src/components/TextListItem.tsx
@@ -11,7 +11,6 @@ import { Image } from './Image';
 import { BoldText, RegularText } from './Text';
 import { Touchable } from './Touchable';
 import { WrapperRow } from './Wrapper';
-import { OpenStatus } from './infoCard/OpenStatus';
 
 export type ItemData = {
   id: string;
@@ -38,6 +37,7 @@ type Props = {
   leftImage?: boolean | undefined;
   navigation: StackNavigationProp<Record<string, any>>;
   noSubtitle?: boolean | undefined;
+  showOpenStatus?: boolean;
   titleFirst?: boolean;
 };
 
@@ -55,6 +55,7 @@ export const TextListItem: NamedExoticComponent<Props> & {
     leftImage,
     navigation,
     noSubtitle,
+    showOpenStatus,
     titleFirst
   }) => {
     const {
@@ -76,6 +77,12 @@ export const TextListItem: NamedExoticComponent<Props> & {
     let titleText = <BoldText>{trimNewLines(title)}</BoldText>;
 
     const textDirection: 'column' | 'column-reverse' = titleFirst ? 'column-reverse' : 'column';
+
+    let status = '';
+    if (showOpenStatus) {
+      const openStatus = isOpen(item?.params?.details?.openingHours);
+      status = openStatus?.open ? 'Jetzt geöffnet' : 'Geschlossen';
+    }
 
     if (teaserTitle) {
       titleText = (
@@ -127,6 +134,7 @@ export const TextListItem: NamedExoticComponent<Props> & {
           ) : undefined)}
 
         <ListItem.Content style={{ flexDirection: textDirection }}>
+          {showOpenStatus && !!status && <RegularText small>{status}</RegularText>}
           {noSubtitle || !subtitle ? titleText : <RegularText small>{subtitle}</RegularText>}
           {noSubtitle || !subtitle ? undefined : titleText}
         </ListItem.Content>
@@ -165,6 +173,7 @@ TextListItem.propTypes = {
   leftImage: PropTypes.bool,
   navigation: PropTypes.object,
   noSubtitle: PropTypes.bool,
+  showOpenStatus: PropTypes.bool,
   titleFirst: PropTypes.bool
 };
 

--- a/src/components/TextListItem.tsx
+++ b/src/components/TextListItem.tsx
@@ -1,16 +1,17 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import PropTypes from 'prop-types';
 import React, { memo, NamedExoticComponent, Validator } from 'react';
-import { StyleSheet } from 'react-native';
+import { ImageStyle, StyleSheet, ViewStyle } from 'react-native';
 import { ListItem } from 'react-native-elements';
 
 import { colors, consts, Icon, normalize } from '../config';
-import { trimNewLines } from '../helpers';
+import { isOpen, trimNewLines } from '../helpers';
 
 import { Image } from './Image';
 import { BoldText, RegularText } from './Text';
 import { Touchable } from './Touchable';
 import { WrapperRow } from './Wrapper';
+import { OpenStatus } from './infoCard/OpenStatus';
 
 export type ItemData = {
   id: string;
@@ -30,10 +31,14 @@ export type ItemData = {
 };
 
 type Props = {
+  containerStyle?: ViewStyle;
+  imageContainerStyle?: ViewStyle;
+  imageStyle?: ImageStyle;
   item: ItemData;
   leftImage?: boolean | undefined;
   navigation: StackNavigationProp<Record<string, any>>;
   noSubtitle?: boolean | undefined;
+  titleFirst?: boolean;
 };
 
 /* eslint-disable complexity */
@@ -41,80 +46,96 @@ export const TextListItem: NamedExoticComponent<Props> & {
   propTypes?: Record<string, Validator<any>>;
 } & {
   defaultProps?: Partial<Props>;
-} = memo<Props>(({ item, leftImage, navigation, noSubtitle }) => {
-  const {
-    badge,
-    bottomDivider,
-    leftIcon,
-    onPress,
-    params,
-    picture,
-    routeName: name,
-    statustitle,
-    statustitleIcon,
-    subtitle,
-    teaserTitle,
-    title,
-    topDivider
-  } = item;
-  const navigate = () => navigation && navigation.push(name, params);
-  let titleText = <BoldText>{trimNewLines(title)}</BoldText>;
+} = memo<Props>(
+  ({
+    containerStyle,
+    imageContainerStyle,
+    imageStyle,
+    item,
+    leftImage,
+    navigation,
+    noSubtitle,
+    titleFirst
+  }) => {
+    const {
+      badge,
+      bottomDivider,
+      leftIcon,
+      onPress,
+      params,
+      picture,
+      routeName: name,
+      statustitle,
+      statustitleIcon,
+      subtitle,
+      teaserTitle,
+      title,
+      topDivider
+    } = item;
+    const navigate = () => navigation && navigation.push(name, params);
+    let titleText = <BoldText>{trimNewLines(title)}</BoldText>;
 
-  if (teaserTitle) {
-    titleText = (
-      <>
-        {titleText}
-        <RegularText small>{teaserTitle}</RegularText>
-      </>
+    const textDirection: 'column' | 'column-reverse' = titleFirst ? 'column-reverse' : 'column';
+
+    if (teaserTitle) {
+      titleText = (
+        <>
+          {titleText}
+          <RegularText small>{teaserTitle}</RegularText>
+        </>
+      );
+    }
+
+    if (statustitle) {
+      titleText = (
+        <>
+          {titleText}
+          <WrapperRow style={styles.statustitleWrapper}>
+            {!!statustitleIcon && statustitleIcon}
+            <RegularText small placeholder>
+              {statustitle}
+            </RegularText>
+          </WrapperRow>
+        </>
+      );
+    }
+
+    // `title` is the first line and `subtitle` the second line, so `title` is used with our subtitle
+    // content and `subtitle` is used with the main title
+    return (
+      <ListItem
+        bottomDivider={bottomDivider !== undefined ? bottomDivider : true}
+        topDivider={topDivider !== undefined ? topDivider : false}
+        containerStyle={[styles.container, containerStyle && containerStyle]}
+        badge={badge}
+        onPress={() => (onPress ? onPress(navigation) : navigate())}
+        disabled={!navigation}
+        delayPressIn={0}
+        Component={Touchable}
+        accessibilityLabel={`(${title}) ${consts.a11yLabel.button}`}
+      >
+        {leftIcon ||
+          (leftImage && !!picture?.url ? (
+            <Image
+              source={{ uri: picture.url }}
+              style={[styles.smallImage, imageStyle && imageStyle]}
+              containerStyle={[
+                styles.smallImageContainer,
+                imageContainerStyle && imageContainerStyle
+              ]}
+            />
+          ) : undefined)}
+
+        <ListItem.Content style={{ flexDirection: textDirection }}>
+          {noSubtitle || !subtitle ? titleText : <RegularText small>{subtitle}</RegularText>}
+          {noSubtitle || !subtitle ? undefined : titleText}
+        </ListItem.Content>
+
+        {!!navigation && <Icon.ArrowRight color={colors.darkText} size={normalize(18)} />}
+      </ListItem>
     );
   }
-
-  if (statustitle) {
-    titleText = (
-      <>
-        {titleText}
-        <WrapperRow style={styles.statustitleWrapper}>
-          {!!statustitleIcon && statustitleIcon}
-          <RegularText small placeholder>
-            {statustitle}
-          </RegularText>
-        </WrapperRow>
-      </>
-    );
-  }
-
-  // `title` is the first line and `subtitle` the second line, so `title` is used with our subtitle
-  // content and `subtitle` is used with the main title
-  return (
-    <ListItem
-      bottomDivider={bottomDivider !== undefined ? bottomDivider : true}
-      topDivider={topDivider !== undefined ? topDivider : false}
-      containerStyle={styles.container}
-      badge={badge}
-      onPress={() => (onPress ? onPress(navigation) : navigate())}
-      disabled={!navigation}
-      delayPressIn={0}
-      Component={Touchable}
-      accessibilityLabel={`(${title}) ${consts.a11yLabel.button}`}
-    >
-      {leftIcon ||
-        (leftImage && !!picture?.url ? (
-          <Image
-            source={{ uri: picture.url }}
-            style={styles.smallImage}
-            containerStyle={styles.smallImageContainer}
-          />
-        ) : undefined)}
-
-      <ListItem.Content>
-        {noSubtitle || !subtitle ? titleText : <RegularText small>{subtitle}</RegularText>}
-        {noSubtitle || !subtitle ? undefined : titleText}
-      </ListItem.Content>
-
-      {!!navigation && <Icon.ArrowRight color={colors.darkText} size={normalize(18)} />}
-    </ListItem>
-  );
-});
+);
 /* eslint-enable complexity */
 
 const styles = StyleSheet.create({
@@ -137,10 +158,14 @@ const styles = StyleSheet.create({
 TextListItem.displayName = 'TextListItem';
 
 TextListItem.propTypes = {
+  containerStyle: PropTypes.object,
+  imageContainerStyle: PropTypes.object,
+  imageStyle: PropTypes.object,
   item: PropTypes.object.isRequired,
   leftImage: PropTypes.bool,
   navigation: PropTypes.object,
-  noSubtitle: PropTypes.bool
+  noSubtitle: PropTypes.bool,
+  titleFirst: PropTypes.bool
 };
 
 TextListItem.defaultProps = {

--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -148,14 +148,16 @@ export const LocationOverview = ({ filterByOpeningTimes, navigation, queryVariab
         selectedMarker={selectedPointOfInterest}
       />
       {selectedPointOfInterest && !detailsLoading && (
-        <Wrapper
-          small
+        <View
           style={[
             styles.listItemContainer,
             stylesWithProps({ navigation: navigationType }).position
           ]}
         >
           <TextListItem
+            containerStyle={styles.textListItemContainer}
+            imageContainerStyle={styles.imageRadius}
+            imageStyle={styles.imageSize}
             item={{
               ...item,
               bottomDivider: false,
@@ -163,18 +165,19 @@ export const LocationOverview = ({ filterByOpeningTimes, navigation, queryVariab
                 ? item.picture
                 : {
                     url: 'https://fileserver.smart-village.app/hb-meinquartier/app-icon.png'
-                  },
-              subtitle: undefined
+                  }
             }}
             leftImage
             navigation={navigation}
+            showOpenStatus
+            titleFirst
           />
           <View style={styles.iconContainer}>
             <Touchable onPress={() => setSelectedPointOfInterest(undefined)}>
               <Icon.Close size={normalize(20)} />
             </Touchable>
           </View>
-        </Wrapper>
+        </View>
       )}
     </>
   );
@@ -191,6 +194,14 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: normalize(7),
     width: normalize(32)
+  },
+  imageSize: {
+    height: normalize(96),
+    width: normalize(96)
+  },
+  imageRadius: {
+    borderBottomLeftRadius: normalize(12),
+    borderTopLeftRadius: normalize(12)
   },
   listItemContainer: {
     backgroundColor: colors.surface,
@@ -212,6 +223,10 @@ const styles = StyleSheet.create({
   map: {
     height: '100%',
     width: '100%'
+  },
+  textListItemContainer: {
+    paddingVertical: 0,
+    padding: 0
   }
 });
 


### PR DESCRIPTION
- added new style props to customise the `TextListItem` via props
- created `textDirection` depending on the `titleFirst´ prop to change the order of the texts
- added `showOpenStatus` prop to `TextListItem` to show whether POI is open or closed
- using the `isOpen` helper to find out if the POI is open or not
- customised `TextListItem` used in `LocationOverview` with new props

MQGB-34

## Test:
please remove the date information in the `pointOfInterest` query to avoid the problem of POIs not loading due to server.
```
export const GET_POINT_OF_INTEREST = gql`
  query PointOfInterest($id: ID!) {
    pointOfInterest(id: $id) {
      id
      title: name
      payload
      category {
        id
        name
        iconName
      }
      ...
```
## Screenshots:

|before|after - open POI|after - close POI|
|--|--|--|
![image](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/ba745c7f-9dac-4233-960d-46f52e3e6c0f)|![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-26 at 09 04 48](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/baee876d-ac2f-42fb-b574-70c5ff25be31)|![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-26 at 09 03 40](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/b6979540-0e18-4795-a962-e4627bbebdc4)|
