### PR TITLE
feat: add pagination to `travelTimes` list

### DIFF
--- a/src/components/screens/TravelTimes.tsx
+++ b/src/components/screens/TravelTimes.tsx
@@ -7,10 +7,13 @@ import { Divider, ListItem } from 'react-native-elements';
 import { Icon, colors, normalize, texts } from '../../config';
 import { momentFormat } from '../../helpers';
 import { QUERY_TYPES, getQuery } from '../../queries';
+import { Button } from '../Button';
 import { LoadingContainer } from '../LoadingContainer';
 import { SectionHeader } from '../SectionHeader';
 import { BoldText, RegularText } from '../Text';
 import { Wrapper } from '../Wrapper';
+
+const MAX_INITIAL_NUM_TO_RENDER = 15;
 
 type TravelTimeProps = {
   departureTime: string;
@@ -33,6 +36,7 @@ export const TravelTimes = ({
   const CategoryIcon = Icon[_upperFirst(iconName)];
   const [today] = useState<string>(new Date().toISOString());
   const queryVariables = { dataProviderId, externalId, date: today };
+  const [moreData, setMoreData] = useState(1);
 
   const { data, loading } = useQuery(getQuery(QUERY_TYPES.TRAVEL_TIMES), {
     variables: queryVariables
@@ -46,6 +50,8 @@ export const TravelTimes = ({
     );
   }
 
+  const paginatedData = data?.travelTimes?.slice(0, moreData * MAX_INITIAL_NUM_TO_RENDER);
+
   return (
     <>
       <SectionHeader title={texts.pointOfInterest.departureTimes} />
@@ -56,78 +62,82 @@ export const TravelTimes = ({
         </BoldText>
       </Wrapper>
 
-      {!!data?.travelTimes?.length &&
-        data.travelTimes.map((item: TravelTimeProps, index: number) => {
-          const { departureTime, route, trip } = item;
-          const { routeShortName, routeType } = route;
-          const { tripHeadsign } = trip;
+      {paginatedData.map((item: TravelTimeProps, index: number) => {
+        const { departureTime, route, trip } = item;
+        const { routeShortName, routeType } = route;
+        const { tripHeadsign } = trip;
 
-          const routeTypes: { [key: string]: string } = {
-            '0': texts.pointOfInterest.routeTypes.tram,
-            '1': texts.pointOfInterest.routeTypes.metro,
-            '2': texts.pointOfInterest.routeTypes.railway,
-            '3': texts.pointOfInterest.routeTypes.bus
-          };
+        const routeTypes: { [key: string]: string } = {
+          '0': texts.pointOfInterest.routeTypes.tram,
+          '1': texts.pointOfInterest.routeTypes.metro,
+          '2': texts.pointOfInterest.routeTypes.railway,
+          '3': texts.pointOfInterest.routeTypes.bus
+        };
 
-          const routeColors: { [key: string]: string } = {
-            '0': colors.primary,
-            '1': colors.primary,
-            '2': colors.primary,
-            '3': colors.primary
-          };
+        const routeColors: { [key: string]: string } = {
+          '0': colors.primary,
+          '1': colors.primary,
+          '2': colors.primary,
+          '3': colors.primary
+        };
 
-          return (
-            <Fragment key={index}>
-              <ListItem style={styles.container}>
-                <ListItem.Content style={styles.itemRow}>
-                  {!!departureTime && (
-                    <RegularText style={styles.time}>
-                      {momentFormat(departureTime, 'HH:mm', 'HH:mm:ss')}
-                    </RegularText>
-                  )}
+        return (
+          <Fragment key={index}>
+            <ListItem style={styles.container}>
+              <ListItem.Content style={styles.itemRow}>
+                {!!departureTime && (
+                  <RegularText style={styles.time}>
+                    {momentFormat(departureTime, 'HH:mm', 'HH:mm:ss')}
+                  </RegularText>
+                )}
 
-                  {!!routeShortName && !!routeType && (
-                    <View style={styles.typeDirection}>
-                      {!!iconName && (
-                        <View
-                          style={[
-                            styles.typeIconContainer,
-                            { backgroundColor: routeColors[routeType || '0'] }
-                          ]}
-                        >
-                          <CategoryIcon color={colors.lightestText} size={normalize(16)} />
-                        </View>
-                      )}
+                {!!routeShortName && !!routeType && (
+                  <View style={styles.typeDirection}>
+                    {!!iconName && (
                       <View
                         style={[
-                          styles.typeView,
-                          { backgroundColor: `${routeColors[routeType || '0']}` }
+                          styles.typeIconContainer,
+                          { backgroundColor: routeColors[routeType || '0'] }
                         ]}
                       >
-                        <RegularText lightest center>
-                          {`${routeTypes[routeType || '0']} ${routeShortName}`}
-                        </RegularText>
+                        <CategoryIcon color={colors.lightestText} size={normalize(16)} />
                       </View>
+                    )}
+                    <View
+                      style={[
+                        styles.typeView,
+                        { backgroundColor: `${routeColors[routeType || '0']}` }
+                      ]}
+                    >
+                      <RegularText lightest center>
+                        {`${routeTypes[routeType || '0']} ${routeShortName}`}
+                      </RegularText>
                     </View>
-                  )}
+                  </View>
+                )}
 
-                  <Icon.ArrowRight
-                    size={normalize(16)}
-                    color={colors.darkText}
-                    style={styles.icon}
-                  />
+                <Icon.ArrowRight size={normalize(16)} color={colors.darkText} style={styles.icon} />
 
-                  {!!tripHeadsign && (
-                    <RegularText small style={styles.headSign}>
-                      {tripHeadsign}
-                    </RegularText>
-                  )}
-                </ListItem.Content>
-              </ListItem>
-              {index !== data.travelTimes.length - 1 && <Divider style={styles.divider} />}
-            </Fragment>
-          );
-        })}
+                {!!tripHeadsign && (
+                  <RegularText small style={styles.headSign}>
+                    {tripHeadsign}
+                  </RegularText>
+                )}
+              </ListItem.Content>
+            </ListItem>
+            {index !== paginatedData.length - 1 && <Divider style={styles.divider} />}
+          </Fragment>
+        );
+      })}
+      {paginatedData.length !== data?.travelTimes?.length && (
+        <Wrapper>
+          <Button
+            title={texts.pointOfInterest.departureTimesShowMoreButton}
+            onPress={() => setMoreData((prev) => prev + 1)}
+            notFullWidth
+          />
+        </Wrapper>
+      )}
     </>
   );
 };

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -757,6 +757,7 @@ export const texts = {
   pointOfInterest: {
     availableVehicles: 'Verfügbare Fahrzeuge',
     departureTimes: 'Abfahrtszeiten',
+    departureTimesShowMoreButton: 'Mehr anzeigen',
     description: 'Beschreibung',
     filterByOpeningTime: 'Nur aktuell geöffnete anzeigen',
     location: 'Anfahrt',


### PR DESCRIPTION
- created `paginatedData` to show the data coming with query with pagination and limited to 15 data at the beginning with `slice` method
- added `MAX_INITIAL_NUM_TO_RENDER` value as 15 because we want to show all data in sections of 15
- added `moreData` state to show new 15 data when the button added at the bottom of the list is clicked

MQGB-54

## Test:

to test, you need to replace `queryVariables.id` with `'7205'` in the Query component in `DetailScreen`.

```
...
 <Query query={getQuery(query)} variables={{ id: '7205', date }} fetchPolicy={fetchPolicy}>
...
```

## Screenshots:

|travelTimes list|showMore button|new data shown|
|--|--|--|
|![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-28 at 12 12 34](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/4b2801b9-89eb-4ab9-8e63-a658e5f20fb4)|![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-28 at 12 12 36](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/ebdfb699-2e36-46f5-90c6-1b3f46f585ea)|![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-28 at 12 12 42](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/6e0caa03-44dd-461f-aed9-919de14d1374)|
