### PR TITLE
fix: not showing a description when adding a link to the organiser

### DIFF
--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -287,6 +287,7 @@ export const GET_EVENT_RECORD = gql`
           webUrls {
             id
             url
+            description
           }
         }
       }


### PR DESCRIPTION
- added `description` to `eventRecords` query to fix the error of showing the link instead of the description text when a link is added for the organiser

SVA-1166

## Screenshots:

|before|after|
|--|--|
![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-29 at 10 37 03](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/c821a397-dc90-46b1-a5a2-4a70deaa5177)|![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-29 at 10 37 16](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/b7c4a8d7-b65d-4244-bed0-9e1185d0be21)|
