### PR TITLE
fix: the problem that notifications cannot be activated

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,6 +9,7 @@
     "platforms": ["ios", "android"],
     "version": "3.3.0",
     "runtimeVersion": { "policy": "nativeVersion" },
+    "extra": { "eas": { "projectId": "20540f3a-6e82-4038-8987-adb6d97f0e75" } },
     "icon": "./assets/icon.png",
     "scheme": "smart-village-app",
     "splash": {

--- a/src/pushNotifications/PermissionHandling.ts
+++ b/src/pushNotifications/PermissionHandling.ts
@@ -1,3 +1,4 @@
+import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { PermissionStatus } from 'expo-permissions';
@@ -37,7 +38,9 @@ export const setInAppPermission = async (newValue: boolean) => {
 
 // https://docs.expo.dev/versions/latest/sdk/notifications/#expopushtokenoptions
 const registerForPushNotificationsAsync = async () => {
-  const { data: token } = await Notifications.getExpoPushTokenAsync();
+  const { data: token } = await Notifications.getExpoPushTokenAsync({
+    projectId: Constants.expoConfig?.extra?.eas.projectId
+  });
 
   return token;
 };


### PR DESCRIPTION
- added `projectId` to `getExpoPushTokenAsync` because it needs `projectId` for notifications due to the new update of expo
- added `projectId` to `app.json` for use in `getExpoPushTokenAsync`

SVA-1180
