### PR TITLE
fix: the bug of not navigating back from map view

### DIFF
--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -236,7 +236,8 @@ export const Overviews = ({ navigation, route }) => {
     if (
       query === QUERY_TYPES.POINTS_OF_INTEREST &&
       showMap &&
-      initialFilter === FILTER_TYPES.LIST
+      initialFilter === FILTER_TYPES.LIST &&
+      switchBetweenListAndMap == SWITCH_BETWEEN_LIST_AND_MAP.BOTTOM_FLOATING_BUTTON
     ) {
       navigation.setOptions({
         headerLeft: () => (


### PR DESCRIPTION
- added `switchBetweenListAndMap` control to `useLayoutEffect` to fix the problem of not being able to go back in navigation when `top-filter` is on in POI list

SVA-1181
