### PR TITLE
fix(navigation): configs without `useContext` and refactorings

### DIFF
--- a/src/SettingsProvider.js
+++ b/src/SettingsProvider.js
@@ -18,7 +18,7 @@ export const SettingsProvider = ({
   initialLocationSettings,
   children
 }) => {
-  const [globalSettings, setGlobalSettings] = useState(initialGlobalSettings);
+  const [globalSettings] = useState(initialGlobalSettings);
   const [listTypesSettings, setListTypesSettings] = useState(initialListTypesSettings);
   const [locationSettings, setLocationSettings] = useState(initialLocationSettings);
 
@@ -26,7 +26,6 @@ export const SettingsProvider = ({
     <SettingsContext.Provider
       value={{
         globalSettings,
-        setGlobalSettings,
         listTypesSettings,
         setListTypesSettings,
         locationSettings,

--- a/src/SettingsProvider.js
+++ b/src/SettingsProvider.js
@@ -5,11 +5,13 @@ export const SettingsContext = createContext({
   globalSettings: {
     filter: {},
     hdvt: {},
-    navigation: {},
+    navigation: 'tab',
     sections: {},
     settings: {},
     widgets: []
-  }
+  },
+  listTypesSettings: {},
+  locationSettings: {}
 });
 
 export const SettingsProvider = ({

--- a/src/components/IndexMapSwitch.js
+++ b/src/components/IndexMapSwitch.js
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
 const stylesWithProps = ({ navigationType }) => {
   return StyleSheet.create({
     position: {
-      bottom: navigationType === 'tab' ? 0 : '5%'
+      bottom: navigationType === 'drawer' ? '5%' : 0
     }
   });
 };

--- a/src/components/IndexMapSwitch.js
+++ b/src/components/IndexMapSwitch.js
@@ -9,10 +9,10 @@ import { Button } from './Button';
 
 export const IndexMapSwitch = ({ filter, setFilter }) => {
   const { globalSettings } = useContext(SettingsContext);
-  const { navigation = 'drawer' } = globalSettings;
+  const { navigation: navigationType } = globalSettings;
 
   return (
-    <View style={[styles.floatingButtonContainer, stylesWithProps({ navigation }).position]}>
+    <View style={[styles.floatingButtonContainer, stylesWithProps({ navigationType }).position]}>
       <Button
         onPress={() => {
           const selectedFilter = filter.find((entry) => entry.selected);
@@ -48,10 +48,10 @@ const styles = StyleSheet.create({
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-const stylesWithProps = ({ navigation }) => {
+const stylesWithProps = ({ navigationType }) => {
   return StyleSheet.create({
     position: {
-      bottom: navigation === 'tab' ? 0 : '5%'
+      bottom: navigationType === 'tab' ? 0 : '5%'
     }
   });
 };

--- a/src/components/ListSettingsItem.js
+++ b/src/components/ListSettingsItem.js
@@ -22,9 +22,6 @@ export const ListSettingsItem = ({ item }) => {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const { listTypesSettings, setListTypesSettings } = useContext(SettingsContext);
   const listTypeForQuery = listTypesSettings[queryType];
-
-  useContext(SettingsContext);
-
   const onPressTitle = useCallback(() => setIsCollapsed((value) => !value), []);
   const getOnPressListType = (listType) => () =>
     setListTypesSettings((previousListTypes) => {

--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -60,7 +60,7 @@ const mapToMapMarkers = (pointsOfInterest: any): MapMarker[] | undefined => {
 export const LocationOverview = ({ filterByOpeningTimes, navigation, queryVariables }: Props) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const { globalSettings } = useContext(SettingsContext);
-  const { navigation: navigationType = 'drawer' } = globalSettings;
+  const { navigation: navigationType } = globalSettings;
   const [selectedPointOfInterest, setSelectedPointOfInterest] = useState<string>();
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime: undefined });
 
@@ -134,10 +134,7 @@ export const LocationOverview = ({ filterByOpeningTimes, navigation, queryVariab
       {selectedPointOfInterest && !detailsLoading && (
         <Wrapper
           small
-          style={[
-            styles.listItemContainer,
-            stylesWithProps({ navigation: navigationType }).position
-          ]}
+          style={[styles.listItemContainer, stylesWithProps({ navigationType }).position]}
         >
           <TextListItem
             item={{
@@ -180,10 +177,10 @@ const styles = StyleSheet.create({
 
 /* eslint-disable react-native/no-unused-styles */
 /* this works properly, we do not want that warning */
-const stylesWithProps = ({ navigation }: { navigation: string }) => {
+const stylesWithProps = ({ navigationType }: { navigationType: string }) => {
   return StyleSheet.create({
     position: {
-      bottom: navigation === 'tab' ? '4%' : '8%'
+      bottom: navigationType === 'tab' ? '4%' : '8%'
     }
   });
 };

--- a/src/components/map/LocationOverview.tsx
+++ b/src/components/map/LocationOverview.tsx
@@ -180,7 +180,7 @@ const styles = StyleSheet.create({
 const stylesWithProps = ({ navigationType }: { navigationType: string }) => {
   return StyleSheet.create({
     position: {
-      bottom: navigationType === 'tab' ? '4%' : '8%'
+      bottom: navigationType === 'drawer' ? '8%' : '4%'
     }
   });
 };

--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -53,8 +53,7 @@ export const LocationSettings = () => {
       Location.getForegroundPermissionsAsync().then((response) => {
         // if the system permission is granted, we can simply enable the sorting
         if (response.status === Location.PermissionStatus.GRANTED) {
-          const newSettings = { locationService: true };
-          setAndSyncLocationSettings(newSettings);
+          setAndSyncLocationSettings({ locationService: true });
           return;
         }
 
@@ -65,8 +64,7 @@ export const LocationSettings = () => {
               if (response.status !== Location.PermissionStatus.GRANTED) {
                 revert();
               } else {
-                const newSettings = { locationService: true };
-                setAndSyncLocationSettings(newSettings);
+                setAndSyncLocationSettings({ locationService: true });
                 return;
               }
             })

--- a/src/config/navigation/config.ts
+++ b/src/config/navigation/config.ts
@@ -1,57 +1,55 @@
 import { LinkingOptions } from '@react-navigation/native';
 import * as Linking from 'expo-linking';
-import { useContext } from 'react';
 
-import { SettingsContext } from '../../SettingsProvider';
 import { NavigatorConfig, ScreenName } from '../../types';
 
 import { tabNavigatorConfig } from './tabConfig';
 
-let navigatorConfig: NavigatorConfig;
-const linkingConfig: LinkingOptions = {
-  prefixes: [Linking.createURL('/')]
-};
-const screens = {
-  [ScreenName.EncounterUserDetail]: 'encounter',
-  [ScreenName.Home]: '*'
-};
-
-const { globalSettings } = useContext(SettingsContext);
-
-if (globalSettings.navigation != 'drawer') {
-  const index = 1; // HINT: needs to be the index of the tab config where encounters is present
-
-  navigatorConfig = {
-    type: 'tab',
-    config: tabNavigatorConfig
+export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
+  let navigatorConfig: NavigatorConfig;
+  const linkingConfig: LinkingOptions = {
+    prefixes: [Linking.createURL('/')]
+  };
+  const screens = {
+    [ScreenName.EncounterUserDetail]: 'encounter',
+    [ScreenName.Home]: '*'
   };
 
-  linkingConfig.config = {
-    screens: {
-      // For tab navigation choose the preferred tab by its position in the config array
-      [`Stack${index}`]: {
-        // The initialRouteName has to be the initial route of the chosen stack:
-        // whatever is specified in the tab config for tab navigation
-        initialRouteName: navigatorConfig.config.tabConfigs[index].stackConfig.initialRouteName,
-        screens
+  if (navigationType != 'drawer') {
+    const index = 1; // HINT: needs to be the index of the tab config where encounters is present
+
+    navigatorConfig = {
+      type: 'tab',
+      config: tabNavigatorConfig
+    };
+
+    linkingConfig.config = {
+      screens: {
+        // For tab navigation choose the preferred tab by its position in the config array
+        [`Stack${index}`]: {
+          // The initialRouteName has to be the initial route of the chosen stack:
+          // whatever is specified in the tab config for tab navigation
+          initialRouteName: navigatorConfig.config.tabConfigs[index].stackConfig.initialRouteName,
+          screens
+        }
       }
-    }
-  };
-} else {
-  navigatorConfig = {
-    type: 'drawer'
-  };
+    };
+  } else {
+    navigatorConfig = {
+      type: 'drawer'
+    };
 
-  linkingConfig.config = {
-    screens: {
-      AppStack: {
-        // The initialRouteName has to be the initial route of the chosen stack:
-        // Home for drawer navigation
-        initialRouteName: ScreenName.Home,
-        screens
+    linkingConfig.config = {
+      screens: {
+        AppStack: {
+          // The initialRouteName has to be the initial route of the chosen stack:
+          // Home for drawer navigation
+          initialRouteName: ScreenName.Home,
+          screens
+        }
       }
-    }
-  };
-}
+    };
+  }
 
-export { linkingConfig, navigatorConfig };
+  return { navigatorConfig, linkingConfig };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,7 @@ const MainAppWithApolloProvider = () => {
         }}
       >
         <OnboardingManager>
-          <Navigator />
+          <Navigator navigationType={initialGlobalSettings.navigation} />
         </OnboardingManager>
       </SettingsProvider>
     </ApolloProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,11 @@ const MainAppWithApolloProvider = () => {
   const [client, setClient] = useState();
   const [initialGlobalSettings, setInitialGlobalSettings] = useState({
     filter: {},
+    hdvt: {},
+    navigation: 'tab',
     sections: {},
     settings: {},
-    widgets: [],
-    hdvt: {}
+    widgets: []
   });
   const [initialListTypesSettings, setInitialListTypesSettings] = useState({});
   const [initialLocationSettings, setInitialLocationSettings] = useState({});

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -3,24 +3,28 @@ import React from 'react';
 import { StatusBar } from 'react-native';
 
 import { colors } from '../config';
-import { linkingConfig, navigatorConfig } from '../config/navigation';
+import { navigationConfig } from '../config/navigation';
 
 import { DrawerNavigator } from './DrawerNavigator';
 import { MainTabNavigator } from './MainTabNavigator';
 
-export const Navigator = () => (
-  <NavigationContainer
-    theme={{
-      dark: DefaultTheme.dark,
-      colors: { ...DefaultTheme.colors, background: colors.surface }
-    }}
-    linking={linkingConfig}
-  >
-    <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
-    {navigatorConfig.type === 'drawer' ? (
-      <DrawerNavigator />
-    ) : (
-      <MainTabNavigator tabNavigatorConfig={navigatorConfig.config} />
-    )}
-  </NavigationContainer>
-);
+export const Navigator = ({ navigationType }: { navigationType: 'drawer' | 'tab' }) => {
+  const { navigatorConfig, linkingConfig } = navigationConfig(navigationType);
+
+  return (
+    <NavigationContainer
+      theme={{
+        dark: DefaultTheme.dark,
+        colors: { ...DefaultTheme.colors, background: colors.surface }
+      }}
+      linking={linkingConfig}
+    >
+      <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
+      {navigatorConfig.type === 'drawer' ? (
+        <DrawerNavigator />
+      ) : (
+        <MainTabNavigator tabNavigatorConfig={navigatorConfig.config} />
+      )}
+    </NavigationContainer>
+  );
+};

--- a/src/screens/MapViewScreen.js
+++ b/src/screens/MapViewScreen.js
@@ -18,7 +18,7 @@ export const MapViewScreen = ({ navigation, route }) => {
   } = route?.params;
 
   const { globalSettings } = useContext(SettingsContext);
-  const { navigation: navigationType = 'drawer' } = globalSettings;
+  const { navigation: navigationType } = globalSettings;
 
   /* the improvement in the next comment line has been added for augmented reality feature. */
   const { data } = route?.params?.augmentedRealityData ?? [];
@@ -47,10 +47,7 @@ export const MapViewScreen = ({ navigation, route }) => {
       {isAugmentedReality && modelData && (
         <Wrapper
           small
-          style={[
-            styles.listItemContainer,
-            stylesWithProps({ navigation: navigationType }).position
-          ]}
+          style={[styles.listItemContainer, stylesWithProps({ navigationType }).position]}
         >
           <TextListItem
             item={{
@@ -103,10 +100,10 @@ const styles = StyleSheet.create({
   }
 });
 
-const stylesWithProps = ({ navigation }) => {
+const stylesWithProps = ({ navigationType }) => {
   return StyleSheet.create({
     position: {
-      bottom: navigation === 'tab' ? '4%' : '8%'
+      bottom: navigationType === 'tab' ? '4%' : '8%'
     }
   });
 };

--- a/src/screens/MapViewScreen.js
+++ b/src/screens/MapViewScreen.js
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
 const stylesWithProps = ({ navigationType }) => {
   return StyleSheet.create({
     position: {
-      bottom: navigationType === 'tab' ? '4%' : '8%'
+      bottom: navigationType === 'drawer' ? '8%' : '4%'
     }
   });
 };


### PR DESCRIPTION
the problem was, that changing settings context triggered a rerendering of the navigation as the config file relied on it. the refactoring made passing the navigation type on initialising the application without the need of reading from the settings context.

also there are some refactorings to unify the code and understand things better.

SVA-1130