### PR TITLE
fix: new data not loading into the list

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,5 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import _uniqBy from 'lodash/uniqBy';
 import moment from 'moment';
 import 'moment/locale/de';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
@@ -207,9 +208,11 @@ export const Calendar = ({
       updateQuery: (prevResult, { fetchMoreResult }) => {
         if (!fetchMoreResult?.[query]?.length) return prevResult;
 
+        const uniqueData = _uniqBy([...prevResult[query], ...fetchMoreResult[query]], 'id');
+
         return {
           ...prevResult,
-          [query]: [...prevResult[query], ...fetchMoreResult[query]]
+          [query]: uniqueData
         };
       }
     });

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,3 +1,4 @@
+import { useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import moment from 'moment';
 import 'moment/locale/de';
@@ -52,6 +53,7 @@ export const Calendar = ({
     ...queryVariables,
     dateRange: [today, today]
   });
+  const [refreshing, setRefreshing] = useState(false);
   const contentContainerId = queryVariables.contentContainerId;
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
 
@@ -105,12 +107,12 @@ export const Calendar = ({
   );
 
   const selectedDay = useMemo(() => {
-    if (isListRefreshing || !queryVariablesWithDateRange?.dateRange?.length) {
+    if (!queryVariablesWithDateRange?.dateRange?.length) {
       return today;
     }
 
     return queryVariablesWithDateRange.dateRange[0];
-  }, [isListRefreshing, queryVariablesWithDateRange]);
+  }, [queryVariablesWithDateRange]);
 
   const markedDates = useMemo(() => {
     const dates: CalendarProps['markedDates'] = {};
@@ -165,21 +167,35 @@ export const Calendar = ({
     }
 
     return parsedListItems;
-  }, [subList, query, dataDateRange, additionalData]);
+  }, [additionalData, dataDateRange, query, selectedDay, subList]);
 
-  useEffect(() => {
-    if (isListRefreshing) {
-      setQueryVariablesWithDateRange({
-        ...queryVariables,
-        dateRange: [today, today]
-      });
-      refetch();
-    }
-  }, [isListRefreshing, queryVariables, refetch]);
+  const refresh = useCallback(
+    async (withCalendar = true) => {
+      setRefreshing(true);
+      if (isConnected) {
+        withCalendar && (await refetch());
+        await refetchDateRange();
+      }
+      setRefreshing(false);
+    },
+    [isConnected, refetch, refetchDateRange]
+  );
 
   useEffect(() => {
     refetchDateRange();
   }, [selectedDay]);
+
+  useEffect(() => {
+    if (isListRefreshing) {
+      refresh();
+    }
+  }, [isListRefreshing]);
+
+  useFocusEffect(
+    useCallback(() => {
+      refresh(false);
+    }, [refresh])
+  );
 
   const fetchMoreData = () =>
     fetchMoreDateRange({
@@ -202,7 +218,7 @@ export const Calendar = ({
     <>
       <RNCalendar
         dayComponent={DayComponent}
-        displayLoadingIndicator={loading}
+        displayLoadingIndicator={loading || refreshing}
         firstDay={1}
         markedDates={markedDates}
         markingType="multi-dot"
@@ -221,10 +237,10 @@ export const Calendar = ({
 
       {subList && (
         <ListComponent
-          data={loadingDateRange ? [] : listItems}
+          data={loadingDateRange || refreshing ? [] : listItems}
           fetchMoreData={fetchMoreData}
           ListEmptyComponent={
-            loadingDateRange ? (
+            loadingDateRange || refreshing ? (
               <LoadingContainer>
                 <ActivityIndicator color={colors.refreshControl} />
               </LoadingContainer>

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { SectionList, StyleSheet } from 'react-native';
 
 import { consts, texts } from '../config';
@@ -13,8 +13,26 @@ import { SectionHeader } from './SectionHeader';
 
 const keyExtractor = (item, index) => `index${index}-id${item.id}`;
 
-const MAX_INITIAL_NUM_TO_RENDER = 20;
+const MAX_INITIAL_NUM_TO_RENDER = 15;
 const { ROOT_ROUTE_NAMES } = consts;
+
+const sectionData = (data) => {
+  return data?.reduce((previous, current) => {
+    const listDate = current?.params?.details?.listDate || current?.listDate;
+
+    // check current for same list date as previous and if it matches push it in that section
+    // otherwise create a new section
+    if (listDate) {
+      if (previous[previous?.length - 1]?.title === listDate) {
+        previous[previous.length - 1].data.push(current);
+      } else {
+        previous.push({ title: listDate, data: [current] });
+      }
+    }
+
+    return previous;
+  }, []);
+};
 
 export const EventList = ({
   data,
@@ -28,11 +46,19 @@ export const EventList = ({
   refreshControl
 }) => {
   const [listEndReached, setListEndReached] = useState(false);
+  const [sectionedData, setSectionedData] = useState([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    setRefreshing(true);
+    setSectionedData(sectionData(data));
+    setRefreshing(false);
+  }, [data]);
 
   const onEndReached = async () => {
     if (fetchMoreData) {
       // if there is a pagination, the end of the list is reached, when no more data is returned
-      // from partially fetching, so we need to check the the data to determine the lists end
+      // from partially fetching, so we need to check the data to determine the lists end
       const { data: moreData } = await fetchMoreData();
 
       setListEndReached(!moreData[QUERY_TYPES.EVENT_RECORDS].length);
@@ -42,22 +68,11 @@ export const EventList = ({
   };
 
   const renderItem = useRenderItem(QUERY_TYPES.EVENT_RECORDS, navigation, { noSubtitle });
-  const sectionedData = data?.reduce((previous, current) => {
-    const listDate = current?.params?.details?.listDate || current?.listDate;
-
-    if (listDate) {
-      if (previous[previous?.length - 1]?.title === listDate) {
-        previous[previous.length - 1].data.push(current);
-      } else {
-        previous.push({ title: listDate, data: [current] });
-      }
-    }
-
-    return previous;
-  }, []);
 
   return (
     <SectionList
+      removeClippedSubviews
+      refreshing={refreshing}
       initialNumToRender={MAX_INITIAL_NUM_TO_RENDER}
       keyExtractor={keyExtractor}
       ListFooterComponent={() => {

--- a/src/components/VerticalList.js
+++ b/src/components/VerticalList.js
@@ -12,7 +12,7 @@ import { SWITCH_BETWEEN_LIST_AND_MAP } from './screens';
 
 const keyExtractor = (item, index) => `index${index}-id${item.id}`;
 
-const MAX_INITIAL_NUM_TO_RENDER = 20;
+const MAX_INITIAL_NUM_TO_RENDER = 15;
 
 export const VerticalList = ({
   data,
@@ -38,7 +38,7 @@ export const VerticalList = ({
   const onEndReached = async () => {
     if (fetchMoreData) {
       // if there is a pagination, the end of the list is reached, when no more data is returned
-      // from partially fetching, so we need to check the the data to determine the lists end
+      // from partially fetching, so we need to check the data to determine the lists end
       const { data: moreData } = await fetchMoreData();
 
       setListEndReached(!moreData[query].length);

--- a/src/components/screens/EventRecords.js
+++ b/src/components/screens/EventRecords.js
@@ -79,7 +79,8 @@ export const EventRecords = ({ navigation, route }) => {
     getQuery(QUERY_TYPES.EVENT_RECORDS, { showEventsFilter }),
     {
       fetchPolicy,
-      variables: queryVariables
+      variables: queryVariables,
+      skip: showCalendar
     }
   );
 
@@ -198,8 +199,10 @@ export const EventRecords = ({ navigation, route }) => {
     }, [isConnected, refetch, refetchVolunteerEvents, showCalendar, showVolunteerEvents])
   );
 
-  const fetchMoreData = () =>
-    fetchMore({
+  const fetchMoreData = () => {
+    if (showCalendar) return { data: { [query]: [] } };
+
+    return fetchMore({
       query: getFetchMoreQuery(query),
       variables: {
         ...queryVariables,
@@ -214,6 +217,7 @@ export const EventRecords = ({ navigation, route }) => {
         };
       }
     });
+  };
 
   if (!query) return null;
 

--- a/src/components/screens/EventRecords.js
+++ b/src/components/screens/EventRecords.js
@@ -203,7 +203,7 @@ export const EventRecords = ({ navigation, route }) => {
       query: getFetchMoreQuery(query),
       variables: {
         ...queryVariables,
-        offset: queryVariables.limit
+        offset: data?.[query]?.length
       },
       updateQuery: (prevResult, { fetchMoreResult }) => {
         if (!fetchMoreResult?.[query]?.length) return prevResult;

--- a/src/components/screens/EventRecords.js
+++ b/src/components/screens/EventRecords.js
@@ -181,10 +181,10 @@ export const EventRecords = ({ navigation, route }) => {
     return parsedListItems;
   }, [additionalData, data, hasDailyFilterSelection, query, queryVariables]);
 
-  const refresh = useCallback(() => {
+  const refresh = useCallback(async () => {
     setRefreshing(true);
     if (isConnected) {
-      refetch();
+      await refetch();
       showVolunteerEvents && refetchVolunteerEvents();
     }
     setRefreshing(false);

--- a/src/components/screens/EventRecords.js
+++ b/src/components/screens/EventRecords.js
@@ -1,5 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import _sortBy from 'lodash/sortBy';
+import _uniqBy from 'lodash/uniqBy';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
@@ -211,9 +212,11 @@ export const EventRecords = ({ navigation, route }) => {
       updateQuery: (prevResult, { fetchMoreResult }) => {
         if (!fetchMoreResult?.[query]?.length) return prevResult;
 
+        const uniqueData = _uniqBy([...prevResult[query], ...fetchMoreResult[query]], 'id');
+
         return {
           ...prevResult,
-          [query]: [...prevResult[query], ...fetchMoreResult[query]]
+          [query]: uniqueData
         };
       }
     });

--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -1,3 +1,4 @@
+import _uniqBy from 'lodash/uniqBy';
 import PropTypes from 'prop-types';
 import React, {
   useCallback,
@@ -266,9 +267,11 @@ export const Overviews = ({ navigation, route }) => {
       updateQuery: (prevResult, { fetchMoreResult }) => {
         if (!fetchMoreResult?.[query]?.length) return prevResult;
 
+        const uniqueData = _uniqBy([...prevResult[query], ...fetchMoreResult[query]], 'id');
+
         return {
           ...prevResult,
-          [query]: [...prevResult[query], ...fetchMoreResult[query]]
+          [query]: uniqueData
         };
       }
     });

--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -261,7 +261,7 @@ export const Overviews = ({ navigation, route }) => {
       query: getFetchMoreQuery(query),
       variables: {
         ...queryVariables,
-        offset: queryVariables.limit
+        offset: data?.[query]?.length
       },
       updateQuery: (prevResult, { fetchMoreResult }) => {
         if (!fetchMoreResult?.[query]?.length) return prevResult;


### PR DESCRIPTION
- updated `sectionedData` to be overwritten only with new data to fix the bug where `sectionedData` is constantly being rebuilt
- added `removeClippedSubviews` to `SectionList` to improve scrolling performance
- added `refreshing` state to ensure that the list is refreshed when new data arrives
- reduced the number of items to be loaded at the beginning of the list from 20 to 15 because the limit of the query is 15
- added `uniqBy` to the return section of the `fetchMoreData` function according to id to fix the error of showing the same data more than once in the `EventList`, `Overviews` and `Calendar` caused by multiple executions of the `fetchMoreData` function
- the list was still fetching in the background even if the calendar with its own list is visible
- changed the offset according to the length of the data to fix the problem that new data cannot be loaded via the `fetchMoreData` function when we go to the bottom of the list

SVA-1114