### PR TITLE
fix: event list screen app crashes on android devices

### DIFF
--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -69,6 +69,10 @@ export const EventList = ({
 
   const renderItem = useRenderItem(QUERY_TYPES.EVENT_RECORDS, navigation, { noSubtitle });
 
+  if (!sectionedData?.length) {
+    return null;
+  }
+
   return (
     <SectionList
       removeClippedSubviews


### PR DESCRIPTION
- added checking if `sectionedData` is empty to `EventList` to fix an issue where `SectionList` would crash the application if `sectionedData` was an empty array before creating the list for android

SVA-1114
