### PR TITLE
feat(settings): MoWaS regional keys handling

### DIFF
--- a/src/components/augmentedReality/AugmentedReality.js
+++ b/src/components/augmentedReality/AugmentedReality.js
@@ -4,7 +4,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useQuery } from 'react-apollo';
 
 import { SettingsContext } from '../../SettingsProvider';
-import { consts, texts } from '../../config';
+import { texts } from '../../config';
 import { checkDownloadedData, navigationToArtworksDetailScreen } from '../../helpers';
 import { QUERY_TYPES, getQuery } from '../../queries';
 import { ScreenName } from '../../types';
@@ -98,7 +98,6 @@ export const AugmentedReality = ({
   }
 
   const mapMarkers = mapToMapMarkers(data);
-  const a11yText = consts.a11yLabel;
 
   return (
     <>

--- a/src/components/settings/ListSettings.js
+++ b/src/components/settings/ListSettings.js
@@ -7,6 +7,7 @@ import { SettingsContext } from '../../SettingsProvider';
 import { ListSettingsItem } from '../ListSettingsItem';
 
 const renderItem = ({ item }) => <ListSettingsItem item={item} />;
+const keyExtractor = (item) => item.queryType;
 
 export const ListSettings = () => {
   const categoriesNews = useContext(SettingsContext).globalSettings?.sections?.categoriesNews ?? [
@@ -29,5 +30,5 @@ export const ListSettings = () => {
     }
   ];
 
-  return <FlatList data={data} renderItem={renderItem} keyExtractor={(item) => item.queryType} />;
+  return <FlatList data={data} keyExtractor={keyExtractor} renderItem={renderItem} />;
 };

--- a/src/components/settings/MowasRegionSettings.tsx
+++ b/src/components/settings/MowasRegionSettings.tsx
@@ -12,6 +12,8 @@ type MowasRegionalKeys = {
   rs: string;
 }[];
 
+const keyExtractor = (item: { rs: string }, index: number) => `index${index}-rs${item.rs}`;
+
 export const MowasRegionSettings = ({
   mowasRegionalKeys
 }: {
@@ -47,6 +49,7 @@ export const MowasRegionSettings = ({
   return (
     <FlatList
       data={mowasRegionalKeys}
+      keyExtractor={keyExtractor}
       renderItem={({ item }) => (
         <SettingsToggle
           item={{

--- a/src/components/settings/MowasRegionSettings.tsx
+++ b/src/components/settings/MowasRegionSettings.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useEffect, useReducer, useState } from 'react';
+import { FlatList } from 'react-native';
+
+import { LoadingSpinner } from '..';
+import { readFromStore } from '../../helpers';
+import { addMowasRegionalKeysToTokenOnServer } from '../../pushNotifications';
+import { MOWAS_REGIONAL_KEYS, MowasFilterAction, mowasRegionalKeysReducer } from '../../reducers';
+import { SettingsToggle } from '../SettingsToggle';
+
+type MowasRegionalKeys = {
+  name: string;
+  rs: string;
+}[];
+
+export const MowasRegionSettings = ({
+  mowasRegionalKeys
+}: {
+  mowasRegionalKeys: MowasRegionalKeys;
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [selectedMowasRegionalKeys, dispatch] = useReducer(mowasRegionalKeysReducer, []);
+
+  const loadFilters = useCallback(async () => {
+    setLoading(true);
+
+    dispatch({
+      type: MowasFilterAction.OverwriteMowasRegionalKeys,
+      payload: ((await readFromStore(MOWAS_REGIONAL_KEYS)) ?? []) as string[]
+    });
+
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadFilters();
+  }, [loadFilters]);
+
+  useEffect(() => {
+    !!mowasRegionalKeys?.length &&
+      addMowasRegionalKeysToTokenOnServer(selectedMowasRegionalKeys.map((id) => parseInt(id, 10)));
+  }, [selectedMowasRegionalKeys]);
+
+  if (!mowasRegionalKeys?.length || loading) {
+    return <LoadingSpinner loading />;
+  }
+
+  return (
+    <FlatList
+      data={mowasRegionalKeys}
+      renderItem={({ item }) => (
+        <SettingsToggle
+          item={{
+            title: item.name,
+            bottomDivider: true,
+            value: !selectedMowasRegionalKeys.includes(item.rs),
+            onActivate: () => {
+              dispatch({ type: MowasFilterAction.RemoveMowasRegionalKey, payload: item.rs });
+            },
+            onDeactivate: () => {
+              dispatch({ type: MowasFilterAction.AddMowasRegionalKey, payload: item.rs });
+            }
+          }}
+        />
+      )}
+    />
+  );
+};

--- a/src/components/settings/PermanentFilterSettings.tsx
+++ b/src/components/settings/PermanentFilterSettings.tsx
@@ -11,6 +11,8 @@ import { getQuery, QUERY_TYPES } from '../../queries';
 import { FilterAction } from '../../types';
 import { SettingsToggle } from '../SettingsToggle';
 
+const keyExtractor = (item: { id: number }, index: number) => `index${index}-id${item.id}`;
+
 export const PermanentFilterSettings = () => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
 
@@ -39,6 +41,7 @@ export const PermanentFilterSettings = () => {
   return (
     <FlatList
       data={data?.newsItemsDataProviders}
+      keyExtractor={keyExtractor}
       renderItem={({ item }) => (
         <SettingsToggle
           item={{

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -1,3 +1,4 @@
 export * from './ListSettings';
 export * from './LocationSettings';
+export * from './MowasRegionSettings';
 export * from './PermanentFilterSettings';

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -856,6 +856,9 @@ export const texts = {
       save: 'Speichern',
       setting: 'Standort'
     },
+    mowasRegion: {
+      setting: 'MoWaS-Regionen'
+    },
     onboarding: {
       onActivate: 'Beim nächsten Start wird die App-Einführung angezeigt.',
       onDeactivate: 'Die App-Einführung wird beim nächsten Start nicht angezeigt.',

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,1 +1,2 @@
+export * from './mowasRegionalKeysReducer';
 export * from './permanentFilterReducer';

--- a/src/reducers/mowasRegionalKeysReducer.ts
+++ b/src/reducers/mowasRegionalKeysReducer.ts
@@ -1,0 +1,40 @@
+import { addToStore } from '../helpers';
+
+export enum MowasFilterAction {
+  AddMowasRegionalKey = 'AddMowasRegionalKey',
+  OverwriteMowasRegionalKeys = 'OverwriteMowasRegionalKeys',
+  RemoveMowasRegionalKey = 'RemoveMowasRegionalKey'
+}
+
+export type MowasFilterReducerAction =
+  | {
+      type: MowasFilterAction.AddMowasRegionalKey | MowasFilterAction.RemoveMowasRegionalKey;
+      payload: string;
+    }
+  | { type: MowasFilterAction.OverwriteMowasRegionalKeys; payload: string[] };
+
+export const MOWAS_REGIONAL_KEYS = 'MOWAS_REGIONAL_KEYS';
+
+export const mowasRegionalKeysReducer: React.Reducer<string[], MowasFilterReducerAction> = (
+  state = [],
+  action
+) => {
+  let newState = state;
+  switch (action.type) {
+    case MowasFilterAction.AddMowasRegionalKey:
+      newState = [...state, action.payload];
+      break;
+    case MowasFilterAction.RemoveMowasRegionalKey:
+      newState = state.filter((id) => id != action.payload);
+      break;
+    case MowasFilterAction.OverwriteMowasRegionalKeys: {
+      newState = [...action.payload];
+      break;
+    }
+  }
+
+  // update the store for next app launch on every change
+  addToStore(MOWAS_REGIONAL_KEYS, newState);
+
+  return newState;
+};

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -39,7 +39,7 @@ import { ScreenName } from '../types';
 
 const { MATOMO_TRACKING } = consts;
 
-const keyExtractor = (item, index) => `index${index}-id${item.id}`;
+const keyExtractor = (item, index) => `index${index}-item${item.title || item}`;
 
 const renderItem = ({ item, navigation }) => {
   if (item === 'locationSettings') {

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -12,7 +12,12 @@ import {
   TextListItem,
   Wrapper
 } from '../components';
-import { ListSettings, LocationSettings, PermanentFilterSettings } from '../components/settings';
+import {
+  ListSettings,
+  LocationSettings,
+  MowasRegionSettings,
+  PermanentFilterSettings
+} from '../components/settings';
 import { colors, consts, texts } from '../config';
 import {
   addToStore,
@@ -58,6 +63,19 @@ const renderItem = ({ item, navigation }) => {
           params: { setting: item, title: texts.settingsContents.permanentFilter.setting },
           routeName: ScreenName.Settings,
           title: texts.settingsContents.permanentFilter.setting
+        }}
+        navigation={navigation}
+      />
+    );
+  }
+
+  if (item === 'mowasRegionSettings') {
+    return (
+      <TextListItem
+        item={{
+          params: { setting: item, title: texts.settingsContents.mowasRegion.setting },
+          routeName: ScreenName.Settings,
+          title: texts.settingsContents.mowasRegion.setting
         }}
         navigation={navigation}
       />
@@ -135,7 +153,7 @@ const onDeactivatePushNotifications = (revert) => {
 
 export const SettingsScreen = ({ navigation, route }) => {
   const { globalSettings } = useContext(SettingsContext);
-  const { settings = {} } = globalSettings;
+  const { mowas, settings = {} } = globalSettings;
   const [data, setData] = useState([]);
   const { setting = '' } = route?.params || {};
 
@@ -257,6 +275,12 @@ export const SettingsScreen = ({ navigation, route }) => {
         data: ['permanentFilterSettings']
       });
 
+      if (mowas?.regionalKeys?.length) {
+        settingsList.push({
+          data: ['mowasRegionSettings']
+        });
+      }
+
       settingsList.push({
         data: ['listSettings']
       });
@@ -299,6 +323,9 @@ export const SettingsScreen = ({ navigation, route }) => {
       break;
     case 'permanentFilterSettings':
       Component = <PermanentFilterSettings />;
+      break;
+    case 'mowasRegionSettings':
+      Component = <MowasRegionSettings mowasRegionalKeys={mowas?.regionalKeys} />;
       break;
     case 'listSettings':
       Component = <ListSettings />;

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -289,18 +289,21 @@ export const SettingsScreen = ({ navigation, route }) => {
         try {
           isARSupportedOnDevice(
             () => null,
-            () =>
+            () => {
               settingsList.push({
                 data: ['augmentedRealitySettings']
-              })
+              });
+
+              setData(settingsList);
+            }
           );
         } catch (error) {
           // if Viro is not integrated, we need to catch the error for `isARSupportedOnDevice of null`
           console.warn(error);
         }
+      } else {
+        setData(settingsList);
       }
-
-      setData(settingsList);
     };
 
     setting == '' && updateData();


### PR DESCRIPTION
- added MoWaS settings entry to be able to de-/select regions to get news and notifications for
- added new token handling for MoWaS regional keys in the way we already do it for data providers
- added reducer like the one existing for data providers to handle actions when toggling in settings
- cleanup & refactorings

to see and have the MoWaS section in settings a `globalSetting` needs to be added on the main-server, for example:

```
"mowas": {
  "regionalKeys": [
    {
      "name": "Internal Development",
      "rs": "999999999999"
    },
    {
      "name": "Angermünde",
      "rs": "120730008008"
    },
    {
      "name": "Amt Schlieben",
      "rs": "120625209445"
    }
  ]
},
```

SVA-1149

|settings overview|MoWaS settings|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2023-10-18 at 16 15 53](https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/2a5e0ce2-d487-4f5b-b5dc-48a6425d39f3)|![Simulator Screen Shot - iPhone 14 - 2023-10-18 at 16 15 56](https://github.com/smart-village-solutions/smart-village-app-app/assets/1942953/83303649-d4a2-447d-8bd7-e49209165fce)|