### PR TITLE
refactor(sue): adjustments for report screen

### DIFF
--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -14,8 +14,8 @@ export const SueReportDescription = ({ control }: { control: any; errors: any })
     <Wrapper style={styles.noPaddingTop}>
       <Input
         name="title"
-        label={`${texts.sue.reportScreen.title} *`}
-        placeholder={texts.sue.reportScreen.title}
+        label={`${texts.sue.report.title} *`}
+        placeholder={texts.sue.report.title}
         control={control}
       />
     </Wrapper>
@@ -23,8 +23,8 @@ export const SueReportDescription = ({ control }: { control: any; errors: any })
     <Wrapper style={styles.noPaddingTop}>
       <Input
         name="description"
-        label={`${texts.sue.reportScreen.description} *`}
-        placeholder={texts.sue.reportScreen.description}
+        label={`${texts.sue.report.description} *`}
+        placeholder={texts.sue.report.description}
         multiline
         control={control}
       />
@@ -42,6 +42,7 @@ export const SueReportDescription = ({ control }: { control: any; errors: any })
               selectorType: IMAGE_SELECTOR_TYPES.SUE,
               item: {
                 name: 'images',
+                infoText: texts.sue.report.imageHint,
                 label: texts.volunteer.images,
                 buttonTitle: texts.volunteer.addImage
               }

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -57,14 +57,14 @@ export const SueReportLocation = ({
       />
 
       <Wrapper>
-        <RegularText small>{texts.sue.reportScreen.map}</RegularText>
+        <RegularText small>{texts.sue.report.mapHint}</RegularText>
       </Wrapper>
 
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="street"
-          label={`${texts.sue.reportScreen.street}`}
-          placeholder={texts.sue.reportScreen.street}
+          label={`${texts.sue.report.street} *`}
+          placeholder={texts.sue.report.street}
           control={control}
         />
       </Wrapper>
@@ -72,8 +72,8 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="homeNumber"
-          label={`${texts.sue.reportScreen.homeNumber}`}
-          placeholder={texts.sue.reportScreen.homeNumber}
+          label={`${texts.sue.report.homeNumber} *`}
+          placeholder={texts.sue.report.homeNumber}
           keyboardType="numeric"
           control={control}
         />
@@ -82,8 +82,8 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="zipCode"
-          label={`${texts.sue.reportScreen.zipCode}`}
-          placeholder={texts.sue.reportScreen.zipCode}
+          label={`${texts.sue.report.zipCode} *`}
+          placeholder={texts.sue.report.zipCode}
           keyboardType="numeric"
           control={control}
         />
@@ -92,8 +92,8 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="city"
-          label={`${texts.sue.reportScreen.city}`}
-          placeholder={texts.sue.reportScreen.city}
+          label={`${texts.sue.report.city} *`}
+          placeholder={texts.sue.report.city}
           control={control}
         />
       </Wrapper>

--- a/src/components/SUE/report/SueReportUser.tsx
+++ b/src/components/SUE/report/SueReportUser.tsx
@@ -13,8 +13,8 @@ export const SueReportUser = ({ control }: { control: any; errors: any }) => (
     <Wrapper style={styles.noPaddingTop}>
       <Input
         name="firstName"
-        label={`${texts.sue.reportScreen.firstName}`}
-        placeholder={texts.sue.reportScreen.firstName}
+        label={`${texts.sue.report.firstName} *`}
+        placeholder={texts.sue.report.firstName}
         control={control}
       />
     </Wrapper>
@@ -22,8 +22,8 @@ export const SueReportUser = ({ control }: { control: any; errors: any }) => (
     <Wrapper style={styles.noPaddingTop}>
       <Input
         name="lastName"
-        label={`${texts.sue.reportScreen.lastName}`}
-        placeholder={texts.sue.reportScreen.lastName}
+        label={`${texts.sue.report.lastName} *`}
+        placeholder={texts.sue.report.lastName}
         control={control}
       />
     </Wrapper>
@@ -31,20 +31,20 @@ export const SueReportUser = ({ control }: { control: any; errors: any }) => (
     <Wrapper style={styles.noPaddingTop}>
       <Input
         name="email"
-        label={`${texts.sue.reportScreen.email} *`}
-        placeholder={texts.sue.reportScreen.email}
+        label={`${texts.sue.report.email} *`}
+        placeholder={texts.sue.report.email}
         keyboardType="email-address"
         control={control}
       />
 
-      <RegularText small>{texts.sue.reportScreen.emailHint}</RegularText>
+      <RegularText small>{texts.sue.report.emailHint}</RegularText>
     </Wrapper>
 
     <Wrapper style={styles.noPaddingTop}>
       <Input
         name="phone"
-        label={`${texts.sue.reportScreen.phone}`}
-        placeholder={texts.sue.reportScreen.phone}
+        label={`${texts.sue.report.phone}`}
+        placeholder={texts.sue.report.phone}
         keyboardType="phone-pad"
         control={control}
       />

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -122,11 +122,14 @@ export const ImageSelector = ({
             name={name}
             value={JSON.parse(value)}
           />
-          <RegularText smallest placeholder>
-            {infoText}
-          </RegularText>
 
-          <Button title={buttonTitle} invert onPress={imageSelect} disabled={values?.length >= 5} />
+          <Button disabled={values?.length >= 5} invert onPress={imageSelect} title={buttonTitle} />
+
+          {!!infoText && (
+            <RegularText small style={styles.sueInfoText}>
+              {infoText}
+            </RegularText>
+          )}
 
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             <WrapperRow>
@@ -241,6 +244,10 @@ const styles = StyleSheet.create({
   sueImage: {
     height: normalize(55),
     width: normalize(88)
+  },
+  sueInfoText: {
+    marginTop: normalize(-7),
+    marginBottom: normalize(5)
   },
   volunteerContainer: {
     marginBottom: normalize(8)

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -126,7 +126,7 @@ export const ImageSelector = ({
             {infoText}
           </RegularText>
 
-          {values?.length < 5 && <Button title={buttonTitle} invert onPress={imageSelect} />}
+          <Button title={buttonTitle} invert onPress={imageSelect} disabled={values?.length >= 5} />
 
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             <WrapperRow>
@@ -228,7 +228,7 @@ const styles = StyleSheet.create({
   },
   sueDeleteImageButton: {
     alignItems: 'center',
-    backgroundColor: colors.accent,
+    backgroundColor: colors.placeholder,
     borderRadius: normalize(11),
     height: normalize(22),
     justifyContent: 'center',
@@ -239,8 +239,8 @@ const styles = StyleSheet.create({
     zIndex: 5
   },
   sueImage: {
-    height: imageHeight(imageWidth() * 0.25),
-    width: imageWidth() * 0.3
+    height: normalize(55),
+    width: normalize(88)
   },
   volunteerContainer: {
     marginBottom: normalize(8)

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -140,7 +140,9 @@ export const Map = ({
               onPress={() => onMarkerPress?.(marker.id)}
               zIndex={isActiveMarker ? 1010 : 1}
             >
-              {!!marker.iconName && marker.iconName != 'ownLocation' ? (
+              {!!marker.iconName &&
+              marker.iconName != 'ownLocation' &&
+              marker.iconName != 'location' ? (
                 <>
                   <MapIcon iconColor={isActiveMarker ? colors.accent : undefined} />
                   <View
@@ -161,7 +163,7 @@ export const Map = ({
                   iconColor={
                     selectedMarker && marker.id === selectedMarker ? colors.accent : undefined
                   }
-                  iconName={marker.iconName ? marker.iconName : undefined}
+                  iconName={marker.iconName}
                 />
               )}
             </Marker>

--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -19,8 +19,7 @@ export const baseLocationMarker = {
 };
 
 export const getLocationMarker = (locationObject) => ({
-  ...baseLocationMarker,
-  ...locationObject,
+  iconName: locationObject?.iconName || baseLocationMarker.iconName,
   position: {
     ...locationObject.coords,
     latitude: locationObject?.coords?.latitude || locationObject?.coords?.lat,

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -910,11 +910,13 @@ export const texts = {
     datetime: 'Datum und Uhrzeit der Meldung',
     description: 'Beschreibung',
     location: 'Ort',
-    reportScreen: {
+    report: {
       alerts: {
-        hint: 'Hinweis',
+        address: 'Bitte stellen Sie sicher, dass Sie Ihre Adressdaten korrekt eingeben',
+        contact: 'Bitte stellen Sie sicher, dass Sie Ihre Kontaktdaten korrekt eingeben.',
         email:
           'Bitte geben Sie eine E-Mail-Adresse an. Ohne Ihre E-Mail-Adresse können wir nicht für eventuelle Rückfrage mit Ihnen Kontakt aufnehmen.',
+        hint: 'Hinweis',
         termsOfService: 'Bitte akzeptieren Sie die Datenschutzbestimmungen.'
       },
       back: 'Zurück',
@@ -926,6 +928,7 @@ export const texts = {
       errorText: 'muss ausgefüllt werden',
       firstName: 'Vorname',
       homeNumber: 'Hausnummer',
+      imageHint: 'ⓘ Es können bis zu 5 Fotos hochgeladen werden',
       lastName: 'Nachname',
       mapHint: 'ⓘ Für Geo-Koordinaten bitte die Position auf der Karte wählen',
       next: 'Weiter',

--- a/src/helpers/parser/sueParser.js
+++ b/src/helpers/parser/sueParser.js
@@ -13,7 +13,7 @@ export const parseSueData = (data, appDesignSystem) => {
     let parsedMediaUrl = [];
 
     try {
-      const mediaArray = item?.mediaUrl || JSON.parse(item?.media_url);
+      const mediaArray = item.mediaUrl || JSON.parse(item.media_url);
       parsedMediaUrl = mediaArray.map((mediaItem) => ({
         id: mediaItem.id,
         sourceUrl: { url: mediaItem.url },
@@ -33,15 +33,15 @@ export const parseSueData = (data, appDesignSystem) => {
       bottomDivider: false,
       iconName: matchedStatus?.iconName,
       params: {
-        title: item?.title,
+        title: item.title,
         query: QUERY_TYPES.SUE.REQUESTS_WITH_SERVICE_REQUEST_ID,
-        queryVariables: { id: item?.serviceRequestId },
+        queryVariables: { id: item.serviceRequestId },
         rootRouteName: ROOT_ROUTE_NAMES.SUE,
         bookmarkable: false,
         details: item
       },
       picture: { url: mainImageOfMediaContents(parsedMediaUrl) },
-      routeName: ScreenName?.Detail,
+      routeName: ScreenName.Detail,
       status: matchedStatus?.status,
       subtitle: undefined
     };

--- a/src/queries/SUE/requests.tsx
+++ b/src/queries/SUE/requests.tsx
@@ -34,31 +34,17 @@ export const postRequests = async (data: any) => {
   formData.append('phone', data?.phone);
   formData.append('service_code', data.serviceCode);
   formData.append('title', data?.title);
-  formData.append('media_file_1', {
-    uri: JSON.parse(data.images)[0]?.uri,
-    name: JSON.parse(data.images)[0]?.imageName,
-    type: JSON.parse(data.images)[0]?.mimeType
-  });
-  formData.append('media_file_2', {
-    uri: JSON.parse(data.images)[1]?.uri,
-    name: JSON.parse(data.images)[1]?.imageName,
-    type: JSON.parse(data.images)[1]?.mimeType
-  });
-  formData.append('media_file_3', {
-    uri: JSON.parse(data.images)[2]?.uri,
-    name: JSON.parse(data.images)[2]?.imageName,
-    type: JSON.parse(data.images)[2]?.mimeType
-  });
-  formData.append('media_file_4', {
-    uri: JSON.parse(data.images)[3]?.uri,
-    name: JSON.parse(data.images)[3]?.imageName,
-    type: JSON.parse(data.images)[3]?.mimeType
-  });
-  formData.append('media_file_5', {
-    uri: JSON.parse(data.images)[4]?.uri,
-    name: JSON.parse(data.images)[4]?.imageName,
-    type: JSON.parse(data.images)[4]?.mimeType
-  });
+
+  const images = JSON.parse(data?.images) || [];
+  for (let i = 0; i < images.length; i++) {
+    const image = images[i];
+
+    formData.append(`media_file_${i + 1}`, {
+      uri: image?.uri,
+      name: image?.imageName,
+      type: image?.mimeType
+    });
+  }
 
   const fetchObj = {
     method: 'POST',

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -224,7 +224,13 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
 
       <Wrapper style={[styles.buttonContainer, currentPage !== 0 && styles.buttonContainerRow]}>
         {currentPage !== 0 && (
-          <Button invert notFullWidth onPress={handlePrevPage} title={texts.sue.report.back} />
+          <Button
+            disabled={isLoading}
+            invert
+            notFullWidth
+            onPress={handlePrevPage}
+            title={texts.sue.report.back}
+          />
         )}
 
         <Button

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import * as Location from 'expo-location';
 import React, { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -8,6 +7,7 @@ import { useMutation } from 'react-query';
 
 import {
   Button,
+  DefaultKeyboardAvoidingView,
   LoadingContainer,
   SafeAreaViewFlex,
   SueReportDescription,
@@ -90,7 +90,8 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
   const {
     control,
     formState: { errors },
-    handleSubmit
+    handleSubmit,
+    getValues
   } = useForm({
     mode: 'onBlur',
     defaultValues: {
@@ -113,14 +114,11 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
 
   const onSubmit = async (sueReportData: TReports) => {
     if (!sueReportData.email) {
-      return Alert.alert(texts.sue.reportScreen.alerts.hint, texts.sue.reportScreen.alerts.email);
+      return Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.email);
     }
 
     if (!sueReportData.termsOfService) {
-      return Alert.alert(
-        texts.sue.reportScreen.alerts.hint,
-        texts.sue.reportScreen.alerts.termsOfService
-      );
+      return Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.termsOfService);
     }
 
     if (
@@ -129,13 +127,14 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
       !sueReportData.zipCode ||
       !sueReportData.city
     ) {
-      Alert.alert(texts.defectReport.alerts.hint, texts.defectReport.alerts.error);
-
-      setIsLoading(false);
-      return;
+      return Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.address);
     }
 
     const addressString = `${sueReportData.street}; ${sueReportData.homeNumber}; ${sueReportData.zipCode}; ${sueReportData.city}`;
+
+    if (!sueReportData.firstName || !sueReportData.lastName || !sueReportData.email) {
+      return Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.contact);
+    }
 
     const formData = {
       addressString,
@@ -151,8 +150,7 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
       .catch(() => {
         setIsLoading(false);
 
-        Alert.alert(texts.defectReport.alerts.hint, texts.defectReport.alerts.error);
-        return;
+        return Alert.alert(texts.defectReport.alerts.hint, texts.defectReport.alerts.error);
       })
       .finally(() => setIsLoading(false));
   };
@@ -192,10 +190,12 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
   }
 
   return (
-    <>
+    <SafeAreaViewFlex>
       <SueReportProgress progress={data} currentProgress={currentPage + 1} />
-      <SafeAreaViewFlex>
+
+      <DefaultKeyboardAvoidingView>
         <ScrollView
+          keyboardShouldPersistTaps="handled"
           horizontal
           pagingEnabled
           ref={scrollViewRef}
@@ -203,11 +203,7 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
           showsHorizontalScrollIndicator={false}
         >
           {data?.map((item: TProgress, index: number) => (
-            <ScrollView
-              key={index}
-              keyboardShouldPersistTaps="handled"
-              contentContainerStyle={styles.contentContainer}
-            >
+            <ScrollView key={index} contentContainerStyle={styles.contentContainer}>
               {Content(
                 item.content,
                 serviceCode,
@@ -220,7 +216,7 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
             </ScrollView>
           ))}
         </ScrollView>
-      </SafeAreaViewFlex>
+      </DefaultKeyboardAvoidingView>
 
       <WrapperHorizontal>
         <Divider />
@@ -228,12 +224,7 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
 
       <Wrapper style={[styles.buttonContainer, currentPage !== 0 && styles.buttonContainerRow]}>
         {currentPage !== 0 && (
-          <Button
-            invert
-            notFullWidth
-            onPress={handlePrevPage}
-            title={texts.sue.reportScreen.back}
-          />
+          <Button invert notFullWidth onPress={handlePrevPage} title={texts.sue.report.back} />
         )}
 
         <Button
@@ -241,13 +232,11 @@ export const SueReportScreen = ({ navigation }: { navigation: any }) => {
           notFullWidth={currentPage !== 0}
           onPress={currentPage < data.length - 1 ? handleNextPage : handleSubmit(onSubmit)}
           title={
-            currentPage === data.length - 1
-              ? texts.sue.reportScreen.sendReport
-              : texts.sue.reportScreen.next
+            currentPage === data.length - 1 ? texts.sue.report.sendReport : texts.sue.report.next
           }
         />
       </Wrapper>
-    </>
+    </SafeAreaViewFlex>
   );
 };
 


### PR DESCRIPTION
- removed `Screen` from `texts.sue.reportScreen` as it is not necessary
- resized the preview of the image after selecting an image on the report screen
- updated the background color of the delete button in the image preview on the report screen as `placeholder`
- removed undefined checks in `sueParser` as unnecessary
- added a requirement to some inputs to prevent the server from sending reports with incomplete information
  - lastName & firstName & street & homeNumber & zipCode
- added new alerts and controls to `SueReportScreen` to show which input needs to be filled when the report is sent with unfilled inputs
- added `DefaultKeyboardAvoidingView` to `SueReportScreen` to make inputs appear above the keyboard when clicked on

SUE-7

## Screenshots:
|image preview with new style|inputs with keyboard avoiding view|address inputs with *|user information inputs with *|
|--|--|--|--|
![Simulator Screenshot - iPhone 14 - 2023-11-03 at 10 30 47](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/f6c11439-798b-41bf-a03f-250f481b8377)|![Simulator Screenshot - iPhone 14 - 2023-11-03 at 10 30 57](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/8a4764b6-366d-4585-94a1-ba2825b08aad)|![Simulator Screenshot - iPhone 14 - 2023-11-03 at 10 31 02](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/2d9a613c-e832-4c3e-9293-84d8fc2e4e76)|![Simulator Screenshot - iPhone 14 - 2023-11-03 at 10 31 05](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/30ccb8d2-5a02-4d59-a67f-eacf59fc6cf0)


