### PR TITLE
feat(sue): add `SueImageFallback` to reports without image

### DIFF
--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -13,6 +13,7 @@ import {
   Map,
   RegularText,
   SafeAreaViewFlex,
+  SueImageFallback,
   SueStatus,
   Touchable,
   Wrapper
@@ -113,12 +114,14 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
             delayPressIn={0}
             onPress={() => navigation.push(item.routeName, item.params)}
           >
-            {!!item.picture?.url && (
+            {!!item.picture?.url ? (
               <Image
                 source={{ uri: item.picture.url }}
                 style={styles.image}
                 containerStyle={styles.imageContainer}
               />
+            ) : (
+              <SueImageFallback style={styles.image} />
             )}
 
             <ListItem.Content>


### PR DESCRIPTION
- added `SueImageFallback` to show in list item if there is a report without image in map view

SUE-4

## Screenshots:

|with image|without image (before)|without image (after)|
|--|--|--|
![Simulator Screenshot - iPhone 14 - 2023-11-03 at 11 01 38](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/a11ed303-660a-4aab-8440-4f6e1b458ecc)|![Simulator Screenshot - iPhone 14 - 2023-11-03 at 11 01 58](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/c6156735-36f5-4eb1-8192-e88ad4f7b94c)|![Simulator Screenshot - iPhone 14 - 2023-11-03 at 11 01 45](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/7954b296-b092-48ea-b8b1-132fb6318e37)