### PR TITLE
fix(ar): app crashes in settings screen

### DIFF
--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -236,7 +236,7 @@ export const SettingsScreen = () => {
               {
                 id: TOP_FILTER.AR_DOWNLOAD_LIST,
                 title: texts.settingsTitles.tabs.arSettings,
-                selected: false
+                selected: !selectedFilterId ? true : false
               }
             ])
         );


### PR DESCRIPTION
- fixed an issue that caused the application to crash when the AR models download tab on the settings screen in applications with AR feature was selected, navigating back and re-entering the settings screen

SVA-1195

The reason for the problem is that in applications with AR feature and devices that support AR feature, we add the filter required for AR to `INITIAL_FILTER` later. For this reason, `selectedFilterId` cannot be found and the application crashes. Therefore, if `selectedFilterId` is `undefined`, the AR filter is made `true`.

## How to test:
* [x] Android
* [x] iOS