### PR TITLE
feat: allow http home pages

### DIFF
--- a/app.json
+++ b/app.json
@@ -75,6 +75,14 @@
           "initialOrientation": "PORTRAIT"
         }
       ],
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true
+          }
+        }
+      ],
       "expo-localization",
       "sentry-expo",
       "./config-plugins/withAndroidMailQueriesAndWhatsappPackage"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "expo-av": "~13.4.1",
     "expo-barcode-scanner": "~12.5.3",
     "expo-blur": "~12.4.1",
+    "expo-build-properties": "^0.8.3",
     "expo-camera": "~13.4.4",
     "expo-clipboard": "~4.3.0",
     "expo-constants": "~14.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,7 +3124,7 @@ ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
+ajv@^8.0.1, ajv@^8.11.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -5374,6 +5374,14 @@ expo-blur@~12.4.1:
   version "12.4.1"
   resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-12.4.1.tgz#b391de84914ef9ece0702378e51e09461ad565ab"
   integrity sha512-lGN8FS9LuGUlEriULTC62cCWyg5V7zSVQeJ6Duh1wSq8aAETinZ2/7wrT6o+Uhd/XVVxFNON2T25AGCOtMG6ew==
+
+expo-build-properties@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/expo-build-properties/-/expo-build-properties-0.8.3.tgz#fbfa156e9619bebda71c66af9a26ebc3490b2365"
+  integrity sha512-kEDDuAadHqJTkvCGK4fXYHVrePiJO1DjyW95AicmwuGwQvGJydYFbuoauf9ybAU+4UH4arhbce8gHI3ZpIj3Jw==
+  dependencies:
+    ajv "^8.11.0"
+    semver "^7.5.3"
 
 expo-camera@~13.4.4:
   version "13.4.4"


### PR DESCRIPTION
- fixed the bug that http sites were not shown in the web view in the app due to poor security of http sites due to the new update of android
  - https://docs.expo.dev/versions/latest/sdk/build-properties/#pluginconfigtypeandroid

SVA-1182

## How to test:
* [x] Android