### PR TITLE
feat(disturber): add multiple images to disturber

### DIFF
--- a/src/components/Disturber.tsx
+++ b/src/components/Disturber.tsx
@@ -1,17 +1,15 @@
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import React, { useEffect, useState } from 'react';
-import { FlatList, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
-import { Icon, colors, device, normalize } from '../config';
-import { addToStore, findClosestItem, imageWidth, isActive, readFromStore } from '../helpers';
+import { Icon, colors, normalize } from '../config';
+import { addToStore, findClosestItem, isActive, readFromStore } from '../helpers';
 import { useHomeRefresh, useStaticContent } from '../hooks';
 
 import { Button } from './Button';
-import { Image } from './Image';
+import { ImagesCarousel } from './ImagesCarousel';
 import { BoldText, RegularText } from './Text';
 import { Wrapper, WrapperHorizontal } from './Wrapper';
-import { ImagesCarousel } from './ImagesCarousel';
-import Carousel from 'react-native-snap-carousel';
 
 type Props = {
   navigation: DrawerNavigationProp<any>;
@@ -112,7 +110,7 @@ export const Disturber = ({ navigation, publicJsonFile }: Props) => {
               </TouchableOpacity>
             )}
 
-            {!!pictures?.length && (
+            {pictures?.length ? (
               <View style={styles.carouselContainer}>
                 <ImagesCarousel
                   aspectRatio={aspectRatio || { HEIGHT: 0.7, WIDTH: 1 }}
@@ -123,6 +121,8 @@ export const Disturber = ({ navigation, publicJsonFile }: Props) => {
                   refreshTimeKey={`publicJsonFile-${publicJsonFile}`}
                 />
               </View>
+            ) : (
+              <View style={styles.withoutImageMarginTop} />
             )}
 
             <Wrapper style={styles.noPaddingBottom}>
@@ -198,6 +198,9 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     lineHeight: normalize(16),
     textTransform: 'uppercase'
+  },
+  withoutImageMarginTop: {
+    marginTop: normalize(21)
   },
   noPaddingBottom: {
     paddingBottom: 0

--- a/src/components/Disturber.tsx
+++ b/src/components/Disturber.tsx
@@ -1,15 +1,17 @@
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { FlatList, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 
-import { Icon, colors, normalize } from '../config';
-import { addToStore, findClosestItem, isActive, readFromStore } from '../helpers';
+import { Icon, colors, device, normalize } from '../config';
+import { addToStore, findClosestItem, imageWidth, isActive, readFromStore } from '../helpers';
 import { useHomeRefresh, useStaticContent } from '../hooks';
 
 import { Button } from './Button';
 import { Image } from './Image';
 import { BoldText, RegularText } from './Text';
 import { Wrapper, WrapperHorizontal } from './Wrapper';
+import { ImagesCarousel } from './ImagesCarousel';
+import Carousel from 'react-native-snap-carousel';
 
 type Props = {
   navigation: DrawerNavigationProp<any>;
@@ -22,6 +24,8 @@ interface DateRange {
 }
 
 interface DataItem {
+  aspectRatio?: { HEIGHT: number; WIDTH: number };
+  autoplayInterval?: number;
   backgroundColor?: string;
   button: {
     navigationTo: string;
@@ -32,7 +36,11 @@ interface DataItem {
   dates: DateRange[];
   description: string;
   id: number;
-  picture?: { aspectRatio?: { HEIGHT: number; WIDTH: number }; uri: string };
+  pictures?: {
+    navigationTo: string;
+    params: { title?: string; webUrl: string };
+    uri: string;
+  }[];
   showButtonToClose?: boolean;
   title: string;
 }
@@ -80,11 +88,13 @@ export const Disturber = ({ navigation, publicJsonFile }: Props) => {
   if (!isVisible || !closestItem) return null;
 
   const {
+    aspectRatio,
+    autoplayInterval,
     backgroundColor,
     button,
     description,
     headline,
-    picture,
+    pictures,
     showButtonToClose = true,
     title
   } = closestItem;
@@ -102,13 +112,17 @@ export const Disturber = ({ navigation, publicJsonFile }: Props) => {
               </TouchableOpacity>
             )}
 
-            {!!picture && (
-              <Image
-                source={picture}
-                borderRadius={normalize(8)}
-                aspectRatio={picture.aspectRatio || { HEIGHT: 0.7, WIDTH: 1 }}
-                resizeMode="cover"
-              />
+            {!!pictures?.length && (
+              <View style={styles.carouselContainer}>
+                <ImagesCarousel
+                  aspectRatio={aspectRatio || { HEIGHT: 0.7, WIDTH: 1 }}
+                  autoplayInterval={autoplayInterval}
+                  data={pictures}
+                  isDisturber
+                  navigation={navigation}
+                  refreshTimeKey={`publicJsonFile-${publicJsonFile}`}
+                />
+              </View>
             )}
 
             <Wrapper style={styles.noPaddingBottom}>
@@ -158,6 +172,11 @@ export const Disturber = ({ navigation, publicJsonFile }: Props) => {
 };
 
 const styles = StyleSheet.create({
+  carouselContainer: {
+    borderTopLeftRadius: normalize(8),
+    borderTopRightRadius: normalize(8),
+    overflow: 'hidden'
+  },
   closeButton: {
     alignItems: 'center',
     backgroundColor: colors.gray20,

--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -15,7 +15,14 @@ import { SettingsContext } from '../SettingsProvider';
 import { ImagesCarouselItem } from './ImagesCarouselItem';
 import { LoadingContainer } from './LoadingContainer';
 
-export const ImagesCarousel = ({ data, navigation, refreshTimeKey, aspectRatio }) => {
+export const ImagesCarousel = ({
+  aspectRatio,
+  autoplayInterval,
+  data,
+  isDisturber,
+  navigation,
+  refreshTimeKey
+}) => {
   const { dimensions } = useContext(OrientationContext);
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const { globalSettings } = useContext(SettingsContext);
@@ -133,13 +140,14 @@ export const ImagesCarousel = ({ data, navigation, refreshTimeKey, aspectRatio }
           autoplay
           loop
           autoplayDelay={0}
-          autoplayInterval={4000}
+          autoplayInterval={autoplayInterval || 4000}
           containerCustomStyle={styles.center}
           onScrollIndexChanged={setCarouselImageIndex}
         />
       )}
 
       {showSliderPauseButton &&
+        !isDisturber &&
         pauseButton(
           horizontalPosition,
           isCopyrighted,
@@ -194,9 +202,11 @@ const styles = StyleSheet.create({
 });
 
 ImagesCarousel.propTypes = {
-  data: PropTypes.array.isRequired,
-  navigation: PropTypes.object,
-  refreshTimeKey: PropTypes.string,
   aspectRatio: PropTypes.object,
-  autoplay: PropTypes.bool
+  autoplay: PropTypes.bool,
+  autoplayInterval: PropTypes.number,
+  data: PropTypes.array.isRequired,
+  isDisturber: PropTypes.bool,
+  navigation: PropTypes.object,
+  refreshTimeKey: PropTypes.string
 };

--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -38,6 +38,8 @@ export const ImagesCarousel = ({
   const [isPaused, setIsPaused] = useState(false);
   const [carouselImageIndex, setCarouselImageIndex] = useState(0);
 
+  const shouldShowPauseButton = showSliderPauseButton && !isDisturber;
+
   const fetchPolicy = graphqlFetchPolicy({
     isConnected,
     isMainserverUp,
@@ -146,8 +148,7 @@ export const ImagesCarousel = ({
         />
       )}
 
-      {showSliderPauseButton &&
-        !isDisturber &&
+      {shouldShowPauseButton &&
         pauseButton(
           horizontalPosition,
           isCopyrighted,


### PR DESCRIPTION
- added `ImagesCarousel` component instead of `Image` component to show when more than one image is added to disturber
- added the ability to add a link directly from the image to disturber
- changed the duration of the cycle of the disturber carousel on the server
- added `isDisturber` prop to `ImagesCarousel` to not show pause button in carousel

SVAK-20

## Screenshots:

|first image with link|second image without link|third image without link|
|--|--|--|
![Simulator Screenshot - iPhone 14 Pro - 2023-11-22 at 21 02 09](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/f0e3b3f0-c19c-43ec-8f60-9dc4276f33bc)|![Simulator Screenshot - iPhone 14 Pro - 2023-11-22 at 21 02 11](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/693e093a-f15b-4c97-8b28-bec5016e81fb)|![Simulator Screenshot - iPhone 14 Pro - 2023-11-22 at 21 02 14](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/94eab33b-650f-47e0-a1ee-43d223f282cb)
