### PR TITLE
feat: add `EventSectionHeader` for text list with big picture

### DIFF
--- a/src/components/TextListItem.tsx
+++ b/src/components/TextListItem.tsx
@@ -112,7 +112,7 @@ export const TextListItem: NamedExoticComponent<Props> & {
           <Image
             source={{ uri: picture.url }}
             style={[styles.smallImage, withCard && styles.withBigCardStyle]}
-            borderRadius={withCard && normalize(8)}
+            borderRadius={withCard ? normalize(8) : undefined}
             containerStyle={styles.smallImageContainer}
           />
         ) : undefined)}

--- a/src/hooks/listHooks.js
+++ b/src/hooks/listHooks.js
@@ -98,6 +98,10 @@ export const useRenderItem = (query, navigation, options = {}) => {
     }
     case LIST_TYPES.CARD_TEXT_LIST: {
       renderItem = ({ item, index, section }) => {
+        if (query === QUERY_TYPES.EVENT_RECORDS && typeof item === 'string') {
+          return <EventSectionHeader {...{ item, navigation, options, query }} />;
+        }
+
         if (index === 0) {
           return (
             <CardListItem navigation={navigation} horizontal={options.horizontal} item={item} />


### PR DESCRIPTION
- added `EventSectionHeader` to `LIST_TYPES.CARD_TEXT_LIST` to fix the problem of header not appearing in `EventList` in text list type with big picture

SVA-1200

## Screenshots:

|before|after|
|--|--|
![Simulator Screenshot - iPhone 14 Pro - 2023-12-12 at 10 15 41](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/3ec7da22-062f-4634-b498-8393c1868042)|![image](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/78748304-4ff9-4ffc-b148-c189c4bfa8e2)
