### PR TITLE
feat: add link to checkbox on report screen

### DIFF
--- a/src/components/SUE/report/SueReportUser.tsx
+++ b/src/components/SUE/report/SueReportUser.tsx
@@ -58,6 +58,8 @@ export const SueReportUser = ({ control }: { control: any; errors: any }) => (
           <Checkbox
             checked={!!value}
             onPress={() => onChange(!value)}
+            link="https://smart-village.app/datenschutzerklaerung/"
+            linkDescription={texts.sue.report.termsOfService}
             title={`${texts.defectReport.inputCheckbox} *`}
             checkedColor={colors.accent}
             checkedIcon="check-square-o"

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -940,6 +940,7 @@ export const texts = {
       phone: 'Telefonnummer',
       sendReport: 'Meldung senden',
       street: 'Straße',
+      termsOfService: 'Datenschutzbestimmungen',
       title: 'Kurze Beschreibung',
       zipCode: 'Postleitzahl'
     }


### PR DESCRIPTION
- added `Link` prop to `Checkbox` component in `SueReportUser` to add a clickable link in the checkbox on the report screen

SUE-16

## Screenshots:

<img width="373" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/62652687-6803-4168-af6f-a7dac0e5174a">