### PR TITLE
feat: store data on the report screen

### DIFF
--- a/src/components/DeleteHeader.tsx
+++ b/src/components/DeleteHeader.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { StyleProp, TouchableOpacity, ViewStyle } from 'react-native';
+
+import { colors, consts, Icon, normalize } from '../config';
+
+const { a11yLabel } = consts;
+
+type Props = {
+  onPress?: () => void;
+  style: StyleProp<ViewStyle>;
+};
+
+export const DeleteHeader = ({ onPress, style }: Props) => (
+  <TouchableOpacity
+    onPress={onPress}
+    accessibilityLabel={a11yLabel.editIcon}
+    accessibilityHint={a11yLabel.editHint}
+  >
+    <Icon.Trash color={colors.lightestText} style={style} size={normalize(22)} />
+  </TouchableOpacity>
+);

--- a/src/components/HeaderRight.tsx
+++ b/src/components/HeaderRight.tsx
@@ -10,6 +10,7 @@ import { BookmarkHeader } from './bookmarks';
 import { CalendarHeader } from './CalendarHeader';
 import { ChatHeader } from './ChatHeader';
 import { DrawerHeader } from './DrawerHeader';
+import { DeleteHeader } from './DeleteHeader';
 import { EditHeader } from './EditHeader';
 import { GroupHeader } from './GroupHeader';
 import { ShareHeader } from './ShareHeader';
@@ -23,6 +24,7 @@ type Props = {
   withBookmark?: boolean;
   withChat?: boolean;
   withCalendar?: boolean;
+  withDelete?: boolean;
   withGroup?: boolean;
   withDrawer?: boolean;
   withEdit?: boolean;
@@ -37,6 +39,7 @@ export const HeaderRight = ({
   withBookmark = false,
   withChat = false,
   withCalendar = false,
+  withDelete = false,
   withGroup = false,
   withDrawer = false,
   withEdit = false,
@@ -46,6 +49,7 @@ export const HeaderRight = ({
     {withBookmark && <BookmarkHeader route={route} style={styles.icon} />}
     {withChat && <ChatHeader navigation={navigation} style={styles.icon} />}
     {withCalendar && <CalendarHeader navigation={navigation} style={styles.icon} />}
+    {withDelete && <DeleteHeader onPress={onPress} style={styles.icon} />}
     {withGroup && <GroupHeader navigation={navigation} style={styles.icon} />}
     {withEdit && <EditHeader onPress={onPress} style={styles.icon} />}
     {withShare && <ShareHeader shareContent={shareContent} style={styles.icon} />}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -33,6 +33,7 @@ export * from './CrossData';
 export * from './DataListSection';
 export * from './DataProviderButton';
 export * from './DateTimePicker';
+export * from './DeleteHeader';
 export * from './DefaultKeyboardAvoidingView';
 export * from './DiagonalGradient';
 export * from './Disturber';

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -914,6 +914,13 @@ export const texts = {
       alerts: {
         address: 'Bitte stellen Sie sicher, dass Sie Ihre Adressdaten korrekt eingeben',
         contact: 'Bitte stellen Sie sicher, dass Sie Ihre Kontaktdaten korrekt eingeben.',
+        dataDeleteAlert: {
+          cancel: 'Nein',
+          deleteButton: 'Löschen',
+          message: 'Sind Sie sicher, dass Sie die Daten löschen wollen?',
+          ok: 'Ja',
+          title: 'Daten löschen'
+        },
         hint: 'Hinweis',
         imageGreater10MBError: 'Das ausgewählte Bild darf maximal 10 MB groß sein.',
         imagesGreater30MBError:


### PR DESCRIPTION
- added the ability to write data to the device's memory with the `storeReportValues` function to prevent deletion of data when the user fills in a report screen, returns to the previous screen or closes and reopens the application
- added `setValue` in `readReportValuesFromStore` to add memorised data to inputs
- added delete button with `HeaderRight` to the right of the header to delete all saved data if any
- added `DeleteHeader` component to add delete button to the right of the header and added `withDelete` prop to `HeaderRight`
- added that if the report is sent successfully or if the user wants to delete the saved data, the `resetStoredValues` function is used to delete the saved data

SUE-28

## Screenshots:

|with Delete button|
|--|
![image](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/b3095fc7-ddad-4a51-94cb-585c538d7dc2)
