### PR TITLE
feat: add voucher categories list

### DIFF
--- a/src/components/TextListItem.tsx
+++ b/src/components/TextListItem.tsx
@@ -16,6 +16,7 @@ export type ItemData = {
   id: string;
   badge?: { value: string; textStyle: { color: string } };
   bottomDivider?: boolean;
+  count?: number;
   leftIcon?: React.ReactElement;
   onPress?: (navigation: any) => void;
   params: Record<string, unknown>;
@@ -48,6 +49,7 @@ export const TextListItem: NamedExoticComponent<Props> & {
   const {
     badge,
     bottomDivider,
+    count,
     leftIcon,
     onPress,
     params,
@@ -144,6 +146,8 @@ export const TextListItem: NamedExoticComponent<Props> & {
             containerStyle={styles.smallImageContainer}
           />
         ) : undefined)}
+
+      {!!count && <BoldText>{count}</BoldText>}
 
       {!!navigation && !withCard && (
         <Icon.ArrowRight color={colors.darkText} size={normalize(18)} />

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -316,7 +316,7 @@ const parseVolunteers = (data, query, skipLastDivider, withDate, isSectioned, cu
 };
 /* eslint-enable complexity */
 
-const parseVouchers = (data, skipLastDivider, withDate) => {
+const parseVouchers = (data, skipLastDivider) => {
   return data?.map((voucher, index) => ({
     routeName: ScreenName.VoucherDetail,
     params: {
@@ -329,6 +329,40 @@ const parseVouchers = (data, skipLastDivider, withDate) => {
     // TODO: update subtitle
     subtitle: 'Test',
     ...voucher,
+    bottomDivider: !skipLastDivider || index !== data.length - 1
+  }));
+};
+
+const parseVouchersCategories = (data, skipLastDivider) => {
+  const categoryCounts = {};
+
+  data.forEach((category) => {
+    category.categories.forEach((subCategory) => {
+      const categoryId = subCategory.id;
+      const categoryName = subCategory.name;
+
+      if (!categoryCounts[categoryId]) {
+        categoryCounts[categoryId] = {
+          name: categoryName,
+          count: 1
+        };
+      } else {
+        categoryCounts[categoryId].count += 1;
+      }
+    });
+  });
+
+  return Object.keys(categoryCounts).map((categoryId, index) => ({
+    id: categoryId,
+    title: categoryCounts[categoryId].name,
+    count: categoryCounts[categoryId].count,
+    routeName: ScreenName.VoucherIndex,
+    params: {
+      title: categoryCounts[categoryId].name,
+      query: QUERY_TYPES.VOUCHERS,
+      queryVariables: {},
+      rootRouteName: ROOT_ROUTE_NAMES.VOUCHER
+    },
     bottomDivider: !skipLastDivider || index !== data.length - 1
   }));
 };
@@ -460,7 +494,9 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
     case QUERY_TYPES.VOLUNTEER.PROFILE:
       return parseVolunteers(data, query, skipLastDivider);
     case QUERY_TYPES.VOUCHERS:
-      return parseVouchers(data[query], skipLastDivider, withDate);
+      return parseVouchers(data[query], skipLastDivider);
+    case QUERY_TYPES.VOUCHERS_CATEGORIES:
+      return parseVouchersCategories(data[QUERY_TYPES.VOUCHERS], skipLastDivider);
     case QUERY_TYPES.CONSUL.DEBATES:
     case QUERY_TYPES.CONSUL.PROPOSALS:
     case QUERY_TYPES.CONSUL.POLLS:

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -43,7 +43,7 @@ import {
   posts,
   user
 } from './volunteer';
-import { GET_VOUCHER, GET_VOUCHERS } from './vouchers';
+import { GET_VOUCHER, GET_VOUCHERS, GET_VOUCHERS_CATEGORIES } from './vouchers';
 import { WASTE_ADDRESSES, WASTE_STREET } from './waste';
 import { GET_WEATHER, GET_WEATHER_CURRENT } from './weather';
 
@@ -78,6 +78,7 @@ export const getQuery = (query, filterOptions = {}) => {
     [QUERY_TYPES.WASTE_ADDRESSES]: WASTE_ADDRESSES,
     [QUERY_TYPES.WASTE_STREET]: WASTE_STREET,
     [QUERY_TYPES.VOUCHERS]: GET_VOUCHERS,
+    [QUERY_TYPES.VOUCHERS_CATEGORIES]: GET_VOUCHERS_CATEGORIES,
     [QUERY_TYPES.VOUCHER]: GET_VOUCHER,
     [QUERY_TYPES.WEATHER_MAP]: GET_WEATHER,
     [QUERY_TYPES.WEATHER_MAP_CURRENT]: GET_WEATHER_CURRENT,

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -75,6 +75,7 @@ export const QUERY_TYPES = {
     USERS: 'volunteerUsers'
   } as const,
   VOUCHERS: 'vouchers',
+  VOUCHERS_CATEGORIES: 'vouchersCategories',
   VOUCHER: 'voucher',
   WASTE_ADDRESSES: 'wasteAddresses',
   WASTE_STREET: 'wasteStreet',

--- a/src/queries/vouchers.js
+++ b/src/queries/vouchers.js
@@ -77,3 +77,14 @@ export const GET_VOUCHER = gql`
     }
   }
 `;
+
+export const GET_VOUCHERS_CATEGORIES = gql`
+  query Vouchers {
+    vouchers {
+      categories {
+        name
+        id
+      }
+    }
+  }
+`;

--- a/src/screens/Voucher/VoucherIndexScreen.tsx
+++ b/src/screens/Voucher/VoucherIndexScreen.tsx
@@ -23,11 +23,14 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
   const [refreshing, setRefreshing] = useState(false);
 
   const query = route.params?.query ?? '';
+  const queryVariables = route.params?.queryVariables ?? {};
 
-  const { data, loading, fetchMore, refetch } = useQuery(getQuery(query), { fetchPolicy });
-
+  const { data, loading, fetchMore, refetch } = useQuery(getQuery(query), {
+    fetchPolicy,
+    variables: queryVariables
+  });
   const listItems = useMemo(() => {
-    return parseListItemsFromQuery(QUERY_TYPES.VOUCHERS, data, undefined, {
+    return parseListItemsFromQuery(query, data, undefined, {
       withDate: false
     });
   }, [data, query]);
@@ -69,13 +72,17 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
       // TODO: replace with dropdown filter & login component here
       ListHeaderComponent={
         <>
-          <Wrapper>
-            <RegularText>Add dropdown Filter Here</RegularText>
-          </Wrapper>
+          {query === QUERY_TYPES.VOUCHERS && (
+            <>
+              <Wrapper>
+                <RegularText>Add dropdown Filter Here</RegularText>
+              </Wrapper>
 
-          <Wrapper>
-            <RegularText>Add dropdown login component here</RegularText>
-          </Wrapper>
+              <Wrapper>
+                <RegularText>Add dropdown login component here</RegularText>
+              </Wrapper>
+            </>
+          )}
         </>
       }
       ListEmptyComponent={


### PR DESCRIPTION
- added `GET_VOUCHERS_CATEGORIES` query to list only the category information of the voucher
- added `parseVouchersCategories` parser to `listItemParser` so that we can show the category list of the voucher in the format we want
- changed query in `parseListItemsFromQuery` to parse voucher category in `VoucherIndexScreen`
- added control in `ListHeaderComponent` to show only query value in `Vouchers`
- added count to `TextListItem` to show how many vouchers are in which category of the voucher on the list

SVAK-35

## Screenshots:

|VoucherIndexScreen `query === vouchers`|VoucherIndexScreen `query === vouchersCategories`|
|--|--|
![Simulator Screenshot - iPhone 14 Pro - 2024-01-09 at 14 47 40](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/b94adca4-d153-4f0d-a311-3399230fb41c)|![Simulator Screenshot - iPhone 14 Pro - 2024-01-09 at 14 47 43](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/5751219f-d7a6-42be-8d23-bb3ddea63032)
