### PR TITLE
feat: integrate generic item query

### DIFF
--- a/src/components/vouchers/VoucherList.tsx
+++ b/src/components/vouchers/VoucherList.tsx
@@ -15,7 +15,7 @@ const sectionData = (data: TVoucherItem[]) => {
   const groupDataByCategory = (data: TVoucherItem[]) => {
     const grouped = {};
 
-    data.forEach((item: TVoucherItem) => {
+    data?.forEach((item: TVoucherItem) => {
       if (item.categories?.length) {
         if (!grouped[item.categories[0].name]) {
           grouped[item.categories[0].name] = [];

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -495,9 +495,9 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
     case QUERY_TYPES.VOLUNTEER.PROFILE:
       return parseVolunteers(data, query, skipLastDivider);
     case QUERY_TYPES.VOUCHERS:
-      return parseVouchers(data[query], skipLastDivider);
+      return parseVouchers(data[QUERY_TYPES.GENERIC_ITEMS], skipLastDivider);
     case QUERY_TYPES.VOUCHERS_CATEGORIES:
-      return parseVouchersCategories(data[QUERY_TYPES.VOUCHERS], skipLastDivider);
+      return parseVouchersCategories(data[QUERY_TYPES.GENERIC_ITEMS], skipLastDivider);
     case QUERY_TYPES.CONSUL.DEBATES:
     case QUERY_TYPES.CONSUL.PROPOSALS:
     case QUERY_TYPES.CONSUL.POLLS:

--- a/src/queries/vouchers.ts
+++ b/src/queries/vouchers.ts
@@ -5,12 +5,33 @@ import { VoucherLogin } from '../types';
 
 // TODO: memberId: 1 will be updated later. 1 will be replaced by the id of the logged in user
 export const GET_VOUCHERS = gql`
-  query Vouchers($limit: Int, $order: GenericItemOrder) {
-    vouchers(limit: $limit, order: $order) {
+  query GenericItems(
+    $ids: [ID]
+    $limit: Int
+    $offset: Int
+    $order: GenericItemOrder
+    $dataProvider: String
+    $categoryId: ID
+  ) {
+    genericItems(
+      ids: $ids
+      limit: $limit
+      skip: $offset
+      order: $order
+      dataProvider: $dataProvider
+      categoryId: $categoryId
+      genericType: "Voucher"
+    ) {
+      id
+      updatedAt
+      createdAt
+      publishedAt
+      genericType
       id
       title
       categories {
         name
+        id
       }
       discountType {
         originalPrice
@@ -31,6 +52,8 @@ export const GET_VOUCHERS = gql`
         title
         intro
         body
+        updatedAt
+        createdAt
       }
       dates {
         id
@@ -44,8 +67,8 @@ export const GET_VOUCHERS = gql`
 `;
 
 export const GET_VOUCHER = gql`
-  query Voucher($id: ID!) {
-    voucher(id: $id) {
+  query GenericItem($id: ID!) {
+    genericItem(id: $id) {
       id
       title
       categories {
@@ -83,8 +106,8 @@ export const GET_VOUCHER = gql`
 `;
 
 export const GET_VOUCHERS_CATEGORIES = gql`
-  query Vouchers {
-    vouchers {
+  query GenericItems {
+    genericItems(genericType: "Voucher") {
       categories {
         name
         id

--- a/src/screens/Voucher/VoucherDetailScreen.tsx
+++ b/src/screens/Voucher/VoucherDetailScreen.tsx
@@ -43,7 +43,7 @@ export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
     return <LoadingSpinner loading />;
   }
 
-  const { contentBlocks, discountType, quota } = data[query];
+  const { contentBlocks, discountType, quota } = data[QUERY_TYPES.GENERIC_ITEM];
   const { availableQuantity, frequency, maxPerPerson, maxQuantity } = quota;
 
   return (


### PR DESCRIPTION
- updated `vouchers` query with `genericItems` as `vouchers` query is no longer in use
- added controls to prevent the application from crashing if the data is undefined

SVAK-35