### PR TITLE
fix: map pixelation problem on android

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -117,6 +117,7 @@ export const Map = ({
         }}
       >
         <UrlTile
+          doubleTileSize={device.platform === 'android'}
           urlTemplate="https://tile-server.sva-services.customer.planetary-quantum.net/tile/{z}/{x}/{y}.png"
           shouldReplaceMapContent={device.platform === 'ios'}
         />


### PR DESCRIPTION
- added `doubleTileSize` prop to `UrlTile` component to solve the pixelation problem of the map in android
  - https://github.com/react-native-maps/react-native-maps/blob/master/docs/tiles.md

SUE-27

Since this feature is standard on iOS, there is no pixelation problem on the iOS platform. In order to solve the pixelation problem on Android, doubleTileSize has been activated only for android devices.

## Screenshots:

|before|after|
|--|--|
![Screenshot (18 01 2024 13_25_53)](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/51bf1a79-51dc-4d8f-836f-824128910fae)|![Screenshot (18 01 2024 14_33_25)](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/c6c0c8db-7698-403e-bc4b-d143a46799a2)
