### PR TITLE
chore: add `@expo/vector-icons` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@apollo/react-hooks": "~3.1.5",
+    "@expo/vector-icons": "14.0.0",
     "@native-html/iframe-plugin": "^2.6.1",
     "@native-html/table-plugin": "^5.3.1",
     "@react-native-async-storage/async-storage": "1.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,11 @@
   dependencies:
     cross-spawn "^7.0.3"
 
+"@expo/vector-icons@14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-14.0.0.tgz#48ce0aa5c05873b07c0c78bfe16c870388f4de9a"
+  integrity sha512-5orm59pdnBQlovhU9k4DbjMUZBHNlku7IRgFY56f7pcaaCnXq9yaLJoOQl9sMwNdFzf4gnkTyHmR5uN10mI9rA==
+
 "@expo/vector-icons@^13.0.0":
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-13.0.0.tgz#e2989b85e95a82bce216f88cf8fb583ab050ec95"


### PR DESCRIPTION
- added version 14 of the `@expo/vector-icons` package to be able to use the newly added icon packages

https://github.com/expo/vector-icons

icon packages:
<img width="1300" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/d0c4ecc7-f44d-4037-99a3-712493122126">
