### PR TITLE
fix: tile appearance

### DIFF
--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -22,7 +22,7 @@ const renderCardContent = (item, horizontal) => {
       !!picture?.url && (
         <Image
           source={{ uri: picture.url }}
-          style={stylesWithProps({ horizontal }).image}
+          childrenContainerStyle={stylesWithProps({ horizontal }).image}
           containerStyle={[styles.imageContainer, imageStyle]}
           borderRadius={imageBorderRadius}
         />

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -250,7 +250,7 @@ const renderFooter = (medias, setMedias) => (
               borderRadius={normalize(4)}
               resizeMode="cover"
               source={{ uri }}
-              style={styles.mediaPreview}
+              childrenContainerStyle={styles.mediaPreview}
             />
           )}
           {type === 'video' && (

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -105,9 +105,7 @@ export const Image = ({
     <View>
       <RNEImage
         source={source}
-        childrenContainerStyle={
-          childrenContainerStyle || style || stylesForImage(aspectRatio).defaultStyle
-        }
+        childrenContainerStyle={childrenContainerStyle || stylesForImage(aspectRatio).defaultStyle}
         containerStyle={containerStyle}
         style={style}
         PlaceholderContent={PlaceholderContent}

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -30,6 +30,7 @@ export const Image = ({
   aspectRatio,
   borderRadius,
   button,
+  childrenContainerStyle,
   containerStyle,
   message,
   PlaceholderContent,
@@ -104,7 +105,9 @@ export const Image = ({
     <View>
       <RNEImage
         source={source}
-        childrenContainerStyle={style || stylesForImage(aspectRatio).defaultStyle}
+        childrenContainerStyle={
+          childrenContainerStyle || style || stylesForImage(aspectRatio).defaultStyle
+        }
         containerStyle={containerStyle}
         style={style}
         PlaceholderContent={PlaceholderContent}
@@ -161,6 +164,7 @@ Image.propTypes = {
   aspectRatio: PropTypes.object,
   borderRadius: PropTypes.number,
   button: PropTypes.object,
+  childrenContainerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   message: PropTypes.string,
   PlaceholderContent: PropTypes.object,

--- a/src/components/TextListItem.tsx
+++ b/src/components/TextListItem.tsx
@@ -111,7 +111,7 @@ export const TextListItem: NamedExoticComponent<Props> & {
         (leftImage && !!picture?.url ? (
           <Image
             source={{ uri: picture.url }}
-            style={styles.smallImage}
+            childrenContainerStyle={styles.smallImage}
             borderRadius={normalize(8)}
             containerStyle={styles.smallImageContainer}
           />
@@ -139,7 +139,7 @@ export const TextListItem: NamedExoticComponent<Props> & {
         (rightImage && !!picture?.url ? (
           <Image
             source={{ uri: picture.url }}
-            style={styles.smallImage}
+            childrenContainerStyle={styles.smallImage}
             borderRadius={normalize(8)}
             containerStyle={styles.smallImageContainer}
           />

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -152,7 +152,7 @@ export const ImageSelector = ({ control, errorType, field, imageId, isMultiImage
       {values.length ? (
         <>
           <WrapperRow center spaceBetween>
-            <Image source={{ uri: values[0].uri }} style={styles.image} />
+            <Image source={{ uri: values[0].uri }} childrenContainerStyle={styles.image} />
 
             <TouchableOpacity onPress={() => deleteImageAlert(() => onDeleteImage(0))}>
               <Icon.Trash color={colors.error} size={normalize(16)} />

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -84,7 +84,7 @@ export const ServiceTile = ({
           ) : (
             <Image
               source={{ uri: item.icon || item.tile }}
-              containerStyle={[
+              childrenContainerStyle={[
                 styles.serviceImage,
                 !!item.tile &&
                   stylesWithProps({

--- a/src/components/weather/DailyWeather.tsx
+++ b/src/components/weather/DailyWeather.tsx
@@ -40,7 +40,7 @@ export const DailyWeather = ({ date, description, icon, temperatures }: Props) =
                   uri: `https://openweathermap.org/img/wn/${icon}@2x.png`,
                   captionText: description
                 }}
-                style={styles.icon}
+                childrenContainerStyle={styles.icon}
                 resizeMode="contain"
               />
             </View>

--- a/src/components/widgets/DefaultWidget.tsx
+++ b/src/components/widgets/DefaultWidget.tsx
@@ -27,7 +27,7 @@ export const DefaultWidget = ({ Icon, count, onPress, text, image }: Props) => {
           {image?.uri ? (
             <Image
               source={image}
-              style={{
+              childrenContainerStyle={{
                 height: normalize(image?.height ?? 26),
                 width: normalize(image?.width ?? 33)
               }}

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -47,7 +47,7 @@ export const WeatherWidget = ({ text }: WidgetProps) => {
                 uri: `https://openweathermap.org/img/wn/${icon}@2x.png`,
                 captionText: description
               }}
-              style={styles.icon}
+              childrenContainerStyle={styles.icon}
               resizeMode="contain"
             />
           </View>


### PR DESCRIPTION
- added `childrenContainerStyle` instead of `containerStyle` to `Image` component in `ServiceTile` to increase the space between tiles
- added `childrenContainerStyle` prop to avoid style confusion in `Image` component

SVA-1256

## Screenshots:

|before|after|
|--|--|
![Simulator Screenshot - iPhone 14 Pro Max - 2024-01-26 at 13 44 09](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/e3f0a6cb-a3e3-4ac3-8135-66c0f66564de)|![Simulator Screenshot - iPhone 14 Pro Max - 2024-01-26 at 13 44 00](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/5bb9c002-46e2-489a-b8e5-1a746d1fe02e)