### PR TITLE
fix: failure to delete stored image file

### DIFF
--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -104,6 +104,7 @@ export const SueReportScreen = ({
   const [currentProgress, setCurrentProgress] = useState(0);
   const [serviceCode, setServiceCode] = useState<string>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoadingStoredData, setIsLoadingStoredData] = useState<boolean>(true);
   const [selectedPosition, setSelectedPosition] = useState<Location.LocationObjectCoords>();
   const [isDone, setIsDone] = useState(false);
   const [storedValues, setStoredValues] = useState<TReports>();
@@ -241,6 +242,8 @@ export const SueReportScreen = ({
       setValue('title', storedValues.title);
       setValue('zipCode', storedValues.zipCode);
     }
+
+    setIsLoadingStoredData(false);
   };
 
   const resetStoredValues = async () => {
@@ -318,7 +321,7 @@ export const SueReportScreen = ({
     }
   }, [storedValues, serviceCode, selectedPosition]);
 
-  if (loading) {
+  if (loading || isLoadingStoredData) {
     return (
       <LoadingContainer>
         <ActivityIndicator color={colors.refreshControl} />


### PR DESCRIPTION
- added `isLoadingStoredData` to `SueReportScreen` to fix the bug where stored images could not be deleted because the `Image` component renders before the stored images are read from the store, and ensured that the `Image` component does not render before the stored images are read from the store

SUE-28
