### PR TITLE
feat: take a photo with the camera

### DIFF
--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -8,7 +8,7 @@ import { colors, consts, Icon, normalize, texts } from '../../../config';
 import { ConsulClient } from '../../../ConsulClient';
 import { deleteArrayItem, errorTextGenerator, jsonParser } from '../../../helpers';
 import { imageHeight, imageWidth } from '../../../helpers/imageHelper';
-import { useSelectImage } from '../../../hooks';
+import { useCaptureImage, useSelectImage } from '../../../hooks';
 import { DELETE_IMAGE } from '../../../queries/consul';
 import { calendarDeleteFile } from '../../../queries/volunteer';
 import { Button } from '../../Button';
@@ -36,6 +36,26 @@ const deleteImageAlert = (onPress) =>
     ]
   );
 
+const selectImageSourceAlert = (imageSelect, imageCapture) =>
+  Alert.alert(
+    texts.sue.report.alerts.imageSelectAlert.title,
+    texts.sue.report.alerts.imageSelectAlert.description,
+    [
+      {
+        text: texts.sue.report.alerts.imageSelectAlert.cancel,
+        style: 'cancel'
+      },
+      {
+        text: texts.sue.report.alerts.imageSelectAlert.gallery,
+        onPress: imageSelect
+      },
+      {
+        text: texts.sue.report.alerts.imageSelectAlert.camera,
+        onPress: imageCapture
+      }
+    ]
+  );
+
 export const ImageSelector = ({
   control,
   errorType,
@@ -58,6 +78,13 @@ export const ImageSelector = ({
   const { selectImage } = useSelectImage(
     undefined, // onChange
     false, // allowsEditing,
+    undefined, // aspect,
+    undefined // quality
+  );
+
+  const { captureImage } = useCaptureImage(
+    undefined, // onChange
+    true, // allowsEditing,
     undefined, // aspect,
     undefined // quality
   );
@@ -95,8 +122,8 @@ export const ImageSelector = ({
     setInfoAndErrorText(deleteArrayItem(infoAndErrorText, index));
   };
 
-  const imageSelect = async () => {
-    const { uri, type } = await selectImage();
+  const imageSelect = async (imageFunction = selectImage) => {
+    const { uri, type } = await imageFunction();
     const { size } = await FileSystem.getInfoAsync(uri);
 
     /* used to specify the mimeType when uploading to the server */
@@ -118,7 +145,12 @@ export const ImageSelector = ({
         <>
           <Input {...item} control={control} hidden name={name} value={JSON.parse(value)} />
 
-          <Button disabled={values?.length >= 5} invert onPress={imageSelect} title={buttonTitle} />
+          <Button
+            disabled={values?.length >= 5}
+            invert
+            onPress={() => selectImageSourceAlert(imageSelect, () => imageSelect(captureImage))}
+            title={buttonTitle}
+          />
 
           {!!infoText && (
             <RegularText small style={styles.sueInfoText}>

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -84,7 +84,7 @@ export const ImageSelector = ({
 
   const { captureImage } = useCaptureImage(
     undefined, // onChange
-    true, // allowsEditing,
+    false, // allowsEditing,
     undefined, // aspect,
     undefined // quality
   );

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -77,15 +77,15 @@ export const ImageSelector = ({
 
   const { selectImage } = useSelectImage(
     undefined, // onChange
-    false, // allowsEditing,
-    undefined, // aspect,
+    false, // allowsEditing
+    selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1], // aspect
     undefined // quality
   );
 
   const { captureImage } = useCaptureImage(
     undefined, // onChange
-    false, // allowsEditing,
-    undefined, // aspect,
+    false, // allowsEditing
+    selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1], // aspect
     undefined // quality
   );
 

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -925,6 +925,14 @@ export const texts = {
         imageGreater10MBError: 'Das ausgewählte Bild darf maximal 10 MB groß sein.',
         imagesGreater30MBError:
           'Die ausgewählten Bilder dürfen insgesamt nicht größer als 30 MB sein.',
+        imageSelectAlert: {
+          camera: 'Kamera',
+          cancel: 'Abbrechen',
+          description:
+            'Möchten Sie ein Bild mit der Kamera aufnehmen oder aus der Galerie auswählen?',
+          gallery: 'Galerie',
+          title: 'Bildquelle auswählen'
+        },
         location: 'Bitte wählen Sie einen Ort auf der Karte aus.',
         serviceCode: 'Bitte wählen Sie aus, um welches Thema es in dem Bericht geht.',
         termsOfService: 'Bitte akzeptieren Sie die Datenschutzbestimmungen.',

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -1,7 +1,9 @@
 import {
+  launchCameraAsync,
   launchImageLibraryAsync,
   MediaTypeOptions,
   PermissionStatus,
+  requestCameraPermissionsAsync,
   requestMediaLibraryPermissionsAsync
 } from 'expo-image-picker';
 import { useCallback, useState } from 'react';
@@ -44,4 +46,41 @@ export const useSelectImage = (
   }, [onChange]);
 
   return { imageUri, selectImage };
+};
+
+export const useCaptureImage = (
+  onChange?: <T>(
+    setter: React.Dispatch<React.SetStateAction<T>>
+  ) => React.Dispatch<React.SetStateAction<T>>,
+  allowsEditing?: boolean,
+  aspect?: [number, number],
+  quality?: number,
+  mediaTypes?: MediaTypeOptions
+) => {
+  const [imageUri, setImageUri] = useState<string>();
+
+  const captureImage = useCallback(async () => {
+    const { status } = await requestCameraPermissionsAsync();
+
+    if (status !== PermissionStatus.GRANTED) {
+      Alert.alert(texts.errors.image.title, texts.errors.image.body);
+      return;
+    }
+
+    // this allows for proper selecting and cropping to 1:1 images (and not videos)
+    // for more details about options see: https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickermediatypeoptions
+    const result = await launchCameraAsync({
+      mediaTypes: mediaTypes ?? MediaTypeOptions.Images,
+      allowsEditing: allowsEditing ?? true,
+      aspect: aspect ?? [1, 1],
+      quality: quality ?? 1
+    });
+
+    if (!result.canceled) {
+      onChange ? onChange(setImageUri)(result.assets[0].uri) : setImageUri(result.assets[0].uri);
+      return result.assets[0];
+    }
+  }, [onChange]);
+
+  return { imageUri, captureImage };
 };

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -34,8 +34,8 @@ export const useSelectImage = (
     // for more details about options see: https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickermediatypeoptions
     const result = await launchImageLibraryAsync({
       mediaTypes: mediaTypes ?? MediaTypeOptions.Images,
-      allowsEditing: allowsEditing ?? true,
-      aspect: aspect ?? [1, 1],
+      allowsEditing: allowsEditing ?? false,
+      aspect,
       quality: quality ?? 1
     });
 
@@ -71,8 +71,8 @@ export const useCaptureImage = (
     // for more details about options see: https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickermediatypeoptions
     const result = await launchCameraAsync({
       mediaTypes: mediaTypes ?? MediaTypeOptions.Images,
-      allowsEditing: allowsEditing ?? true,
-      aspect: aspect ?? [1, 1],
+      allowsEditing: allowsEditing ?? false,
+      aspect,
       quality: quality ?? 1
     });
 


### PR DESCRIPTION
- added `useCaptureImage` to `imagePicker` to take a photo with the camera
- added alert to select image from gallery or camera
- added `useCaptureImage` to be able to run the camera
- added `imageFunction` prop to `imageSelect` function to avoid code repetition and made it work with the function sent with the prop
- updated `imageSelect` `onPress` in `Button` component with `secImageSourceAlert`

SUE-31

## How to test:
* [x] Android
* [x] iOS


## Screenshots:

|image source select alert|camera screen|image edit screen|show a photo taken from the camera|
|--|--|--|--|
![IMG_6784](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/0fea3198-9c0b-4d89-8365-04d2e98fd63c)|![IMG_6785](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/708abac3-1a28-4000-b42c-2c6cf7460415)|![IMG_6786](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/93542618-6616-4401-9f8e-2d42a52acacf)|![IMG_6787](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/3e2e5224-a664-4134-9def-a13e1e4357ad)
