### PR TITLE
feat: remove logo on the map

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -106,7 +106,7 @@ export const Map = ({
         mapPadding={{
           top: 0,
           right: 0,
-          bottom: -normalize(30),
+          bottom: normalize(device.height * 2),
           left: 0
         }}
         legalLabelInsets={{


### PR DESCRIPTION
- added bottom value in `mapPadding` as twice the `height` of the device to remove the logo displayed on the map

SUE-33

Since the bottom value could never take a negative value, the `-normalize(30)` value was not working. For this reason, the bottom value was set to twice the height of the device and the logo was made invisible on the screen of the device.

## How to test:
* [x] Android portrait mode
* [x] Android landscape mode


## Screenshots:

|before|after|
|--|--|
![Screenshot_20240129-142458](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/ee40bd73-dfef-4010-b76c-4d169dfea16d)|![Screenshot_20240129-142440](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/3095b5d2-e46d-42c1-ba4e-d92ba6730b6c)

