### PR TITLE
fix: app crashes when selecting location from map

### DIFF
--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -137,7 +137,7 @@ export const SueReportLocation = ({
           ])
         }
         onMapPress={({ nativeEvent }) => {
-          setUpdatedRegion(true);
+          setUpdatedRegion(false);
           setSelectedPosition(nativeEvent.coordinate);
           reverseGeocode(nativeEvent.coordinate);
         }}

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -141,7 +141,11 @@ export const SueReportLocation = ({
           setSelectedPosition(nativeEvent.coordinate);
           reverseGeocode(nativeEvent.coordinate);
         }}
-        updatedRegion={selectedPosition && updatedRegion ? { ...selectedPosition } : undefined}
+        updatedRegion={
+          !!selectedPosition && updatedRegion
+            ? { ...selectedPosition, latitudeDelta: 0.01, longitudeDelta: 0.01 }
+            : undefined
+        }
       />
 
       <Wrapper>

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -7,6 +7,7 @@ import { colors, device, Icon, normalize } from '../../config';
 import { imageHeight, imageWidth } from '../../helpers';
 import { SettingsContext } from '../../SettingsProvider';
 import { MapMarker } from '../../types';
+import { RegularText } from '../Text';
 
 type Props = {
   geometryTourData?: LatLng[];
@@ -42,6 +43,7 @@ const MapIcon = ({
   return <MarkerIcon color={iconColor} size={iconSize} />;
 };
 
+/* eslint-disable complexity */
 export const Map = ({
   geometryTourData,
   isMaximizeButtonVisible = false,
@@ -111,7 +113,7 @@ export const Map = ({
         mapPadding={{
           top: 0,
           right: 0,
-          bottom: normalize(device.height * 2),
+          bottom: -normalize(30),
           left: 0
         }}
         legalLabelInsets={{
@@ -134,7 +136,6 @@ export const Map = ({
             zIndex={1}
           />
         )}
-        {/* eslint-disable complexity */}
         {locations?.map((marker, index) => {
           const isActiveMarker = selectedMarker && marker.id === selectedMarker;
 
@@ -197,7 +198,6 @@ export const Map = ({
             </Marker>
           );
         })}
-        {/* eslint-enable complexity */}
       </MapView>
       {isMaximizeButtonVisible && (
         <TouchableOpacity style={styles.maximizeMapButton} onPress={onMaximizeButtonPress}>
@@ -209,9 +209,15 @@ export const Map = ({
           <Icon.GPS size={normalize(18)} />
         </TouchableOpacity>
       )}
+      {device.platform === 'android' && (
+        <View style={styles.logoContainer}>
+          <RegularText smallest>© OpenStreetMap</RegularText>
+        </View>
+      )}
     </View>
   );
 };
+/* eslint-enable complexity */
 
 const styles = StyleSheet.create({
   container: {
@@ -219,6 +225,17 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surface,
     flex: 1,
     justifyContent: 'center'
+  },
+  logoContainer: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    bottom: 0,
+    height: normalize(30),
+    justifyContent: 'center',
+    left: normalize(13),
+    position: 'absolute',
+    width: normalize(90),
+    zIndex: 1
   },
   mapIconOnLocationMarker: {
     backgroundColor: colors.primary,

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -234,8 +234,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     left: normalize(13),
     position: 'absolute',
-    width: normalize(90),
-    zIndex: 1
+    width: normalize(100)
   },
   mapIconOnLocationMarker: {
     backgroundColor: colors.primary,


### PR DESCRIPTION
- reverted `bottom` in `mapPadding` to fix bounce bug when selecting location on map
- added `OpenStreetMap` text only for android platform to cover the google logo that appears on android devices
- added `latitudeDelta` and `longitudeDelta` values to solve the delta error that causes the application to crash when the location is selected from the map on android devices

SUE-32

## Screenshots:

|before|after|
|--|--|
![Screenshot (31 01 2024 11_30_13)](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/5c7a9f8e-27b2-4e59-9d72-86bba370f40c)|![Screenshot (31 01 2024 10_30_54)](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/e6e4dfeb-e949-49d7-8c50-6fe272c9436a)