### PR TITLE
feat(sue): update react-query usage

### DIFF
--- a/src/queries/SUE/requests.tsx
+++ b/src/queries/SUE/requests.tsx
@@ -3,8 +3,11 @@ import _mapKeys from 'lodash/mapKeys';
 
 import { apiKey, jurisdictionId, sueFetchObj, suePostRequest, sueRequestsUrl } from '../../helpers';
 
-export const requests = async () => {
-  const response = await (await fetch(`${sueRequestsUrl}`, sueFetchObj)).json();
+export const requests = async (queryVariables) => {
+  const queryParams = new URLSearchParams(queryVariables);
+  const response = await (
+    await fetch(`${sueRequestsUrl}&${queryParams.toString()}`, sueFetchObj)
+  ).json();
 
   return new Promise((resolve) => {
     // return with converted keys to camelCase for being accessible per JavaScript convention

--- a/src/screens/SUE/SueListScreen.tsx
+++ b/src/screens/SUE/SueListScreen.tsx
@@ -3,7 +3,7 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useContext, useMemo, useState } from 'react';
 import { ActivityIndicator, RefreshControl } from 'react-native';
-import { useQuery } from 'react-query';
+import { useInfiniteQuery } from 'react-query';
 
 import { NetworkContext } from '../../NetworkProvider';
 import { SettingsContext } from '../../SettingsProvider';
@@ -27,18 +27,29 @@ export const SueListScreen = ({ navigation, route }: Props) => {
   const { globalSettings } = useContext(SettingsContext);
   const { appDesignSystem = {} } = globalSettings;
   const query = route.params?.query ?? '';
-  const queryVariables = route.params?.queryVariables ?? {};
+  const queryVariables = route.params?.queryVariables ?? { offset: 0, limit: 10000 };
   const [refreshing, setRefreshing] = useState(false);
 
-  const { data, isLoading, refetch } = useQuery([query, queryVariables], () =>
-    getQuery(query)(queryVariables)
+  const { data, fetchNextPage, hasNextPage, isLoading, refetch } = useInfiniteQuery(
+    [query, queryVariables],
+    ({ pageParam }) => getQuery(query)({ ...queryVariables, offset: pageParam || 0 }),
+    {
+      getNextPageParam: (lastPage, allPages) => {
+        if (lastPage?.length === 0) return; // no more pages
+
+        // increment offset for the next page
+        return (allPages?.length || 1) * queryVariables.limit;
+      }
+    }
   );
 
+  const dataPages = data?.pages?.flat() || [];
+
   const listItems = useMemo(() => {
-    if (data?.length) {
-      return parseListItemsFromQuery(query, data, undefined, { appDesignSystem });
-    }
-  }, [data, query, queryVariables]);
+    if (!dataPages?.length) return [];
+
+    return parseListItemsFromQuery(query, dataPages, undefined, { appDesignSystem }).reverse();
+  }, [dataPages, query, queryVariables]);
 
   if (isLoading) {
     return (
@@ -59,7 +70,8 @@ export const SueListScreen = ({ navigation, route }: Props) => {
       <ListComponent
         navigation={navigation}
         query={query}
-        data={listItems.reverse()}
+        data={listItems}
+        fetchMoreData={hasNextPage ? fetchNextPage : undefined}
         ListFooterLoadingIndicator={SueLoadingIndicator}
         refreshControl={
           <RefreshControl


### PR DESCRIPTION
- added possibility to pass params to the fetch for requests
- refactored `useQuery` to `useInfiniteQuery` to be able to paginate
- set limit to 10000 to ensure loading "all" requests, as we cannot use pagination, because the response isn't sorted with latest first
  - we need to reverse the result manually, which contradicts infinite scroll
- added workaround on map screen to avoid rendering problems with images
  - there were images of one case shown at a different case while loading the right image
  - now we will see the loading indicator after a short reload of the overlay
- fixed image component style
- moved `reverse` in the list items `useMemo` hook to avoid unnecessary renderings caused by list items not being reversed before
- renamed `selectedRequest` to `selectedRequestId` as it is a state for a requests id

SUE-39