### PR TITLE
fix: unable to edit tile error

### DIFF
--- a/src/components/screens/Service.tsx
+++ b/src/components/screens/Service.tsx
@@ -15,7 +15,25 @@ import { WrapperWrap } from '../Wrapper';
 import { DraggableGrid } from './DraggableGrid';
 import { ServiceTile, TServiceTile } from './ServiceTile';
 
-const { MATOMO_TRACKING } = consts;
+const { MATOMO_TRACKING, UMLAUT_REGEX } = consts;
+
+const umlautSwitcher = (text: string) => {
+  if (!text) return;
+
+  const umlautReplacements = {
+    ü: 'ue',
+    ä: 'ae',
+    ö: 'oe',
+    Ü: 'UE',
+    Ä: 'AE',
+    Ö: 'OE',
+    ß: 'ss'
+  };
+
+  const replacedText = text.replace(UMLAUT_REGEX, (match: string) => umlautReplacements[match]);
+
+  return replacedText;
+};
 
 export const Service = ({
   data,
@@ -55,7 +73,7 @@ export const Service = ({
   const renderItem = useCallback(
     (item: TServiceTile, index: number) => (
       <ServiceTile
-        draggableId={item.title || item.accessibilityLabel}
+        draggableId={umlautSwitcher(item.title) || umlautSwitcher(item.accessibilityLabel)}
         hasDiagonalGradientBackground={hasDiagonalGradientBackground}
         isEditMode={isEditMode}
         item={item}

--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -77,6 +77,7 @@ export const consts = {
   URL_REGEX:
     /^https?:\/\/(?:www\.)?[-a-z0-9@:%._\+~#=]{1,256}\.[a-z0-9()]{1,6}\b(?:[-a-z0-9()@:%_\+.~#?&\/=]*)$/i,
   VIDEO_TYPE_REGEX: /\.(swf|avi|flv|mpg|rm|mov|wav|asf|3gp|mkv|rmvb|mp4)$/i,
+  UMLAUT_REGEX: /[üäöÜÄÖß]/g,
 
   CALENDAR: {
     DOT_SIZE: 6,


### PR DESCRIPTION
- created `UMLAUT_REGEX` to detect hopeless letters that cause the application to crash when editing tile view
- changed the umlaut letters in the texts used in `draggableId` to prevent the application from crashing when organising the order of the tiles

SVA-1291
