### PR TITLE
fix: app crashes in map view due to pagination

### DIFF
--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -63,7 +63,7 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
   const { appDesignSystem, navigation: navigationType } = globalSettings;
   const { sueStatus = {} } = appDesignSystem;
   const { statusViewColors = {}, statusTextColors = {} } = sueStatus;
-  const queryVariables = route.params?.queryVariables ?? { offset: 0, limit: 10000 };
+  const queryVariables = route.params?.queryVariables ?? {};
   const [selectedRequestId, setSelectedRequestId] = useState<string>();
 
   const { data, isLoading } = useQuery([QUERY_TYPES.SUE.REQUESTS, queryVariables], () =>


### PR DESCRIPTION
- removed the `limit` and `offset` required for pagination in list view because they are not required in map view and cause the app to crash

SUE-39

`limit` and `offset` values required for pagination have been removed from the api request in the map view. When `limit` and `offset` values are in `queryVariables`, a blank page is encountered when switching from map view to list view. In order to get the data in list view, it is necessary to pull the data from the api again with pull to refresh. 