### PR TITLE
feat: add sending report loading screen

### DIFF
--- a/src/components/SUE/report/SueReportDone.tsx
+++ b/src/components/SUE/report/SueReportDone.tsx
@@ -10,11 +10,24 @@ import { BoldText, RegularText } from '../../Text';
 import { Wrapper } from '../../Wrapper';
 import { Button } from '../../Button';
 
-export const SueReportDone = ({ navigation }: { navigation: any }) => {
+export const SueReportDone = ({
+  isDone,
+  isLoading,
+  navigation
+}: {
+  isDone: boolean;
+  isLoading: boolean;
+  navigation: any;
+}) => {
   const { globalSettings } = useContext(SettingsContext);
-  const { sections = {} } = globalSettings;
-  const { reportEndScreen = {} } = sections;
-  const { title = '', subTitle = '' } = reportEndScreen;
+  const { appDesignSystem = {} } = globalSettings;
+  const { sueReportScreen = {} } = appDesignSystem;
+  const { reportSendDone = {}, reportSendLoading = {} } = sueReportScreen;
+  const { title: loadingTitle = '', subtitle: loadingSubtitle = '' } = reportSendLoading;
+  const { title: doneTitle = '', subtitle: doneSubtitle = '' } = reportSendDone;
+
+  const title = isDone ? doneTitle : loadingTitle;
+  const subtitle = isDone ? doneSubtitle : loadingSubtitle;
 
   return (
     <>
@@ -22,7 +35,7 @@ export const SueReportDone = ({ navigation }: { navigation: any }) => {
         <BoldText center>{title}</BoldText>
       </Wrapper>
       <Wrapper>
-        <RegularText center>{subTitle}</RegularText>
+        <RegularText center>{subtitle}</RegularText>
       </Wrapper>
 
       <Wrapper>
@@ -32,14 +45,16 @@ export const SueReportDone = ({ navigation }: { navigation: any }) => {
         />
       </Wrapper>
 
-      <Wrapper>
-        <Button
-          title="Zur Meldungsliste"
-          invert
-          notFullWidth
-          onPress={() => navigation.navigate(ScreenName.SueList)}
-        />
-      </Wrapper>
+      {!isLoading && isDone && (
+        <Wrapper>
+          <Button
+            title="Zur Meldungsliste"
+            invert
+            notFullWidth
+            onPress={() => navigation.navigate(ScreenName.SueList)}
+          />
+        </Wrapper>
+      )}
     </>
   );
 };

--- a/src/components/SUE/report/SueReportSend.tsx
+++ b/src/components/SUE/report/SueReportSend.tsx
@@ -10,7 +10,7 @@ import { BoldText, RegularText } from '../../Text';
 import { Wrapper } from '../../Wrapper';
 import { Button } from '../../Button';
 
-export const SueReportDone = ({
+export const SueReportSend = ({
   isDone,
   isLoading,
   navigation

--- a/src/components/SUE/report/index.ts
+++ b/src/components/SUE/report/index.ts
@@ -1,6 +1,6 @@
 export * from './SueReportDescription';
-export * from './SueReportDone';
 export * from './SueReportLocation';
 export * from './SueReportProgress';
+export * from './SueReportSend';
 export * from './SueReportServices';
 export * from './SueReportUser';

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -180,7 +180,7 @@ export const ImageSelector = ({
 
                   <Image
                     source={{ uri: item.uri }}
-                    style={styles.sueImage}
+                    childrenContainerStyle={styles.sueImage}
                     borderRadius={normalize(4)}
                   />
                 </View>

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -142,7 +142,7 @@ export const SueReportScreen = ({
     }
   });
 
-  const { mutateAsync, isLoading: isMutationLoading } = useMutation(postRequests);
+  const { mutateAsync } = useMutation(postRequests);
 
   const onSubmit = async (sueReportData: TReports) => {
     storeReportValues();
@@ -164,15 +164,21 @@ export const SueReportScreen = ({
     setIsLoading(true);
     mutateAsync(formData)
       .then(() => {
-        setIsDone(true);
-        resetStoredValues();
+        setTimeout(() => {
+          setIsDone(true);
+          resetStoredValues();
+        }, 1500);
       })
       .catch(() => {
         setIsLoading(false);
 
         return Alert.alert(texts.defectReport.alerts.hint, texts.defectReport.alerts.error);
       })
-      .finally(() => setIsLoading(false));
+      .finally(() => {
+        setTimeout(() => {
+          setIsLoading(false);
+        }, 1500);
+      });
   };
 
   /* eslint-disable complexity */
@@ -315,8 +321,8 @@ export const SueReportScreen = ({
     );
   }
 
-  if (isDone || isMutationLoading) {
-    return <SueReportSend navigation={navigation} isDone={isDone} isLoading={isMutationLoading} />;
+  if (isDone || isLoading) {
+    return <SueReportSend navigation={navigation} isDone={isDone} isLoading={isLoading} />;
   }
 
   return (

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -167,17 +167,13 @@ export const SueReportScreen = ({
         setTimeout(() => {
           setIsDone(true);
           resetStoredValues();
+          setIsLoading(false);
         }, 1500);
       })
       .catch(() => {
         setIsLoading(false);
 
         return Alert.alert(texts.defectReport.alerts.hint, texts.defectReport.alerts.error);
-      })
-      .finally(() => {
-        setTimeout(() => {
-          setIsLoading(false);
-        }, 1500);
       });
   };
 

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -14,9 +14,9 @@ import {
   LoadingContainer,
   SafeAreaViewFlex,
   SueReportDescription,
-  SueReportDone,
   SueReportLocation,
   SueReportProgress,
+  SueReportSend,
   SueReportServices,
   SueReportUser,
   Wrapper,
@@ -316,7 +316,7 @@ export const SueReportScreen = ({
   }
 
   if (isDone || isMutationLoading) {
-    return <SueReportDone navigation={navigation} isDone={isDone} isLoading={isMutationLoading} />;
+    return <SueReportSend navigation={navigation} isDone={isDone} isLoading={isMutationLoading} />;
   }
 
   return (

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -142,7 +142,7 @@ export const SueReportScreen = ({
     }
   });
 
-  const { mutateAsync } = useMutation(postRequests);
+  const { mutateAsync, isLoading: isMutationLoading } = useMutation(postRequests);
 
   const onSubmit = async (sueReportData: TReports) => {
     storeReportValues();
@@ -315,8 +315,8 @@ export const SueReportScreen = ({
     );
   }
 
-  if (isDone) {
-    return <SueReportDone navigation={navigation} />;
+  if (isDone || isMutationLoading) {
+    return <SueReportDone navigation={navigation} isDone={isDone} isLoading={isMutationLoading} />;
   }
 
   return (


### PR DESCRIPTION
- added `isMutationLoading` to understand when sending the report
- added `loadingTitle` and `loadingSubtitle` that can be edited from the server to show when sending the report in the `SueReportDone` component
- added `isDone` and `isLoading` props to `SueReportDone` component to check if the report is in the status of being sent to the server
- updated the `style` prop in the `Image` component with `childrenContainerStyle` to fix the style distortion bug after the image is selected in `ImageSelector`
- apdated the name of the `SueReportDone` component to `SueReportSend` for clarity

SUE-38

## Screenshots:

|report send loading|
|--|
![Simulator Screenshot - iPhone 14 Pro Max - 2024-02-13 at 13 01 24](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/12c972d8-19cd-4325-bbc8-ef01687f1b89)

