### PR TITLE
feat: add button to close list item in map view

### DIFF
--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -2,7 +2,7 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import _upperFirst from 'lodash/upperFirst';
 import React, { useContext, useMemo, useState } from 'react';
-import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { ListItem } from 'react-native-elements';
 import { useQuery } from 'react-query';
 
@@ -19,10 +19,16 @@ import {
   Touchable,
   Wrapper
 } from '../../components';
-import { colors, consts, normalize, texts } from '../../config';
+import { Icon, colors, consts, normalize, texts } from '../../config';
 import { parseListItemsFromQuery } from '../../helpers';
 import { QUERY_TYPES, getQuery } from '../../queries';
 import { MapMarker } from '../../types';
+
+const CloseButton = ({ onPress }: { onPress: () => void }) => (
+  <TouchableOpacity onPress={onPress} style={styles.closeButton}>
+    <Icon.Close size={normalize(16)} color={colors.surface} />
+  </TouchableOpacity>
+);
 
 type ItemProps = {
   iconName: string;
@@ -141,13 +147,19 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
             onPress={() => navigation.push(item.routeName, item.params)}
           >
             {item.picture?.url ? (
-              <Image
-                source={{ uri: item.picture.url }}
-                childrenContainerStyle={styles.image}
-                containerStyle={styles.imageContainer}
-              />
+              <>
+                <Image
+                  source={{ uri: item.picture.url }}
+                  childrenContainerStyle={styles.image}
+                  containerStyle={styles.imageContainer}
+                />
+                <CloseButton onPress={() => setSelectedRequestId(undefined)} />
+              </>
             ) : (
-              <SueImageFallback style={styles.image} />
+              <>
+                <SueImageFallback style={styles.image} />
+                <CloseButton onPress={() => setSelectedRequestId(undefined)} />
+              </>
             )}
 
             <ListItem.Content>
@@ -165,6 +177,17 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
 };
 
 const styles = StyleSheet.create({
+  closeButton: {
+    alignItems: 'center',
+    backgroundColor: colors.overlayRgba,
+    borderRadius: normalize(12),
+    height: normalize(22),
+    justifyContent: 'center',
+    left: normalize(12),
+    position: 'absolute',
+    top: normalize(12),
+    width: normalize(22)
+  },
   listItemContainer: {
     backgroundColor: colors.surface,
     borderRadius: normalize(8),


### PR DESCRIPTION
- added `CloseButton` to `SueMapScreen` to add the option to close the list item that appears after selecting any pin from the map
- added into `item.picture?.url` control so that `CloseButton` component appears on the picture and list item design is not broken
- added '72' to `colors.darkText` to make the background color of `closeButton` transparent

SUE-50

## Screenshots:

|before|after|after with image|
|--|--|--|
![Simulator Screenshot - iPhone 14 Pro Max - 2024-02-13 at 13 44 33](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/3dfd46fd-7d63-48c5-9f8e-d52602264932)|![Simulator Screenshot - iPhone 14 Pro Max - 2024-02-13 at 13 44 25](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/eb48b8c3-98d0-4ab3-9ee5-b13c411f9f1a)|![Simulator Screenshot - iPhone 14 Pro Max - 2024-02-13 at 13 49 30](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/72ba27cb-3c89-4148-a63b-f155bce0610b)

