### PR TITLE
fix: the error that null occurs when the description text is sent empty

### DIFF
--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -158,7 +158,8 @@ export const SueReportScreen = ({
       lat: selectedPosition?.latitude,
       long: selectedPosition?.longitude,
       serviceCode,
-      ...sueReportData
+      ...sueReportData,
+      description: sueReportData.description || '-'
     };
 
     setIsLoading(true);


### PR DESCRIPTION
- updated the description text with - to correct the `null` expression that occurs if the description text is not filled when sending the report

SUE-54
