### PR TITLE
fix: an image reinsertion error that was deleted during the reporting process

### DIFF
--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -233,6 +233,7 @@ export const SueReportScreen = ({
   };
 
   const resetStoredValues = async () => {
+    setIsLoadingStoredData(true);
     await AsyncStorage.removeItem(SUE_REPORT_VALUES);
     setStoredValues(undefined);
     setServiceCode(undefined);
@@ -244,6 +245,7 @@ export const SueReportScreen = ({
       animated: true
     });
     setCurrentProgress(0);
+    setIsLoadingStoredData(false);
   };
 
   const handleNextPage = async () => {
@@ -307,7 +309,7 @@ export const SueReportScreen = ({
     }
   }, [storedValues, serviceCode, selectedPosition]);
 
-  if (loading || isLoadingStoredData) {
+  if (loading) {
     return (
       <LoadingContainer>
         <ActivityIndicator color={colors.refreshControl} />
@@ -334,16 +336,22 @@ export const SueReportScreen = ({
         >
           {data?.map((item: TProgress, index: number) => (
             <ScrollView key={index} contentContainerStyle={styles.contentContainer}>
-              {Content(
-                item.content,
-                serviceCode,
-                setServiceCode,
-                control,
-                errors,
-                selectedPosition,
-                setSelectedPosition,
-                setValue,
-                getValues
+              {isLoadingStoredData ? (
+                <LoadingContainer>
+                  <ActivityIndicator color={colors.refreshControl} />
+                </LoadingContainer>
+              ) : (
+                Content(
+                  item.content,
+                  serviceCode,
+                  setServiceCode,
+                  control,
+                  errors,
+                  selectedPosition,
+                  setSelectedPosition,
+                  setValue,
+                  getValues
+                )
               )}
             </ScrollView>
           ))}


### PR DESCRIPTION
- added `isLoadingStoredData` control to the return section to overwrite the old image when a new image is added after deleting the saved data with the button on the top right in the header and to reload the content
- updated the `setIsLoadingStoredData` value in `resetStoredValues` so that the `Content` content can be refreshed after the data is deleted

SUE-55
