### PR TITLE
feat: add modal to upload photos

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -10,12 +10,14 @@ import { Touchable } from './Touchable';
 
 export const Modal = ({
   children,
+  closeButton,
   height,
   isBackdropPress,
   isListView,
   isVisible,
   modalHiddenButtonName,
-  onModalVisible
+  onModalVisible,
+  overlayStyle
 }) => {
   return (
     <Overlay
@@ -23,17 +25,19 @@ export const Modal = ({
       isVisible={isVisible}
       onBackdropPress={isBackdropPress ? onModalVisible : undefined}
       windowBackgroundColor={colors.overlayRgba}
-      overlayStyle={[!isListView && styles.overlay, styles.overlayWidth, { height }]}
+      overlayStyle={[!isListView && styles.overlay, styles.overlayWidth, { height }, overlayStyle]}
       supportedOrientations={['portrait', 'landscape']}
     >
       <>
         {children}
 
-        <Touchable onPress={onModalVisible}>
-          <BoldText center underline primary>
-            {modalHiddenButtonName}
-          </BoldText>
-        </Touchable>
+        {closeButton || (
+          <Touchable onPress={onModalVisible}>
+            <BoldText center underline primary>
+              {modalHiddenButtonName}
+            </BoldText>
+          </Touchable>
+        )}
       </>
     </Overlay>
   );
@@ -51,12 +55,14 @@ const styles = StyleSheet.create({
 
 Modal.propTypes = {
   children: PropTypes.node.isRequired,
+  closeButton: PropTypes.node,
   height: PropTypes.string,
   isBackdropPress: PropTypes.bool,
   isListView: PropTypes.bool,
   isVisible: PropTypes.bool.isRequired,
   modalHiddenButtonName: PropTypes.string,
-  onModalVisible: PropTypes.func.isRequired
+  onModalVisible: PropTypes.func.isRequired,
+  overlayStyle: PropTypes.object
 };
 
 Modal.defaultProps = {

--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -51,8 +51,7 @@ export const SueReportDescription = ({ control }: { control: any; errors: any })
                 item: {
                   name: 'images',
                   infoText: texts.sue.report.imageHint,
-                  label: texts.volunteer.images,
-                  buttonTitle: texts.volunteer.addImage
+                  buttonTitle: texts.sue.report.addImage
                 }
               }}
             />

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { useMutation } from 'react-apollo';
 import { Alert, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Divider } from 'react-native-elements';
 
 import { colors, consts, Icon, normalize, texts } from '../../../config';
 import { ConsulClient } from '../../../ConsulClient';
@@ -14,8 +15,10 @@ import { calendarDeleteFile } from '../../../queries/volunteer';
 import { Button } from '../../Button';
 import { Input } from '../../form';
 import { Image } from '../../Image';
-import { RegularText } from '../../Text';
-import { WrapperRow } from '../../Wrapper';
+import { Modal } from '../../Modal';
+import { BoldText, RegularText } from '../../Text';
+import { Touchable } from '../../Touchable';
+import { WrapperRow, WrapperVertical } from '../../Wrapper';
 
 const { IMAGE_SELECTOR_TYPES, IMAGE_TYPE_REGEX, URL_REGEX } = consts;
 
@@ -36,26 +39,6 @@ const deleteImageAlert = (onPress) =>
     ]
   );
 
-const selectImageSourceAlert = (imageSelect, imageCapture) =>
-  Alert.alert(
-    texts.sue.report.alerts.imageSelectAlert.title,
-    texts.sue.report.alerts.imageSelectAlert.description,
-    [
-      {
-        text: texts.sue.report.alerts.imageSelectAlert.cancel,
-        style: 'cancel'
-      },
-      {
-        text: texts.sue.report.alerts.imageSelectAlert.gallery,
-        onPress: imageSelect
-      },
-      {
-        text: texts.sue.report.alerts.imageSelectAlert.camera,
-        onPress: imageCapture
-      }
-    ]
-  );
-
 export const ImageSelector = ({
   control,
   errorType,
@@ -70,6 +53,7 @@ export const ImageSelector = ({
 
   const [infoAndErrorText, setInfoAndErrorText] = useState(JSON.parse(value));
   const [imagesAttributes, setImagesAttributes] = useState(JSON.parse(value));
+  const [isModalVisible, setIsModalVisible] = useState(false);
 
   const [deleteImage] = useMutation(DELETE_IMAGE, {
     client: ConsulClient
@@ -135,6 +119,7 @@ export const ImageSelector = ({
     errorTextGenerator({ errorType, infoAndErrorText, mimeType, setInfoAndErrorText, uri });
 
     setImagesAttributes([...imagesAttributes, { uri, mimeType, imageName, size }]);
+    setIsModalVisible(!isModalVisible);
   };
 
   const values = jsonParser(value);
@@ -147,8 +132,10 @@ export const ImageSelector = ({
 
           <Button
             disabled={values?.length >= 5}
+            icon={<Icon.Camera size={normalize(16)} />}
+            iconPosition="left"
             invert
-            onPress={() => selectImageSourceAlert(imageSelect, () => imageSelect(captureImage))}
+            onPress={() => setIsModalVisible(!isModalVisible)}
             title={buttonTitle}
           />
 
@@ -187,6 +174,51 @@ export const ImageSelector = ({
               ))}
             </WrapperRow>
           </ScrollView>
+
+          <Modal
+            isBackdropPress
+            isVisible={isModalVisible}
+            onModalVisible={() => setIsModalVisible(false)}
+            closeButton={
+              <TouchableOpacity
+                onPress={() => setIsModalVisible(false)}
+                style={styles.overlayCloseButton}
+              >
+                <>
+                  <BoldText small style={styles.overlayCloseButtonText}>
+                    {texts.sue.report.alerts.close}
+                  </BoldText>
+                  <Icon.Close size={normalize(16)} color={colors.darkText} />
+                </>
+              </TouchableOpacity>
+            }
+            overlayStyle={styles.overlay}
+          >
+            <WrapperVertical style={styles.noPaddingTop}>
+              <BoldText>{texts.sue.report.addImage}</BoldText>
+            </WrapperVertical>
+
+            <WrapperVertical style={styles.noPaddingTop}>
+              <Divider />
+            </WrapperVertical>
+
+            <WrapperVertical>
+              <Button
+                icon={<Icon.Camera size={normalize(16)} />}
+                iconPosition="left"
+                invert
+                onPress={() => imageSelect(captureImage)}
+                title={texts.sue.report.alerts.imageSelectAlert.camera}
+              />
+              <Button
+                icon={<Icon.Albums size={normalize(16)} />}
+                iconPosition="left"
+                invert
+                onPress={() => imageSelect(selectImage)}
+                title={texts.sue.report.alerts.imageSelectAlert.gallery}
+              />
+            </WrapperVertical>
+          </Modal>
         </>
       );
     }
@@ -264,6 +296,26 @@ const styles = StyleSheet.create({
   image: {
     height: imageHeight(imageWidth() * 0.6),
     width: imageWidth() * 0.6
+  },
+  noPaddingTop: {
+    paddingTop: 0
+  },
+  overlay: {
+    bottom: 0,
+    paddingBottom: normalize(56),
+    paddingHorizontal: normalize(16),
+    paddingTop: normalize(24),
+    position: 'absolute',
+    width: '100%'
+  },
+  overlayCloseButton: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center'
+  },
+  overlayCloseButtonText: {
+    paddingRight: normalize(10),
+    paddingTop: normalize(3)
   },
   sueDeleteImageButton: {
     alignItems: 'center',

--- a/src/config/Icon.tsx
+++ b/src/config/Icon.tsx
@@ -115,6 +115,7 @@ const NamedIcon = ({
 export const Icon = {
   About: (props: IconProps) => <NamedIcon name="menu" {...props} />,
   AddImage: (props: IconProps) => <SvgIcon xml={addImage} {...props} />,
+  Albums: (props: IconProps) => <NamedIcon name="albums" {...props} />,
   ArrowDown: (props: IconProps) => <SvgIcon xml={arrowDown} {...props} />,
   ArrowDownCircle: (props: IconProps) => <NamedIcon name="arrow-down-circle" {...props} />,
   ArrowLeft: (props: IconProps) => <SvgIcon xml={arrowLeft} {...props} />,

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -930,8 +930,10 @@ export const texts = {
     description: 'Beschreibung',
     location: 'Ort',
     report: {
+      addImage: 'Bilder hinzufügen',
       alerts: {
         address: 'Bitte stellen Sie sicher, dass Sie Ihre Adressdaten korrekt eingeben',
+        close: 'Schließen',
         contact: 'Bitte stellen Sie sicher, dass Sie Ihre Kontaktdaten korrekt eingeben.',
         dataDeleteAlert: {
           cancel: 'Nein',
@@ -945,11 +947,11 @@ export const texts = {
         imagesGreater30MBError:
           'Die ausgewählten Bilder dürfen insgesamt nicht größer als 30 MB sein.',
         imageSelectAlert: {
-          camera: 'Kamera',
+          camera: 'Bild aufnehmen',
           cancel: 'Abbrechen',
           description:
             'Möchten Sie ein Bild mit der Kamera aufnehmen oder aus der Galerie auswählen?',
-          gallery: 'Galerie',
+          gallery: 'Galerie öffnen',
           title: 'Bildquelle auswählen'
         },
         location: 'Bitte wählen Sie einen Ort auf der Karte aus.',


### PR DESCRIPTION
- added `Modal` to `ImageSelector` instead of alert to show where to select the image
- added `overlayStyle` and `closeButton` props to customise the `Modal` component
- added icon for selecting photos from gallery
- updated the necessary texts for the component

SUE-52

## Screenshots:

|portrait mode|landscape mode|
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-26 at 11 42 14](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/11e1939b-f4cc-4379-b66d-765ec0f28cd5)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-26 at 11 42 28](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/3b9a9ef1-8d17-4421-8f2c-52b22423739c)
