### PR TITLE
feat: add control to fill the city input

### DIFF
--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -184,7 +184,7 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="zipCode"
-          label={texts.sue.report.zipCode}
+          label={`${texts.sue.report.zipCode} *`}
           placeholder={texts.sue.report.zipCode}
           maxLength={5}
           keyboardType="numeric"
@@ -198,7 +198,7 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="city"
-          label={texts.sue.report.city}
+          label={`${texts.sue.report.city} *`}
           placeholder={texts.sue.report.city}
           control={control}
           onChange={geocode}

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -933,6 +933,7 @@ export const texts = {
       alerts: {
         address: 'Bitte stellen Sie sicher, dass Sie Ihre Adressdaten korrekt eingeben',
         contact: 'Bitte stellen Sie sicher, dass Sie Ihre Kontaktdaten korrekt eingeben.',
+        city: 'Bitte geben Sie den Ort an',
         dataDeleteAlert: {
           cancel: 'Nein',
           deleteButton: 'Löschen',
@@ -956,9 +957,11 @@ export const texts = {
         no: 'Nein',
         myLocation: 'Möchten Sie Ihren aktuellen Standort verwenden?',
         serviceCode: 'Bitte wählen Sie aus, um welches Thema es in dem Bericht geht.',
+        street: 'Bitte geben Sie die Straße an',
         termsOfService: 'Bitte akzeptieren Sie die Datenschutzbestimmungen.',
         title: 'Bitte kurz beschreiben, worum es geht.',
         yes: 'Ja',
+        zipCode: 'Bitte geben Sie die Postleitzahl an',
         zipCodeLength: 'Postleitzahl muss 5-stellig sein.'
       },
       back: 'Zurück',

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -211,8 +211,20 @@ export const SueReportScreen = ({
         }
         break;
       case 2:
-        if (getValues().zipCode?.length && getValues().zipCode.length !== 5) {
+        if (getValues().houseNumber && !getValues().street) {
+          return texts.sue.report.alerts.street;
+        }
+
+        if (!getValues().zipCode) {
+          return texts.sue.report.alerts.zipCode;
+        }
+
+        if (getValues().zipCode.length !== 5) {
           return texts.sue.report.alerts.zipCodeLength;
+        }
+
+        if (!getValues().city) {
+          return texts.sue.report.alerts.city;
         }
         break;
       default:


### PR DESCRIPTION
- added alert to notify that if the postcode input is filled in, the city input must also be filled in to prevent the city input from being empty
- added a new alert to fill in the street input if the house number is entered
- added * for required inputs

MQGB-60

## Screenshots:

|post code alert|city alert|
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-26 at 13 03 04](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/09d08391-4cb2-49a3-831b-873fc1fb8e78)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-26 at 13 03 09](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/9dd3608e-35b2-4677-b19e-0a94ab6b8187)
