### PR TITLE
feat: show inputs above the keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-snap-carousel": "4.0.0-beta.6",
-    "react-native-status-bar-height": "^2.6.0",
     "react-native-svg": "13.9.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-web": "~0.19.6",

--- a/src/components/DefaultKeyboardAvoidingView.tsx
+++ b/src/components/DefaultKeyboardAvoidingView.tsx
@@ -1,27 +1,9 @@
-import React from 'react';
-import { useContext } from 'react';
-import { KeyboardAvoidingView, Platform, PlatformIOSStatic, StyleSheet } from 'react-native';
-import { getStatusBarHeight } from 'react-native-status-bar-height';
+import React, { useContext } from 'react';
+import { KeyboardAvoidingView, StyleSheet } from 'react-native';
 
-import { device } from '../config';
 import { OrientationContext } from '../OrientationProvider';
-
-const getHeaderHeight = (orientation: string) =>
-  // Android always 56
-  // iOS:
-  //   portrait: 44
-  //   landscape: tablet 66 / phone 32
-  Platform.select({
-    ios: orientation === 'landscape' ? (!(Platform as PlatformIOSStatic).isPad ? 32 : 66) : 44,
-    default: 56
-  });
-
-const statusBarHeight = (orientation: string) =>
-  device.platform === 'android'
-    ? getStatusBarHeight()
-    : orientation === 'portrait'
-    ? getStatusBarHeight()
-    : 0;
+import { device } from '../config';
+import { getHeaderHeight, statusBarHeight } from '../helpers';
 
 export const DefaultKeyboardAvoidingView = ({ children }: { children: React.ReactNode }) => {
   const { orientation } = useContext(OrientationContext);

--- a/src/helpers/headerHelper.ts
+++ b/src/helpers/headerHelper.ts
@@ -1,5 +1,5 @@
+import Constants from 'expo-constants';
 import { Platform, PlatformIOSStatic } from 'react-native';
-import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 import { device } from '../config';
 
@@ -15,7 +15,7 @@ export const getHeaderHeight = (orientation: 'portrait' | 'landscape') =>
 
 export const statusBarHeight = (orientation: 'portrait' | 'landscape') =>
   device.platform === 'android'
-    ? getStatusBarHeight()
+    ? Constants.statusBarHeight
     : orientation === 'portrait'
-    ? getStatusBarHeight()
+    ? Constants.statusBarHeight
     : 0;

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -8,6 +8,7 @@ export * from './constructionSites';
 export * from './documentPicker';
 export * from './HomeRefresh';
 export * from './imagePicker';
+export * from './keyboardHeight';
 export * from './listHooks';
 export * from './locationHooks';
 export * from './matomoHooks';

--- a/src/hooks/keyboardHeight.ts
+++ b/src/hooks/keyboardHeight.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { Keyboard, KeyboardEvent } from 'react-native';
+
+export const useKeyboardHeight = () => {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const onKeyboardChange = ({ endCoordinates }: KeyboardEvent) => {
+      setKeyboardHeight(endCoordinates?.height || 0);
+    };
+
+    const showSubscription = Keyboard.addListener('keyboardDidShow', onKeyboardChange);
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', onKeyboardChange);
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
+
+  return keyboardHeight;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9565,11 +9565,6 @@ react-native-snap-carousel@4.0.0-beta.6:
     "@types/react-addons-shallow-compare" "^0.14.22"
     react-addons-shallow-compare "15.6.2"
 
-react-native-status-bar-height@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.6.0.tgz#b6afd25b6e3d533c43d0fcdcfd5cafd775592cea"
-  integrity sha512-z3SGLF0mHT+OlJDq7B7h/jXPjWcdBT3V14Le5L2PjntjjWM3+EJzq2BcXDwV+v67KFNJic5pgA26cCmseYek6w==
-
 react-native-svg@13.9.0:
   version "13.9.0"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-13.9.0.tgz#8df8a690dd00362601f074dec5d3a86dd0f99c7f"


### PR DESCRIPTION
- added the `headerHelper` to `DefaultKeyboardAvoidingView`, which is used in many parts of the code to avoid code duplication
- using `statusBarHeight` of `expo-constants` package because `react-native-status-bar-height` package cannot calculate status bar size of iPhone 14 Pro and higher models
  - https://github.com/ovr/react-native-status-bar-height
- removed `react-native-status-bar-height` package from `package.json` because it is not used
- added `getKeyboardHeight` helper to detect the size of the keyboard when it is opened
- added a `View` half the size of the keyboard, which is created only when the keyboard is opened, into `ScrollView` in order to make the inputs hidden behind the keyboard visible by scrolling the screen on android devices
- wrapped all content with `DefaultKeyboardAvoidingView` to make the buttons at the bottom of the screen appear above the keyboard when the keyboard is opened
  - this feature does not currently work for android
- added `Keyboard.dismiss()` to dismiss the keyboard if the continue or back button is pressed while the keyboard is open

SUE-58

please remember to run `yarn prebuild` as a package has been deleted.

## Screenshots:

iOS:
|SueReportDescription screen with button (keyboard active)|SueReportLocation screen with button (keyboard active) - focus on zip code|SueReportLocation Screen (keyboard deactive)|
|--|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-27 at 15 52 41](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/bc1bd7ce-9b43-4b88-8723-9280921636cc)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-27 at 15 52 49](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/9c837d6f-b1df-4f9a-ace3-f8e169221b0c)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-27 at 15 52 51](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/5d302346-9079-4756-b0df-79c62eae6f36)


Android:
|SueReportLocation (keyboard deactive) - bottom of scroll view |SueReportLocation (keyboard active) - focus on city / bottom of scroll view|SueReportLocation (keyboard deactive) - view when the city input is clicked|landscape mode|
|--|--|--|--| 
![Screenshot_20240227-155333](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/34fa245f-1313-4a92-8719-74443119211f)|![Screenshot_20240227-155337](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/adfe8fe9-6ee5-4707-b887-db00c21ab9c6)|![Screenshot_20240227-155343](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/fb6306ab-5b8d-48b9-8079-dab6d3d07636)|![Screenshot_20240227-155442](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/66a07b60-ca09-4fd1-9ab5-955c99bb0824)
