### PR TITLE
feat: extend the waiting time when sending a report

### DIFF
--- a/src/components/SUE/report/SueReportSend.tsx
+++ b/src/components/SUE/report/SueReportSend.tsx
@@ -62,7 +62,7 @@ export const SueReportSend = ({
 const styles = StyleSheet.create({
   image: {
     height: normalize(50),
-    width: device.width,
+    width: '100%',
     alignSelf: 'center'
   }
 });

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -172,11 +172,14 @@ export const SueReportScreen = ({
     setIsLoading(true);
     mutateAsync(formData)
       .then(() => {
-        setTimeout(() => {
-          setIsDone(true);
-          resetStoredValues();
-          setIsLoading(false);
-        }, 1500);
+        setTimeout(
+          () => {
+            setIsDone(true);
+            resetStoredValues();
+            setIsLoading(false);
+          },
+          JSON.parse(sueReportData?.images).length ? 0 : 3000
+        );
       })
       .catch(() => {
         setIsLoading(false);


### PR DESCRIPTION
- increased the waiting time of the report from 1.5 seconds to 3 seconds if there is no image
- added a control to avoid waiting an extra 3 seconds because images take a long time to load
- added width value of 100% to prevent the loading gif from being clipped

SUE-38

please remember to set the version in `app.json` to `60.0.0` during testing.