### PR TITLE
feat: include the selected day in the filter

### DIFF
--- a/src/components/filter/DateFilter.tsx
+++ b/src/components/filter/DateFilter.tsx
@@ -92,12 +92,14 @@ export const DateFilter = ({ containerStyle, data, filters, setFilters }: Props)
       <WrapperRow spaceBetween>
         {data.map((item) => {
           useEffect(() => {
+            const endTimeOfDay = item.name === 'start_date' ? 'T00:00:00+01:00' : 'T22:59:59+01:00';
+
             setFilters(
               updateFilters({
                 currentFilters: filters,
                 name: item.name as keyof FilterProps,
                 removeFromFilter: !selectedDate[item.name],
-                value: `${selectedDate[item.name]}T00:00:00+01:00`
+                value: `${selectedDate[item.name]}${endTimeOfDay}`
               })
             );
           }, [selectedDate[item.name]]);


### PR DESCRIPTION
- added `endTimeOfDay` to include the selected `end_date` in the filter and set it to `'T22:59:59+01:00'` which is the last time of the day

SUE-14

## Screenshots:

|before|after|
|--|--|
<img width="331" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/d324c7b0-096c-414e-ac81-e33e2c9e9306">|<img width="332" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/1527866f-0303-4829-8f18-72a1162072dc">
