### PR TITLE
fix: the problem of images on the onboarding appearing above the status

### DIFF
--- a/src/screens/AppIntroScreen.tsx
+++ b/src/screens/AppIntroScreen.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
 import { ListRenderItem, ScrollView, StatusBar, StyleSheet, View } from 'react-native';
 import AppIntroSlider from 'react-native-app-intro-slider';
+import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 import { BoldText, Image, RegularText, SafeAreaViewFlex, Wrapper } from '../components';
-import { colors, normalize, texts } from '../config';
+import { colors, device, normalize, texts } from '../config';
 import { useStaticContent } from '../hooks';
 import { parseIntroSlides } from '../jsonValidation';
 import { AppIntroSlide } from '../types';
@@ -43,7 +44,11 @@ const renderSlide: ListRenderItem<AppIntroSlide> = ({ item }) => {
 };
 
 export const AppIntroScreen = ({ setOnboardingComplete }: Props) => {
-  const { data: slides, error, loading } = useStaticContent({
+  const {
+    data: slides,
+    error,
+    loading
+  } = useStaticContent({
     name: 'appIntroSlides',
     type: 'json',
     parseFromJson: parseIntroSlides,
@@ -77,6 +82,7 @@ export const AppIntroScreen = ({ setOnboardingComplete }: Props) => {
         activeDotStyle={styles.activeDot}
         dotClickEnabled={false}
         scrollEnabled={false}
+        style={device.platform === 'android' && { paddingTop: getStatusBarHeight() }}
       />
     </SafeAreaViewFlex>
   );


### PR DESCRIPTION
- added `paddingTop` style as the size of the status bar to the `AppIntroSlider` component to solve the problem of the images on the onboarding screen appearing above the `StatusBar` on android devices

SVA-1155

I can't share screenshots because this problem doesn't occur in development mode. We can first see if the problem is solved after creating a new version.