### PR TITLE
feat: add style for landscape mode to photos

### DIFF
--- a/src/components/CardListItem.js
+++ b/src/components/CardListItem.js
@@ -156,14 +156,16 @@ const styles = StyleSheet.create({
     paddingTop: 0
   },
   sueContentContainer: {
-    borderWidth: 1,
     borderColor: colors.gray20,
-    borderRadius: normalize(8)
+    borderRadius: normalize(8),
+    borderWidth: 1,
+    width: '100%'
   },
   sueImageContainer: {
     alignSelf: 'auto',
     borderTopLeftRadius: normalize(8),
-    borderTopRightRadius: normalize(8)
+    borderTopRightRadius: normalize(8),
+    width: '100%'
   }
 });
 

--- a/src/screens/SUE/SueDetailScreen.tsx
+++ b/src/screens/SUE/SueDetailScreen.tsx
@@ -96,7 +96,7 @@ export const SueDetailScreen = ({ route }: Props) => {
         }
       >
         <ImageSection mediaContents={mediaContents} />
-        {!mediaContents?.length && <SueImageFallback />}
+        {!mediaContents?.length && <SueImageFallback style={styles.sueImageContainer} />}
 
         {!!serviceName && !!requestedDatetime && (
           <SueCategory serviceName={serviceName} requestedDatetime={requestedDatetime} />
@@ -183,5 +183,8 @@ const styles = StyleSheet.create({
   },
   noPaddingTop: {
     paddingTop: 0
+  },
+  sueImageContainer: {
+    width: '100%'
   }
 });


### PR DESCRIPTION
- added width style for the list to cover the entire screen when using the app in landscape mode while in list view

SUE-67

## Screenshots:

currently there is a problem on the API side, so the data is not being loaded. Therefore, I cannot upload before and after screenshots here. To test, switch to list view in the app and turn the phone sideways. 