### PR TITLE
feat: add size limit control for each image

### DIFF
--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -210,11 +210,17 @@ export const SueReportScreen = ({
           const images = JSON.parse(getValues().images);
 
           let totalSize = 0;
-          images.map(async ({ size }: { size: number }) => {
+          const sizeOfImage = images.some(({ size }: { size: number }) => {
             totalSize += size;
+            return size >= 10485760;
           });
 
-          /* the server does not support files more than 30MB in size. */
+          /* the server does not support files more than 10MB in size. */
+          if (sizeOfImage) {
+            return texts.sue.report.alerts.imageGreater10MBError;
+          }
+
+          /* the server does not support files larger than 30 MB in total of all files. */
           if (totalSize >= 31457280) {
             return texts.sue.report.alerts.imagesGreater30MBError;
           }


### PR DESCRIPTION
- updated the `alertTextGeneratorForMissingData` function to prevent the report screen from moving to the next step if a selected image is higher than 10MB, since the server allows a maximum of 10MB for each image and the total image size should be maximum 30MB

SUE-63

For Test:

To download an image larger than 10MB, please follow these steps:
https://commons.wikimedia.org/wiki/File:Pizigani_1367_Chart_10MB.jpg

<img width="654" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/76c63802-a7ed-4d09-9c61-aa4daf6c8209">
<img width="1164" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/1834bfbd-6efa-4cb3-8608-f01820f0cfae">
<img width="243" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/0d087956-58a1-41a0-9c1d-93304af5b971">

To test, drag the following image with a size greater than 10MB into the Simulator. Select this image from the `SueReportScreen`. Because this image is larger than 10MB, you will receive an alert that will prevent you from proceeding to the next step.

## Screenshots:

|warning|alert|
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-07 at 10 18 17](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/7de4cffb-35e2-463c-934c-350b3250ad17)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-07 at 10 18 19](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/9250a4ab-0256-4325-9e1b-03e68a3285f3)
