### PR TITLE
feat: disable orientation for the report screen

### DIFF
--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -190,7 +190,9 @@ const styles = StyleSheet.create({
     alignSelf: 'center'
   },
   imageContainer: {
-    alignSelf: 'center'
+    alignItems: 'center',
+    alignSelf: 'center',
+    width: '100%'
   },
   pauseButton: {
     alignItems: 'center',

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StackScreenProps } from '@react-navigation/stack';
 import * as Location from 'expo-location';
+import * as ScreenOrientation from 'expo-screen-orientation';
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { UseFormGetValues, UseFormSetValue, useForm } from 'react-hook-form';
 import { ActivityIndicator, Alert, Keyboard, ScrollView, StyleSheet, View } from 'react-native';
@@ -119,6 +120,20 @@ export const SueReportScreen = ({
   const scrollViewContentRef = useRef(null);
 
   const keyboardHeight = useKeyboardHeight();
+
+  useEffect(() => {
+    // this screen is set to portrait mode because half of the screen is visible in landscape
+    // mode when viewing pictures in large screen mode
+    ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('blur', () => {
+      ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.DEFAULT);
+    });
+
+    return unsubscribe;
+  }, [navigation]);
 
   const {
     control,


### PR DESCRIPTION
- added `PORTRAIT_UP` lock to `SueReportScreen` because calculating the sizes of different steps on the report screen and scrolling at the same rate is not possible on different sized devices
- added listener to automatically set the orientation of the screen to `DEFAULT` when the user leaves `SueReportScreen`
- updated the style so that the pictures in the `ImagesCarousel` we use in `HomeScreen` can also adjust themselves according to orientation

SUE-67

please set the version in app.json to 60.0.0 for testing.
## Screenshots:

|HomeScreen before|HomeScreen after|
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-08 at 09 50 46](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/145f62c6-4f92-4c89-ba31-d0598e0d7632)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-08 at 09 50 25](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/f16a545d-d443-4681-80db-80284b8becec)

