### PR TITLE
feat: add city and postcode limits to create a report

### DIFF
--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -9,7 +9,13 @@ import { Input } from '../../form';
 
 const { IMAGE_SELECTOR_TYPES, IMAGE_SELECTOR_ERROR_TYPES } = consts;
 
-export const SueReportDescription = ({ control }: { control: any; errors: any }) => {
+export const SueReportDescription = ({
+  control,
+  requiredInputs
+}: {
+  control: any;
+  requiredInputs: string[];
+}) => {
   const titleRef = useRef();
   const descriptionRef = useRef();
 
@@ -18,7 +24,7 @@ export const SueReportDescription = ({ control }: { control: any; errors: any })
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="title"
-          label={`${texts.sue.report.title} *`}
+          label={`${texts.sue.report.title} ${requiredInputs?.includes('title') ? '*' : ''}`}
           placeholder={texts.sue.report.title}
           control={control}
           ref={titleRef}
@@ -29,7 +35,9 @@ export const SueReportDescription = ({ control }: { control: any; errors: any })
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="description"
-          label={texts.sue.report.description}
+          label={`${texts.sue.report.description} ${
+            requiredInputs?.includes('description') ? '*' : ''
+          }`}
           placeholder={texts.sue.report.description}
           multiline
           control={control}

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -19,18 +19,21 @@ import { Input } from '../../form';
 import { Map } from '../../map';
 import { getLocationMarker } from '../../settings';
 
+/* eslint-disable complexity */
 export const SueReportLocation = ({
   control,
+  getValues,
+  requiredInputs,
   selectedPosition,
   setSelectedPosition,
-  setValue,
-  getValues
+  setValue
 }: {
   control: any;
+  getValues: UseFormGetValues<TValues>;
+  requiredInputs: string[];
   selectedPosition: Location.LocationObjectCoords | undefined;
   setSelectedPosition: (position: Location.LocationObjectCoords | undefined) => void;
   setValue: UseFormSetValue<TValues>;
-  getValues: UseFormGetValues<TValues>;
 }) => {
   const { locationSettings } = useLocationSettings();
   const systemPermission = useSystemPermission();
@@ -160,7 +163,7 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="street"
-          label={texts.sue.report.street}
+          label={`${texts.sue.report.street} ${requiredInputs?.includes('street') ? '*' : ''}`}
           placeholder={texts.sue.report.street}
           textContentType="streetAddressLine1"
           control={control}
@@ -173,7 +176,9 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="houseNumber"
-          label={texts.sue.report.houseNumber}
+          label={`${texts.sue.report.houseNumber} ${
+            requiredInputs?.includes('houseNumber') ? '*' : ''
+          }`}
           placeholder={texts.sue.report.houseNumber}
           textContentType="off"
           control={control}
@@ -186,7 +191,7 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="zipCode"
-          label={texts.sue.report.zipCode}
+          label={`${texts.sue.report.zipCode} ${requiredInputs?.includes('zipCode') ? '*' : ''}`}
           placeholder={texts.sue.report.zipCode}
           maxLength={5}
           keyboardType="numeric"
@@ -201,7 +206,7 @@ export const SueReportLocation = ({
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="city"
-          label={texts.sue.report.city}
+          label={`${texts.sue.report.city} ${requiredInputs?.includes('city') ? '*' : ''}`}
           placeholder={texts.sue.report.city}
           control={control}
           textContentType="addressCity"
@@ -212,6 +217,7 @@ export const SueReportLocation = ({
     </View>
   );
 };
+/* eslint-enable complexity */
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/SUE/report/SueReportUser.tsx
+++ b/src/components/SUE/report/SueReportUser.tsx
@@ -10,7 +10,15 @@ import { Input } from '../../form';
 
 const { EMAIL_REGEX } = consts;
 
-export const SueReportUser = ({ control, errors }: { control: any; errors: any }) => {
+export const SueReportUser = ({
+  control,
+  errors,
+  requiredInputs
+}: {
+  control: any;
+  errors: any;
+  requiredInputs: string[];
+}) => {
   const firstNameRef = useRef();
   const lastNameRef = useRef();
   const emailRef = useRef();
@@ -21,7 +29,9 @@ export const SueReportUser = ({ control, errors }: { control: any; errors: any }
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="firstName"
-          label={texts.sue.report.firstName}
+          label={`${texts.sue.report.firstName} ${
+            requiredInputs?.includes('firstName') ? '*' : ''
+          }`}
           placeholder={texts.sue.report.firstName}
           textContentType="givenName"
           control={control}
@@ -33,7 +43,7 @@ export const SueReportUser = ({ control, errors }: { control: any; errors: any }
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="lastName"
-          label={texts.sue.report.lastName}
+          label={`${texts.sue.report.lastName} ${requiredInputs?.includes('lastName') ? '*' : ''}`}
           placeholder={texts.sue.report.lastName}
           textContentType="familyName"
           control={control}
@@ -45,7 +55,7 @@ export const SueReportUser = ({ control, errors }: { control: any; errors: any }
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="email"
-          label={texts.sue.report.email}
+          label={`${texts.sue.report.email} ${requiredInputs?.includes('email') ? '*' : ''}`}
           placeholder={texts.sue.report.email}
           keyboardType="email-address"
           autoCapitalize="none"
@@ -69,7 +79,7 @@ export const SueReportUser = ({ control, errors }: { control: any; errors: any }
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="phone"
-          label={`${texts.sue.report.phone}`}
+          label={`${texts.sue.report.phone} ${requiredInputs?.includes('phone') ? '*' : ''}`}
           placeholder={texts.sue.report.phone}
           keyboardType="phone-pad"
           textContentType="telephoneNumber"

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -959,6 +959,7 @@ export const texts = {
         limitOfArea: (city) =>
           `Leider kann die Sag's uns Einfach nur Standorte der ${city} nutzen.`,
         location: 'Bitte wählen Sie einen Ort auf der Karte aus.',
+        missingAnyInput: 'Bitte füllen Sie alle Pflichtfelder aus',
         no: 'Nein',
         myLocation: 'Möchten Sie Ihren aktuellen Standort verwenden?',
         serviceCode: 'Bitte wählen Sie aus, um welches Thema es in dem Bericht geht.',

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -956,6 +956,8 @@ export const texts = {
           title: 'Bildquelle auswählen'
         },
         invalidMail: 'Die eingegebene E-Mail-Adresse ist nicht gültig.',
+        limitOfArea: (city) =>
+          `Leider kann die Sag's uns Einfach nur Standorte der ${city} nutzen.`,
         location: 'Bitte wählen Sie einen Ort auf der Karte aus.',
         no: 'Nein',
         myLocation: 'Möchten Sie Ihren aktuellen Standort verwenden?',

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -47,6 +47,7 @@ export type TValues = {
 
 const Content = (
   content: 'category' | 'description' | 'location' | 'user',
+  requiredInputs: string[],
   serviceCode: string,
   setServiceCode: any,
   control: any,
@@ -58,7 +59,9 @@ const Content = (
 ) => {
   switch (content) {
     case 'description':
-      return <SueReportDescription control={control} errors={errors} />;
+      return (
+        <SueReportDescription control={control} errors={errors} requiredInputs={requiredInputs} />
+      );
     case 'location':
       return (
         <SueReportLocation
@@ -67,10 +70,11 @@ const Content = (
           setSelectedPosition={setSelectedPosition}
           setValue={setValue}
           getValues={getValues}
+          requiredInputs={requiredInputs}
         />
       );
     case 'user':
-      return <SueReportUser control={control} errors={errors} />;
+      return <SueReportUser control={control} errors={errors} requiredInputs={requiredInputs} />;
     default:
       return <SueReportServices serviceCode={serviceCode} setServiceCode={setServiceCode} />;
   }
@@ -87,15 +91,16 @@ type TReports = {
   lastName: string;
   phone: string;
   street: string;
-  title: string;
   termsOfService: string;
+  title: string;
   zipCode: string;
 };
 
 type TProgress = {
-  title: string;
   content: 'category' | 'description' | 'location' | 'user';
+  requiredInputs: TValues[];
   serviceCode: string;
+  title: string;
 };
 
 export const SueReportScreen = ({
@@ -280,6 +285,14 @@ export const SueReportScreen = ({
       default:
         break;
     }
+
+    const isAnyInputMissing = data?.[currentProgress]?.requiredInputs?.some(
+      (inputKey) => !getValues()[inputKey]
+    );
+
+    if (isAnyInputMissing) {
+      return texts.sue.report.alerts.missingAnyInput;
+    }
   };
   /* eslint-enable complexity */
 
@@ -421,6 +434,7 @@ export const SueReportScreen = ({
               ) : (
                 Content(
                   item.content,
+                  item.requiredInputs,
                   serviceCode,
                   setServiceCode,
                   control,


### PR DESCRIPTION
- added `city` and `zipCodes` limitations that can be updated via main-server when creating a report
- added `errorMessage` which can be set via main-server as there may be different alert messages for different cities

SUE-57

please set the version in app.json to 60.0.0 for testing.

The config added to main-server is as follows. For reports that do not match the postal codes or city in this config, the next step is prevented.
the limitation can be done only with the `zipCodes` array or only with the `city`.

If the `errorMessage` value is not added to the configuration, the following message is displayed by default.
`Leider kann die Sag's uns Einfach nur Standorte der  nutzen.

```
    "limitOfArea": {
      "zipCodes": [
        "85625"
      ],
      "city": "kiel",
      "errorMessage": "Leider kann die Sag's uns Einfach nur Standorte der Landeshaupstadt Kiel nutzen."
    }
```

## Screenshots:

|alert with false city and zipCode value|alert with false city value|alert with false zipCode value|with main-server config|
|--|--|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-08 at 10 47 16](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/0a3420dc-e3c4-4960-929f-d1177e36c1c4)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-08 at 10 47 22](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/f18b22f1-388e-4c1e-9f8d-4a2d86930e5d)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-08 at 10 49 09](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/2c47f4e3-cb19-4724-87d6-198ff6afe7ed)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-08 at 10 47 38](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/328baab7-3bee-401b-8258-5024a8a40272)
