### PR TITLE
feat(sue): list previous reports on the report screen

### DIFF
--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -25,11 +25,9 @@ import { Map } from '../../map';
 import { getLocationMarker } from '../../settings';
 
 enum SueStatus {
-  CLOSED = 'TICKET_STATUS_CLOSED',
   IN_PROCESS = 'TICKET_STATUS_IN_PROCESS',
   INVALID = 'TICKET_STATUS_INVALID',
   OPEN = 'TICKET_STATUS_OPEN',
-  UNPROCESSED = 'TICKET_STATUS_UNPROCESSED',
   WAIT_REQUESTOR = 'TICKET_STATUS_WAIT_REQUESTOR',
   WAIT_THIRDPARTY = 'TICKET_STATUS_WAIT_THIRDPARTY'
 }
@@ -71,7 +69,7 @@ export const SueReportLocation = ({
 
   const queryVariables = {
     start_date: '1900-01-01T00:00:00+01:00',
-    status: `${SueStatus.UNPROCESSED},${SueStatus.OPEN},${SueStatus.IN_PROCESS},${SueStatus.WAIT_REQUESTOR},${SueStatus.WAIT_THIRDPARTY}`
+    status: Object.values(SueStatus).map((status) => status)
   };
 
   const { data, isLoading } = useQuery(

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -23,6 +23,16 @@ import { Input } from '../../form';
 import { Map } from '../../map';
 import { getLocationMarker } from '../../settings';
 
+enum SueStatus {
+  CLOSED = 'TICKET_STATUS_CLOSED',
+  IN_PROCESS = 'TICKET_STATUS_IN_PROCESS',
+  INVALID = 'TICKET_STATUS_INVALID',
+  OPEN = 'TICKET_STATUS_OPEN',
+  UNPROCESSED = 'TICKET_STATUS_UNPROCESSED',
+  WAIT_REQUESTOR = 'TICKET_STATUS_WAIT_REQUESTOR',
+  WAIT_THIRDPARTY = 'TICKET_STATUS_WAIT_THIRDPARTY'
+}
+
 /* eslint-disable complexity */
 export const SueReportLocation = ({
   control,
@@ -58,18 +68,22 @@ export const SueReportLocation = ({
   const cityInputRef = useRef();
 
   const queryVariables = {
-    status:
-      'TICKET_STATUS_UNPROCESSED,TICKET_STATUS_OPEN,TICKET_STATUS_IN_PROCESS,TICKET_STATUS_WAIT_REQUESTOR,TICKET_STATUS_WAIT_THIRDPARTY'
+    start_date: '1900-01-01T00:00:00+01:00',
+    status: `${SueStatus.UNPROCESSED},${SueStatus.OPEN},${SueStatus.IN_PROCESS},${SueStatus.WAIT_REQUESTOR},${SueStatus.WAIT_THIRDPARTY}`
   };
 
-  const { data, isLoading } = useQuery([QUERY_TYPES.SUE.REQUESTS, queryVariables], () =>
-    getQuery(QUERY_TYPES.SUE.REQUESTS)(queryVariables)
+  const { data, isLoading } = useQuery(
+    [QUERY_TYPES.SUE.REQUESTS, queryVariables],
+    () => getQuery(QUERY_TYPES.SUE.REQUESTS)(queryVariables),
+    {
+      cacheTime: 1000 * 60 * 60 * 24 // 24 hours
+    }
   );
 
   const mapMarkers = useMemo(
     () =>
       mapToMapMarkers(
-        parseListItemsFromQuery(QUERY_TYPES.SUE.REQUESTS, data, undefined, {
+        parseListItemsFromQuery(QUERY_TYPES.SUE.REQUESTS_WITH_SERVICE_REQUEST_ID, data, undefined, {
           appDesignSystem
         }),
         statusViewColors,

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -1,4 +1,5 @@
 import * as Location from 'expo-location';
+import moment from 'moment';
 import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
 import { UseFormGetValues, UseFormSetValue } from 'react-hook-form';
 import { Alert, StyleSheet, View } from 'react-native';
@@ -55,6 +56,7 @@ export const SueReportLocation = ({
   const { appDesignSystem } = globalSettings;
   const { sueStatus = {} } = appDesignSystem;
   const { statusViewColors = {}, statusTextColors = {} } = sueStatus;
+  const now = moment();
 
   const { position } = usePosition(systemPermission?.status !== Location.PermissionStatus.GRANTED);
   const { position: lastKnownPosition } = useLastKnownPosition(
@@ -76,7 +78,7 @@ export const SueReportLocation = ({
     [QUERY_TYPES.SUE.REQUESTS, queryVariables],
     () => getQuery(QUERY_TYPES.SUE.REQUESTS)(queryVariables),
     {
-      cacheTime: 1000 * 60 * 60 * 24 // 24 hours
+      cacheTime: moment().endOf('day').diff(now) // end of day
     }
   );
 

--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -39,7 +39,7 @@ type ItemProps = {
   title: string;
 };
 
-const mapToMapMarkers = (
+export const mapToMapMarkers = (
   items: ItemProps[],
   statusViewColors: Record<string, string | undefined>,
   statusTextColors: Record<string, string | undefined>


### PR DESCRIPTION
- added `query` to `SueReportLocation` to see open and edited reports in the map view shown in the location step on the report screen
- added `mapMarkers` to convert the data coming from the API via query into the correct format for the map
- exported from `SueMapScreen` to use the `mapToMarkers` function in `SueReportLocation`
- added location information created with `mapMarkers` to `locations` array
- updated query's `cacheTime` to 24 hours
- added `SueStatus` `enum` to see statuses in one place
- added `start_date` to `queryVariables` to get all data
- updated the query in `parseListItemsFromQuery` with `REQUESTS_WITH_SERVICE_REQUEST_ID` to keep the code in the same structure

SUE-75

## Test:

- To test, upgrade the version in `app.json` to `60.0.0`,
- Click the Jetzt Meldung machen button on the `HomeScreen`,
- Fill in the required information in the `ReportScreen` and proceed to step 3

## Screenshots:

|before (without selecting the location)|after (without selecting the location)|before (with selecting the location)|after (with selecting the location)|
|--|--|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-14 at 13 26 46](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/41743d5f-7e95-4a32-bd7d-ee228de39db6)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-14 at 13 26 26](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/ba5ed835-5c3b-4b7f-a91d-51b4773de729)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-14 at 13 26 49](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/f6d0f93c-18b2-4f03-ac68-1e8c240913cd)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-14 at 13 26 30](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/28d667b2-04f1-4058-b4a4-8e9b2652cc08)


