### PR TITLE
feat(sue): update api key via server

### DIFF
--- a/src/helpers/sueHelper.ts
+++ b/src/helpers/sueHelper.ts
@@ -1,24 +1,35 @@
-import * as appJson from '../../app.json';
-import { secrets } from '../config';
+import { storageHelper } from './storageHelper';
 
-const namespace = appJson.expo.slug as keyof typeof secrets;
-export const serverUrl = secrets[namespace]?.sue?.serverUrl;
-export const apiKey = secrets[namespace]?.sue?.apiKey;
-export const jurisdictionId = secrets[namespace]?.sue?.jurisdictionId;
+export const fetchSueEndpoints = async (serviceRequestId?: number) => {
+  const globalSettings = await storageHelper.globalSettings();
+  const { apiConfig = {} } = globalSettings?.settings?.sue || {};
 
-export const sueFetchObj = {
-  method: 'GET',
-  headers: {
-    accept: 'application/json',
-    api_key: apiKey
-  }
+  const { apiKey, jurisdictionId, serverUrl } = apiConfig[apiConfig?.whichApi] || apiConfig;
+
+  const sueFetchObj = {
+    method: 'GET',
+    headers: {
+      accept: 'application/json',
+      api_key: apiKey
+    }
+  };
+
+  const suePostRequest = `${serverUrl}/requests`;
+  const suePrioritiesUrl = `${serverUrl}/priorities?jurisdiction_id=${jurisdictionId}`;
+  const sueRequestsUrl = `${serverUrl}/requests?jurisdiction_id=${jurisdictionId}`;
+  const sueRequestsUrlWithServiceId = `${serverUrl}/requests/${serviceRequestId}?jurisdiction_id=${jurisdictionId}`;
+  const sueServicesUrl = `${serverUrl}/services?jurisdiction_id=${jurisdictionId}`;
+  const sueStatusesUrl = `${serverUrl}/statuses?jurisdiction_id=${jurisdictionId}`;
+
+  return {
+    apiKey,
+    jurisdictionId,
+    sueFetchObj,
+    suePostRequest,
+    suePrioritiesUrl,
+    sueRequestsUrl,
+    sueRequestsUrlWithServiceId,
+    sueServicesUrl,
+    sueStatusesUrl
+  };
 };
-
-export const suePrioritiesUrl = `${serverUrl}/priorities?jurisdiction_id=${jurisdictionId}`;
-export const sueRequestsUrl = `${serverUrl}/requests?jurisdiction_id=${jurisdictionId}`;
-export const sueRequestsUrlWithServiceId = (serviceRequestId: number) =>
-  `${serverUrl}/requests/${serviceRequestId}?jurisdiction_id=${jurisdictionId}`;
-export const sueServicesUrl = `${serverUrl}/services?jurisdiction_id=${jurisdictionId}`;
-export const sueStatusesUrl = `${serverUrl}/statuses?jurisdiction_id=${jurisdictionId}`;
-
-export const suePostRequest = `${serverUrl}/requests`;

--- a/src/queries/SUE/priorities.tsx
+++ b/src/queries/SUE/priorities.tsx
@@ -1,9 +1,11 @@
 import _camelCase from 'lodash/camelCase';
 import _mapKeys from 'lodash/mapKeys';
 
-import { sueFetchObj, suePrioritiesUrl } from '../../helpers';
+import { fetchSueEndpoints } from '../../helpers';
 
 export const priorities = async () => {
+  const { sueFetchObj = {}, suePrioritiesUrl = '' } = await fetchSueEndpoints();
+
   const response = await (await fetch(`${suePrioritiesUrl}`, sueFetchObj)).json();
 
   return new Promise((resolve) => {

--- a/src/queries/SUE/requests.tsx
+++ b/src/queries/SUE/requests.tsx
@@ -1,10 +1,12 @@
 import _camelCase from 'lodash/camelCase';
 import _mapKeys from 'lodash/mapKeys';
 
-import { apiKey, jurisdictionId, sueFetchObj, suePostRequest, sueRequestsUrl } from '../../helpers';
+import { fetchSueEndpoints } from '../../helpers';
 
 export const requests = async (queryVariables) => {
   const queryParams = new URLSearchParams(queryVariables);
+  const { sueFetchObj = {}, sueRequestsUrl = '' } = await fetchSueEndpoints();
+
   const response = await (
     await fetch(`${sueRequestsUrl}&${queryParams.toString()}`, sueFetchObj)
   ).json();
@@ -26,7 +28,9 @@ export const requests = async (queryVariables) => {
 
 /* eslint-disable complexity */
 export const postRequests = async (data: any) => {
+  const { apiKey = '', jurisdictionId = '', suePostRequest = '' } = await fetchSueEndpoints();
   const formData = new FormData();
+
   data?.addressString && formData.append('address_string', data.addressString);
   data?.description && formData.append('description', data.description);
   data?.email && formData.append('email', data.email);

--- a/src/queries/SUE/requestsWithServiceRequestId.tsx
+++ b/src/queries/SUE/requestsWithServiceRequestId.tsx
@@ -1,12 +1,14 @@
 import _camelCase from 'lodash/camelCase';
 import _mapKeys from 'lodash/mapKeys';
 
-import { sueFetchObj, sueRequestsUrlWithServiceId } from '../../helpers';
+import { fetchSueEndpoints } from '../../helpers';
 
 export const requestsWithServiceRequestId = async (serviceRequestId: number) => {
-  const response = await (
-    await fetch(`${sueRequestsUrlWithServiceId(serviceRequestId)}`, sueFetchObj)
-  ).json();
+  const { sueFetchObj = {}, sueRequestsUrlWithServiceId = '' } = await fetchSueEndpoints(
+    serviceRequestId
+  );
+
+  const response = await (await fetch(`${sueRequestsUrlWithServiceId}`, sueFetchObj)).json();
 
   // convert media_url to JSON, as it is returned as a string by the API
   if (response?.media_url) {

--- a/src/queries/SUE/services.tsx
+++ b/src/queries/SUE/services.tsx
@@ -1,9 +1,11 @@
 import _camelCase from 'lodash/camelCase';
 import _mapKeys from 'lodash/mapKeys';
 
-import { sueFetchObj, sueServicesUrl } from '../../helpers';
+import { fetchSueEndpoints } from '../../helpers';
 
 export const services = async () => {
+  const { sueFetchObj = {}, sueServicesUrl = '' } = await fetchSueEndpoints();
+
   const response = await (await fetch(`${sueServicesUrl}`, sueFetchObj)).json();
 
   return new Promise((resolve) => {

--- a/src/queries/SUE/statuses.tsx
+++ b/src/queries/SUE/statuses.tsx
@@ -1,9 +1,11 @@
 import _camelCase from 'lodash/camelCase';
 import _mapKeys from 'lodash/mapKeys';
 
-import { sueFetchObj, sueStatusesUrl } from '../../helpers';
+import { fetchSueEndpoints } from '../../helpers';
 
 export const statuses = async () => {
+  const { sueFetchObj = {}, sueStatusesUrl = '' } = await fetchSueEndpoints();
+
   const response = await (await fetch(`${sueStatusesUrl}`, sueFetchObj)).json();
 
   return new Promise((resolve) => {

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -115,7 +115,7 @@ export const SueReportScreen = ({
 
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
-  const { limitOfArea = {} } = settings;
+  const { limitOfArea = {} } = settings?.sue;
   const {
     city: limitOfCity = '',
     zipCodes: limitOfZipCodes = [],


### PR DESCRIPTION
- added `fetchSueEndpoints` function to `sueHelper` to update `apiKey` via `globalSettings`
- integrated `fetchSueEndpoints` into queries
- updated `SueReportScreen` because the `limitOfArea` object has been moved into the `sue` object

SUE-82

## For Test:

create a new object named `sue` inside the `settings` object in `globalSettings` for testing
create an object called `apiConfig` inside the `sue`
```
"settings": {
    "sue": {
      "apiConfig": {},
    }
  },
```

the `apiConfig` object may look as follows
```
"apiConfig": {
  "serverUrl": "xxx",
  "apiKey": "xxx",
  "jurisdictionId": "1"
}
```
```
"apiConfig": {
  "whichApi": "testApi",
  "testApi": {
    "serverUrl": "xxx",
    "apiKey": "xxx",
    "jurisdictionId": "2"
  },
  "productionApi": {
    "serverUrl": "xxx",
    "apiKey": "xxx",
    "jurisdictionId": "3"
  }
}
```
If more than one api is used and you need to switch between them, replace the text in the `whichApi` section with the name of the api object you want.

If only one api is to be used, you can write the necessary information directly into the `apiConfig`.