### PR TITLE
feat: expand `PermanentFilterProvider` with `mowasRegionalKeys`

### DIFF
--- a/src/PermanentFilterProvider.tsx
+++ b/src/PermanentFilterProvider.tsx
@@ -2,26 +2,46 @@ import { noop } from 'lodash';
 import React, { createContext, useCallback, useEffect, useReducer } from 'react';
 
 import { readFromStore } from './helpers';
-import { DATA_PROVIDER_FILTER_KEY, permanentFilterReducer } from './reducers';
+import {
+  DATA_PROVIDER_FILTER_KEY,
+  MOWAS_REGIONAL_KEYS,
+  MowasFilterAction,
+  MowasFilterReducerAction,
+  mowasRegionalKeysReducer,
+  permanentFilterReducer
+} from './reducers';
 import { FilterAction, FilterReducerAction } from './types';
 
 type PermanentFilterProviderValues = {
-  state: string[];
-  dispatch: React.Dispatch<FilterReducerAction>;
+  dataProviderState: string[];
+  dataProviderDispatch: React.Dispatch<FilterReducerAction>;
+  mowasRegionalKeysState: string[];
+  mowasRegionalKeysDispatch: React.Dispatch<MowasFilterReducerAction>;
 };
 
 export const PermanentFilterContext = createContext<PermanentFilterProviderValues>({
-  dispatch: noop,
-  state: []
+  dataProviderState: [],
+  dataProviderDispatch: noop,
+  mowasRegionalKeysState: [],
+  mowasRegionalKeysDispatch: noop
 });
 
 export const PermanentFilterProvider = ({ children }: { children?: React.ReactNode }) => {
-  const [state, dispatch] = useReducer(permanentFilterReducer, []);
+  const [dataProviderState, dataProviderDispatch] = useReducer(permanentFilterReducer, []);
+  const [mowasRegionalKeysState, mowasRegionalKeysDispatch] = useReducer(
+    mowasRegionalKeysReducer,
+    []
+  );
 
   const loadFilters = useCallback(async () => {
     const dataProviderIds = ((await readFromStore(DATA_PROVIDER_FILTER_KEY)) ?? []) as string[];
+    const mowasRegionalKeys = ((await readFromStore(MOWAS_REGIONAL_KEYS)) ?? []) as string[];
 
-    dispatch({ type: FilterAction.OverwriteDataProviders, payload: dataProviderIds });
+    dataProviderDispatch({ type: FilterAction.OverwriteDataProviders, payload: dataProviderIds });
+    mowasRegionalKeysDispatch({
+      type: MowasFilterAction.OverwriteMowasRegionalKeys,
+      payload: mowasRegionalKeys
+    });
   }, []);
 
   useEffect(() => {
@@ -29,7 +49,14 @@ export const PermanentFilterProvider = ({ children }: { children?: React.ReactNo
   }, [loadFilters]);
 
   return (
-    <PermanentFilterContext.Provider value={{ dispatch, state }}>
+    <PermanentFilterContext.Provider
+      value={{
+        dataProviderState,
+        dataProviderDispatch,
+        mowasRegionalKeysState,
+        mowasRegionalKeysDispatch
+      }}
+    >
       {children}
     </PermanentFilterContext.Provider>
   );

--- a/src/PermanentFilterProvider.tsx
+++ b/src/PermanentFilterProvider.tsx
@@ -13,10 +13,10 @@ import {
 import { FilterAction, FilterReducerAction } from './types';
 
 type PermanentFilterProviderValues = {
-  dataProviderState: string[];
   dataProviderDispatch: React.Dispatch<FilterReducerAction>;
-  mowasRegionalKeysState: string[];
+  dataProviderState: string[];
   mowasRegionalKeysDispatch: React.Dispatch<MowasFilterReducerAction>;
+  mowasRegionalKeysState: string[];
 };
 
 export const PermanentFilterContext = createContext<PermanentFilterProviderValues>({
@@ -51,10 +51,10 @@ export const PermanentFilterProvider = ({ children }: { children?: React.ReactNo
   return (
     <PermanentFilterContext.Provider
       value={{
-        dataProviderState,
         dataProviderDispatch,
-        mowasRegionalKeysState,
-        mowasRegionalKeysDispatch
+        dataProviderState,
+        mowasRegionalKeysDispatch,
+        mowasRegionalKeysState
       }}
     >
       {children}

--- a/src/components/DropdownHeader.js
+++ b/src/components/DropdownHeader.js
@@ -11,7 +11,7 @@ import { QUERY_TYPES } from '../queries';
 import { DropdownSelect } from './DropdownSelect';
 import { Wrapper } from './Wrapper';
 
-const dropdownEntries = (query, queryVariables, data, excludedDataProviders, isLocationFilter) => {
+const dropdownEntries = (query, queryVariables, data, excludeDataProviderIds, isLocationFilter) => {
   // check if there is something set in the certain `queryVariables`
   // if not, - Alle - will be selected in the `dropdownData`
   const selected = {
@@ -55,7 +55,7 @@ const dropdownEntries = (query, queryVariables, data, excludedDataProviders, isL
     }
   } else if (query === QUERY_TYPES.NEWS_ITEMS) {
     const filteredDataProviders = data?.dataProviders?.filter(
-      (dataProvider) => !excludedDataProviders.includes(dataProvider.id)
+      (dataProvider) => !excludeDataProviderIds.includes(dataProvider.id)
     );
 
     if (filteredDataProviders?.length) {
@@ -89,10 +89,10 @@ export const DropdownHeader = ({
     [QUERY_TYPES.NEWS_ITEMS]: 'value'
   }[query];
 
-  const { state: excludedDataProviders } = usePermanentFilter();
+  const { excludeDataProviderIds } = usePermanentFilter();
 
   const [dropdownData, setDropdownData] = useState(
-    dropdownEntries(query, queryVariables, data, excludedDataProviders, isLocationFilter)
+    dropdownEntries(query, queryVariables, data, excludeDataProviderIds, isLocationFilter)
   );
 
   const selectedDropdownData = dropdownData?.find((entry) => entry.selected) || {};
@@ -102,7 +102,7 @@ export const DropdownHeader = ({
 
   useEffect(() => {
     setDropdownData(
-      dropdownEntries(query, queryVariables, data, excludedDataProviders, isLocationFilter)
+      dropdownEntries(query, queryVariables, data, excludeDataProviderIds, isLocationFilter)
     );
   }, [data]);
 

--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -64,7 +64,12 @@ const keyForSelectedValueByQuery = (query) => {
   return QUERIES[query];
 };
 
-const getAdditionalQueryVariables = (query, selectedValue, excludeDataProviderIds) => {
+const getAdditionalQueryVariables = (
+  query,
+  selectedValue,
+  excludeDataProviderIds,
+  excludeMowasRegionalKeys
+) => {
   const keyForSelectedValue = keyForSelectedValueByQuery(query);
   const additionalQueryVariables = {};
 
@@ -74,6 +79,10 @@ const getAdditionalQueryVariables = (query, selectedValue, excludeDataProviderId
 
   if (excludeDataProviderIds?.length) {
     additionalQueryVariables.excludeDataProviderIds = excludeDataProviderIds;
+  }
+
+  if (excludeMowasRegionalKeys?.length) {
+    additionalQueryVariables.excludeMowasRegionalKeys = excludeMowasRegionalKeys;
   }
 
   return additionalQueryVariables;
@@ -122,7 +131,7 @@ export const Overviews = ({ navigation, route }) => {
   const showMap = isMapSelected(query, filterType);
   const sortByDistance = query === QUERY_TYPES.POINTS_OF_INTEREST;
   const [filterByOpeningTimes, setFilterByOpeningTimes] = useState(false);
-  const { state: excludeDataProviderIds } = usePermanentFilter();
+  const { excludeDataProviderIds, excludeMowasRegionalKeys } = usePermanentFilter();
   const { loading: loadingPosition, position } = usePosition(!sortByDistance);
   const title = route.params?.title ?? '';
   const titleDetail = route.params?.titleDetail ?? '';
@@ -168,7 +177,12 @@ export const Overviews = ({ navigation, route }) => {
 
           return {
             ...prevQueryVariables,
-            ...getAdditionalQueryVariables(query, selectedValue, excludeDataProviderIds)
+            ...getAdditionalQueryVariables(
+              query,
+              selectedValue,
+              excludeDataProviderIds,
+              excludeMowasRegionalKeys
+            )
           };
         });
       } else {
@@ -182,7 +196,7 @@ export const Overviews = ({ navigation, route }) => {
         }
       }
     },
-    [query, queryVariables, excludeDataProviderIds]
+    [query, queryVariables, excludeDataProviderIds, excludeMowasRegionalKeys]
   );
 
   const listItems = useMemo(() => {
@@ -229,9 +243,14 @@ export const Overviews = ({ navigation, route }) => {
     // the query is not returning anything.
     setQueryVariables({
       ...(route.params?.queryVariables ?? {}),
-      ...getAdditionalQueryVariables(query, undefined, excludeDataProviderIds)
+      ...getAdditionalQueryVariables(
+        query,
+        undefined,
+        excludeDataProviderIds,
+        excludeMowasRegionalKeys
+      )
     });
-  }, [route.params?.queryVariables, query, excludeDataProviderIds]);
+  }, [route.params?.queryVariables, query, excludeDataProviderIds, excludeMowasRegionalKeys]);
 
   useLayoutEffect(() => {
     if (

--- a/src/components/settings/PermanentFilterSettings.tsx
+++ b/src/components/settings/PermanentFilterSettings.tsx
@@ -20,7 +20,8 @@ export const PermanentFilterSettings = () => {
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
 
-  const { state: excludedDataProviderIds, dispatch } = usePermanentFilter();
+  const { excludeDataProviderIds: excludedDataProviderIds, dataProviderDispatch: dispatch } =
+    usePermanentFilter();
 
   const { data, loading } = useQuery(getQuery(QUERY_TYPES.NEWS_ITEMS_DATA_PROVIDER), {
     fetchPolicy

--- a/src/hooks/permanentFilter.ts
+++ b/src/hooks/permanentFilter.ts
@@ -2,4 +2,21 @@ import { useContext } from 'react';
 
 import { PermanentFilterContext } from '../PermanentFilterProvider';
 
-export const usePermanentFilter = () => useContext(PermanentFilterContext);
+export const usePermanentFilter = () => {
+  const {
+    dataProviderState,
+    dataProviderDispatch,
+    mowasRegionalKeysState,
+    mowasRegionalKeysDispatch
+  } = useContext(PermanentFilterContext);
+
+  const excludeDataProviderIds = dataProviderState;
+  const excludeMowasRegionalKeys = mowasRegionalKeysState;
+
+  return {
+    excludeDataProviderIds,
+    excludeMowasRegionalKeys,
+    dataProviderDispatch,
+    mowasRegionalKeysDispatch
+  };
+};

--- a/src/hooks/permanentFilter.ts
+++ b/src/hooks/permanentFilter.ts
@@ -4,19 +4,16 @@ import { PermanentFilterContext } from '../PermanentFilterProvider';
 
 export const usePermanentFilter = () => {
   const {
-    dataProviderState,
     dataProviderDispatch,
-    mowasRegionalKeysState,
-    mowasRegionalKeysDispatch
+    dataProviderState,
+    mowasRegionalKeysDispatch,
+    mowasRegionalKeysState
   } = useContext(PermanentFilterContext);
 
-  const excludeDataProviderIds = dataProviderState;
-  const excludeMowasRegionalKeys = mowasRegionalKeysState;
-
   return {
-    excludeDataProviderIds,
-    excludeMowasRegionalKeys,
     dataProviderDispatch,
+    excludeDataProviderIds: dataProviderState,
+    excludeMowasRegionalKeys: mowasRegionalKeysState,
     mowasRegionalKeysDispatch
   };
 };

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -8,7 +8,7 @@ export const GET_NEWS_ITEMS = gql`
     $dataProvider: String
     $dataProviderId: ID
     $excludeDataProviderIds: [ID]
-    $excludeMowasRegionalKeys: [ID]
+    $excludeMowasRegionalKeys: [String]
     $categoryId: ID
     $categoryIds: [ID]
   ) {

--- a/src/queries/newsItems.js
+++ b/src/queries/newsItems.js
@@ -8,6 +8,7 @@ export const GET_NEWS_ITEMS = gql`
     $dataProvider: String
     $dataProviderId: ID
     $excludeDataProviderIds: [ID]
+    $excludeMowasRegionalKeys: [ID]
     $categoryId: ID
     $categoryIds: [ID]
   ) {
@@ -18,6 +19,7 @@ export const GET_NEWS_ITEMS = gql`
       dataProvider: $dataProvider
       dataProviderId: $dataProviderId
       excludeDataProviderIds: $excludeDataProviderIds
+      excludeMowasRegionalKeys: $excludeMowasRegionalKeys
       categoryId: $categoryId
       categoryIds: $categoryIds
     ) {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -198,7 +198,7 @@ export const HomeScreen = ({ navigation, route }) => {
   } = staticContentList;
   const { events: showVolunteerEvents = false } = hdvt;
   const [refreshing, setRefreshing] = useState(false);
-  const { state: excludeDataProviderIds } = usePermanentFilter();
+  const { excludeDataProviderIds, excludeMowasRegionalKeys } = usePermanentFilter();
 
   const interactionHandler = useCallback(
     (response) => {
@@ -281,7 +281,7 @@ export const HomeScreen = ({ navigation, route }) => {
       limit: limitNews,
       navigation,
       query: QUERY_TYPES.NEWS_ITEMS,
-      queryVariables: { limit: 3, excludeDataProviderIds },
+      queryVariables: { limit: 3, excludeDataProviderIds, excludeMowasRegionalKeys },
       showData: showNews
     },
     {


### PR DESCRIPTION
- updated `PermanentFilterProviderValues` type to include separate state and dispatch variables for `dataProviderIds` and `mowasRegionalKeys`
- updated `PermanentFilterContext` to reflect the changes in `PermanentFilterProviderValues`
- extended `PermanentFilterProvider` to use `mowasRegionalKeysReducer` and added logic to load and dispatch `mowasRegionalKeys` alongside `dataProviderIds`
- refactored the `usePermanentFilter` hook to return `excludeDataProviderIds` and `excludeMowasRegionalKeys`
- updated `PermanentFilterSettings` to integrate the change to the `usePermanentFilter` hook
- integrated changes to the `usePermanentFilter` hook into `Overviews` and `HomeScreen`
- added `excludeMowasRegionalKeys` `queryVariables` to `newsItems` query
- added `excludeMowasRegionalKeys` to `queryVariables` in `Overviews` and `HomeScreen`

SVAK-37

Since the `newsItems` query does not have the `excludeDataProviderIds` `queryVariables`, the data is not currently visible. The data will be displayed after the query has this `queryVariables`.

## Test:

Please attach the following log to `HomeScreen` for testing.
```
console.warn({ excludeDataProviderIds, excludeMowasRegionalKeys });
```
Then go to the `SettingsScreen` and change the switchers in the Datenquellen or MoWaS-Regionen section. When you refresh the app, you will see the following text on the log screen.
```
{"excludeDataProviderIds": ["5"], "excludeMowasRegionalKeys": ["120630008008"]}
```