### PR TITLE
feat(voucher): add qr code scan screen

### DIFF
--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -157,6 +157,11 @@ export const consts = {
     }
   },
 
+  HOST_NAMES: {
+    DETAIL: 'detail',
+    ENCOUNTER: 'encounter'
+  },
+
   LIST_TYPES: {
     CARD_LIST: 'cardList',
     IMAGE_TEXT_LIST: 'imageTextList',

--- a/src/config/navigation/config.ts
+++ b/src/config/navigation/config.ts
@@ -12,6 +12,7 @@ export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
   };
   const screens = {
     [ScreenName.EncounterUserDetail]: 'encounter',
+    [ScreenName.Detail]: 'detail',
     [ScreenName.Home]: '*'
   };
 

--- a/src/config/navigation/config.ts
+++ b/src/config/navigation/config.ts
@@ -2,8 +2,11 @@ import { LinkingOptions } from '@react-navigation/native';
 import * as Linking from 'expo-linking';
 
 import { NavigatorConfig, ScreenName } from '../../types';
+import { consts } from '../consts';
 
 import { tabNavigatorConfig } from './tabConfig';
+
+const { HOST_NAMES } = consts;
 
 export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
   let navigatorConfig: NavigatorConfig;
@@ -11,8 +14,8 @@ export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
     prefixes: [Linking.createURL('/')]
   };
   const screens = {
-    [ScreenName.EncounterUserDetail]: 'encounter',
-    [ScreenName.Detail]: 'detail',
+    [ScreenName.EncounterUserDetail]: HOST_NAMES.ENCOUNTER,
+    [ScreenName.Detail]: HOST_NAMES.DETAIL,
     [ScreenName.Home]: '*'
   };
 

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -64,6 +64,7 @@ import {
   VoucherHomeScreen,
   VoucherIndexScreen,
   VoucherLoginScreen,
+  VoucherScannerScreen,
   WasteCollectionScreen,
   WasteReminderScreen,
   WeatherScreen,
@@ -437,6 +438,11 @@ export const defaultStackConfig = ({
       routeName: ScreenName.VoucherLogin,
       screenComponent: VoucherLoginScreen,
       screenOptions: { title: texts.screenTitles.voucher.home }
+    },
+    {
+      routeName: ScreenName.VoucherScanner,
+      screenComponent: VoucherScannerScreen,
+      screenOptions: { title: texts.screenTitles.voucher.qr }
     },
     {
       routeName: ScreenName.WasteCollection,

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -824,7 +824,9 @@ export const texts = {
     },
     voucher: {
       home: 'TreueClub',
-      index: 'Neue Angebote'
+      index: 'Neue Angebote',
+      partner: 'Kooperationspartner',
+      qr: 'Code scannen'
     },
     wasteCollection: 'Abfallkalender',
     weather: 'Wetter'
@@ -1171,6 +1173,12 @@ export const texts = {
     offersCategories: 'Angebote Kategorien',
     result: 'Ergebnis',
     results: 'Ergebnisse',
+    scannerScreen: {
+      errorBody:
+        'Beim Scannen des Codes ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.',
+      errorButton: 'Erneut versuchen',
+      errorTitle: 'Fehler'
+    },
     secret: 'Kundennummer'
   },
   wasteCalendar: {

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1140,6 +1140,8 @@ export const texts = {
       close: 'Schließen',
       daily: 'pro Tag',
       desiredQuantity: 'Gewünschte Anzahl',
+      emptyMessage:
+        'Der Inhalt kann nicht geladen werden. Bitte überprüfen Sie Ihre Internetverbindung.',
       frequency: (maxPerPerson, frequency) =>
         `${maxPerPerson}x pro Person ${texts.voucher.detailScreen[frequency]} einlösbar`,
       limit: (availableQuantity, maxQuantity) =>
@@ -1174,8 +1176,7 @@ export const texts = {
     result: 'Ergebnis',
     results: 'Ergebnisse',
     scannerScreen: {
-      errorBody:
-        'Beim Scannen des Codes ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.',
+      errorBody: 'Beim Scannen des Codes ist ein Fehler aufgetreten. Bitte erneut versuchen.',
       errorButton: 'Erneut versuchen',
       errorTitle: 'Fehler'
     },

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -4,6 +4,7 @@ import { Query } from 'react-apollo';
 import { ActivityIndicator, RefreshControl, ScrollView } from 'react-native';
 
 import {
+  EmptyMessage,
   EventRecord,
   LoadingContainer,
   NewsItem,
@@ -13,7 +14,7 @@ import {
   Tour
 } from '../components';
 import { FeedbackFooter } from '../components/FeedbackFooter';
-import { colors, consts } from '../config';
+import { colors, consts, texts } from '../config';
 import { graphqlFetchPolicy } from '../helpers';
 import { useRefreshTime } from '../hooks';
 import { NetworkContext } from '../NetworkProvider';
@@ -83,8 +84,8 @@ const useRootRouteByCategory = (details, navigation) => {
 export const DetailScreen = ({ navigation, route }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const query = route.params?.query ?? '';
-  const detailId = route.params?.id ?? undefined;
-  const queryVariables = route.params?.queryVariables || detailId ? { id: detailId } : {};
+  const id = route.params?.id;
+  const queryVariables = route.params?.queryVariables || id ? { id } : {};
   const details = route.params?.details ?? {};
   const [today] = useState(new Date().toISOString());
 
@@ -134,7 +135,8 @@ export const DetailScreen = ({ navigation, route }) => {
 
         // we can have `data` from GraphQL or `details` from the previous list view.
         // if there is no cached `data` or network fetched `data` we fallback to the `details`.
-        if ((!data || !data[query]) && !details) return null;
+        if ((!data || !data[query]) && !details)
+          return <EmptyMessage title={texts.voucher.detailScreen.emptyMessage} />;
 
         const Component = getComponent(query, data?.[query]?.genericType ?? details?.genericType);
 

--- a/src/screens/DetailScreen.js
+++ b/src/screens/DetailScreen.js
@@ -83,7 +83,8 @@ const useRootRouteByCategory = (details, navigation) => {
 export const DetailScreen = ({ navigation, route }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const query = route.params?.query ?? '';
-  const queryVariables = route.params?.queryVariables ?? {};
+  const detailId = route.params?.id ?? undefined;
+  const queryVariables = route.params?.queryVariables || detailId ? { id: detailId } : {};
   const details = route.params?.details ?? {};
   const [today] = useState(new Date().toISOString());
 

--- a/src/screens/EncounterScannerScreen.tsx
+++ b/src/screens/EncounterScannerScreen.tsx
@@ -14,10 +14,12 @@ import {
   Wrapper
 } from '../components';
 import { LoadingSpinner } from '../components/LoadingSpinner';
-import { device, texts } from '../config';
+import { consts, device, texts } from '../config';
 import { getBestSupportedRatioWithRetry, getNumericalRatioFromAspectRatio } from '../helpers';
 import { useCreateEncounter } from '../hooks';
 import { AcceptedRatio, ScreenName, User } from '../types';
+
+const { HOST_NAMES } = consts;
 
 const useOrientationLock = () =>
   useEffect(() => {
@@ -32,7 +34,7 @@ const showErrorAlert = () => Alert.alert(texts.errors.errorTitle, texts.encounte
 const parseQrCode = (data: string): string | undefined => {
   const result = Linking.parse(data);
 
-  if (result.scheme === appJson.expo.scheme && result.hostname === 'encounter') {
+  if (result.scheme === appJson.expo.scheme && result.hostname === HOST_NAMES.ENCOUNTER) {
     return result.queryParams?.qrId;
   }
 };

--- a/src/screens/Voucher/VoucherScannerScreen.tsx
+++ b/src/screens/Voucher/VoucherScannerScreen.tsx
@@ -6,16 +6,18 @@ import { Alert, StyleSheet } from 'react-native';
 
 import appJson from '../../../app.json';
 import { SafeAreaViewFlex } from '../../components';
-import { texts } from '../../config';
+import { consts, texts } from '../../config';
 import { ScreenName } from '../../types';
 import { QUERY_TYPES } from '../../queries';
+
+const { HOST_NAMES } = consts;
 
 const parseQrCode = (
   data: string
 ): { query: string; queryVariables: { id: number | undefined } } => {
   const result = Linking.parse(data);
 
-  if (result.scheme === appJson.expo.scheme && result.hostname === 'detail') {
+  if (result.scheme === appJson.expo.scheme && result.hostname === HOST_NAMES.DETAIL) {
     const id = result.queryParams?.id as number | undefined;
     const query = result.queryParams?.query?.toString() || '';
 
@@ -33,6 +35,7 @@ export const VoucherScannerScreen = ({ navigation }: StackScreenProps<any>) => {
 
     if (!queryVariables?.id) {
       setIsScanning(false);
+
       return Alert.alert(
         texts.voucher.scannerScreen.errorTitle,
         texts.voucher.scannerScreen.errorBody,

--- a/src/screens/Voucher/VoucherScannerScreen.tsx
+++ b/src/screens/Voucher/VoucherScannerScreen.tsx
@@ -1,0 +1,69 @@
+import { StackScreenProps } from '@react-navigation/stack';
+import { BarCodeScanningResult, Camera } from 'expo-camera';
+import * as Linking from 'expo-linking';
+import React, { useState } from 'react';
+import { Alert, StyleSheet } from 'react-native';
+
+import appJson from '../../../app.json';
+import { SafeAreaViewFlex } from '../../components';
+import { texts } from '../../config';
+import { ScreenName } from '../../types';
+import { QUERY_TYPES } from '../../queries';
+
+const parseQrCode = (
+  data: string
+): { query: string; queryVariables: { id: number | undefined } } => {
+  const result = Linking.parse(data);
+
+  if (result.scheme === appJson.expo.scheme && result.hostname === 'detail') {
+    const id = result.queryParams?.id as number | undefined;
+    const query = result.queryParams?.query?.toString() || '';
+
+    return { query, queryVariables: { id } };
+  }
+
+  return { query: QUERY_TYPES.POINT_OF_INTEREST, queryVariables: { id: undefined } };
+};
+
+export const VoucherScannerScreen = ({ navigation }: StackScreenProps<any>) => {
+  const [isScanning, setIsScanning] = useState(true);
+
+  const handleBarCodeScanned = ({ data }: BarCodeScanningResult) => {
+    const { query, queryVariables } = parseQrCode(data);
+
+    if (!queryVariables?.id) {
+      setIsScanning(false);
+      return Alert.alert(
+        texts.voucher.scannerScreen.errorTitle,
+        texts.voucher.scannerScreen.errorBody,
+        [
+          {
+            text: texts.voucher.scannerScreen.errorButton,
+            onPress: () => setIsScanning(true)
+          }
+        ]
+      );
+    }
+
+    return navigation.navigate(ScreenName.Detail, {
+      queryVariables,
+      query,
+      title: texts.screenTitles.voucher.partner
+    });
+  };
+
+  return (
+    <SafeAreaViewFlex>
+      {isScanning ? (
+        <Camera onBarCodeScanned={handleBarCodeScanned} style={styles.scanner} />
+      ) : null}
+    </SafeAreaViewFlex>
+  );
+};
+
+const styles = StyleSheet.create({
+  scanner: {
+    height: '100%',
+    width: '100%'
+  }
+});

--- a/src/screens/Voucher/index.ts
+++ b/src/screens/Voucher/index.ts
@@ -2,3 +2,4 @@ export * from './VoucherDetailScreen';
 export * from './VoucherHomeScreen';
 export * from './VoucherIndexScreen';
 export * from './VoucherLoginScreen';
+export * from './VoucherScannerScreen';

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -70,6 +70,7 @@ export enum ScreenName {
   VoucherHome = 'VoucherHome',
   VoucherIndex = 'VoucherIndex',
   VoucherLogin = 'VoucherLogin',
+  VoucherScanner = 'VoucherScanner',
   WasteCollection = 'WasteCollection',
   WasteReminder = 'WasteReminder',
   Weather = 'Weather',


### PR DESCRIPTION
- added `detail` to `screens` object in `config.ts` to redirect qr codes read with system camera to `DetailScreen` in the app
- added `VoucherScannerScreen` to be able to scan qr from within the app
- added `parseQrCode` function to get the data we need for routing from the data generated when qr is scanned
  - the link that should be in the qr is like this -> `smart-village-app://detail?query=pointOfInterest&id=41147`
- added query value as `pointOfInterest` as default, although there is no query value in the data
- added alert to notify the user if the data in the qr does not contain an `id` and added state control to prevent the alert from being rendered infinitely

SVAK-40

## Test:

For the test, go to the VoucherScannerScreen and show the following QR to the camera.

<img width="286" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/00b77059-b66c-40a5-968b-b7281424ee6a">


After the QR is recognised you will be automatically redirected to the `DetailScreen` of the POI with id `41147`


## Screenshots:

|VoucherScannerScreen without QR|VoucherScannerScreen with QR|
|--|--|
![IMG_7010](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/3a7cd5c0-5799-411b-a419-4a4fe6d650eb)|![IMG_7011](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/2bb6bf5a-d429-4b69-8837-263703c55b03)
