### PR TITLE
feat: add answer section to detail screen

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -925,6 +925,7 @@ export const texts = {
     pushNotifications: 'Push-Benachrichtigungen'
   },
   sue: {
+    answer: 'Antworten',
     currentStatus: 'Aktueller Status',
     datetime: 'Datum und Uhrzeit der Meldung',
     description: 'Beschreibung',

--- a/src/screens/SUE/SueDetailScreen.tsx
+++ b/src/screens/SUE/SueDetailScreen.tsx
@@ -60,6 +60,7 @@ export const SueDetailScreen = ({ route }: Props) => {
     mediaUrl,
     requestedDatetime,
     serviceName,
+    serviceNotice,
     status,
     title
   } = data;
@@ -168,6 +169,19 @@ export const SueDetailScreen = ({ route }: Props) => {
         {!!requestedDatetime && <SueDatetime requestedDatetime={requestedDatetime} />}
 
         {!!status && <SueStatuses status={status} />}
+
+        {!!serviceNotice && (
+          <>
+            <WrapperHorizontal>
+              <Divider />
+            </WrapperHorizontal>
+
+            <Wrapper>
+              <BoldText>{texts.sue.answer}</BoldText>
+              <HtmlView html={serviceNotice} />
+            </Wrapper>
+          </>
+        )}
       </ScrollView>
     </SafeAreaViewFlex>
   );


### PR DESCRIPTION
- added `serviceNotice` section from API to be shown in `SueDetailScreen`

SUE-29

## Test:

not every report has an answer. There must be a report with an answer. (Sperrmüll im Park - id 327)

## Screenshots:

|answer section|
|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-02 at 15 45 28](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/572ba782-f572-4e91-a896-6b9edbfd5aaf)
