### PR TITLE
feat: add description of categories to report screen

### DIFF
--- a/src/components/SUE/report/SueReportServices.tsx
+++ b/src/components/SUE/report/SueReportServices.tsx
@@ -6,7 +6,7 @@ import { colors, device, normalize } from '../../../config';
 import { imageHeight } from '../../../helpers';
 import { QUERY_TYPES, getQuery } from '../../../queries';
 import { LoadingSpinner } from '../../LoadingSpinner';
-import { BoldText } from '../../Text';
+import { BoldText, RegularText } from '../../Text';
 
 export const SueReportServices = ({
   serviceCode,
@@ -52,6 +52,12 @@ export const SueReportServices = ({
             ]}
           >
             <BoldText center>{item.serviceName}</BoldText>
+
+            {!!item.description && (
+              <RegularText center smallest numberOfLines={3}>
+                {item.description}
+              </RegularText>
+            )}
           </TouchableOpacity>
         );
       })}


### PR DESCRIPTION
- added description text for categories to be shown in tiles in `SueReportServices`

SUE-84

since there is no limit on the description text, a limit of `numberOfLines={3}` has been added until a better solution is found

## Screenshots:

|iPhone SE|iPhone 15 Pro Max|
|--|--|
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-04-02 at 16 18 38](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/7d44d448-b51d-4a70-9a99-d37993154ed6)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-02 at 16 18 40](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/f19af1c9-deb2-46d0-a149-8998a18a7e04)
