### PR TITLE
chore: compile in the latest xcode version for iOS

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -6,7 +6,10 @@
     "production": {
       "node": "16.13.0",
       "yarn": "1.22.19",
-      "channel": "production"
+      "channel": "production",
+      "ios": {
+        "image": "latest"
+      }
     },
     "preview": {
       "extends": "production",


### PR DESCRIPTION
- updated xcode version in `eas.json` to latest to eliminate Apple's warning when a new build is created

SVA-1305
