### PR TITLE
feat: add voucher list to poi detail screen

### DIFF
--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
-import { View } from 'react-native';
+import React, { useContext, useMemo, useState } from 'react';
+import { FlatList, View } from 'react-native';
 
 import { NetworkContext } from '../../NetworkProvider';
 import { consts, texts } from '../../config';
-import { matomoTrackingString } from '../../helpers';
+import { matomoTrackingString, parseListItemsFromQuery } from '../../helpers';
 import { useMatomoTrackScreenView, useOpenWebScreen } from '../../hooks';
+import { QUERY_TYPES } from '../../queries';
 import { Button } from '../Button';
 import { DataProviderButton } from '../DataProviderButton';
 import { DataProviderNotice } from '../DataProviderNotice';
@@ -16,6 +17,7 @@ import { SectionHeader } from '../SectionHeader';
 import { Wrapper } from '../Wrapper';
 import { InfoCard } from '../infoCard';
 import { Map } from '../map';
+import { VoucherListItem } from '../vouchers';
 
 import { AvailableVehicles } from './AvailableVehicles';
 import { OpeningTimesCard } from './OpeningTimesCard';
@@ -24,14 +26,16 @@ import { PriceCard } from './PriceCard';
 import { TimeTables } from './TimeTables';
 
 const { MATOMO_TRACKING } = consts;
+const INITIAL_VOUCHER_COUNT = 2;
+const INCREMENT_VOUCHER_COUNT = 5;
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const [loadedVoucherDataCount, setLoadedVoucherDataCount] = useState(INITIAL_VOUCHER_COUNT);
   const {
     addresses,
-    payload,
     categories,
     category,
     contact,
@@ -42,9 +46,11 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
     mediaContents,
     openingHours,
     operatingCompany,
+    payload,
     priceInformations,
     title,
     travelTimes,
+    vouchers,
     webUrls
   } = data;
 
@@ -67,6 +73,12 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
     ])
   );
 
+  const voucherListItems = useMemo(() => {
+    return parseListItemsFromQuery(QUERY_TYPES.VOUCHERS, vouchers, undefined, {
+      withDate: false
+    });
+  }, [vouchers]);
+
   const businessAccount = dataProvider?.dataType === 'business_account';
 
   return (
@@ -85,6 +97,28 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
           webUrls={webUrls}
         />
       </Wrapper>
+
+      {!!vouchers?.length && (
+        <View>
+          <SectionHeader title={texts.pointOfInterest.vouchers} />
+          <FlatList
+            data={voucherListItems.slice(0, loadedVoucherDataCount)}
+            renderItem={({ item }) => <VoucherListItem item={item} navigation={navigation} />}
+            ListFooterComponent={() =>
+              voucherListItems.length > loadedVoucherDataCount && (
+                <Wrapper>
+                  <Button
+                    title={texts.pointOfInterest.loadMoreVouchers}
+                    onPress={() =>
+                      setLoadedVoucherDataCount((prev) => prev + INCREMENT_VOUCHER_COUNT)
+                    }
+                  />
+                </Wrapper>
+              )
+            }
+          />
+        </View>
+      )}
 
       {!!payload?.freeStatusUrl && (
         <AvailableVehicles freeStatusUrl={payload.freeStatusUrl} iconName={category?.iconName} />

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -74,9 +74,14 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
   );
 
   const voucherListItems = useMemo(() => {
-    return parseListItemsFromQuery(QUERY_TYPES.VOUCHERS, vouchers, undefined, {
-      withDate: false
-    });
+    return parseListItemsFromQuery(
+      QUERY_TYPES.VOUCHERS,
+      { [QUERY_TYPES.GENERIC_ITEMS]: vouchers },
+      undefined,
+      {
+        withDate: false
+      }
+    );
   }, [vouchers]);
 
   const businessAccount = dataProvider?.dataType === 'business_account';

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1138,6 +1138,8 @@ export const texts = {
       close: 'Schließen',
       daily: 'pro Tag',
       desiredQuantity: 'Gewünschte Anzahl',
+      emptyMessage:
+        'Es tut uns leid. Etwas ist schief gelaufen. Bitte versuchen Sie es später noch einmal.',
       frequency: (maxPerPerson, frequency) =>
         `${maxPerPerson}x pro Person ${texts.voucher.detailScreen[frequency]} einlösbar`,
       limit: (availableQuantity, maxQuantity) =>

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -760,6 +760,7 @@ export const texts = {
     departureTimes: 'Abfahrtszeiten',
     description: 'Beschreibung',
     filterByOpeningTime: 'Nur aktuell geöffnete anzeigen',
+    loadMoreVouchers: 'Mehr anzeigen',
     location: 'Anfahrt',
     noAvailableVehicles: 'Im Moment ist kein Fahrzeug verfügbar',
     openingTime: 'Öffnungszeiten',
@@ -781,6 +782,7 @@ export const texts = {
     },
     showLunches: 'Zum aktuellen Gastro-Angebot',
     today: 'Heute',
+    vouchers: 'Aktuelle Angebote',
     yourPosition: 'Ihre Position'
   },
   pushNotifications: {

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -495,7 +495,7 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
     case QUERY_TYPES.VOLUNTEER.PROFILE:
       return parseVolunteers(data, query, skipLastDivider);
     case QUERY_TYPES.VOUCHERS:
-      return parseVouchers(data[QUERY_TYPES.GENERIC_ITEMS], skipLastDivider);
+      return parseVouchers(data[QUERY_TYPES.GENERIC_ITEMS] || data, skipLastDivider);
     case QUERY_TYPES.VOUCHERS_CATEGORIES:
       return parseVouchersCategories(data[QUERY_TYPES.GENERIC_ITEMS], skipLastDivider);
     case QUERY_TYPES.CONSUL.DEBATES:

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -495,7 +495,7 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
     case QUERY_TYPES.VOLUNTEER.PROFILE:
       return parseVolunteers(data, query, skipLastDivider);
     case QUERY_TYPES.VOUCHERS:
-      return parseVouchers(data[QUERY_TYPES.GENERIC_ITEMS] || data, skipLastDivider);
+      return parseVouchers(data[QUERY_TYPES.GENERIC_ITEMS], skipLastDivider);
     case QUERY_TYPES.VOUCHERS_CATEGORIES:
       return parseVouchersCategories(data[QUERY_TYPES.GENERIC_ITEMS], skipLastDivider);
     case QUERY_TYPES.CONSUL.DEBATES:

--- a/src/queries/pointsOfInterest.js
+++ b/src/queries/pointsOfInterest.js
@@ -202,6 +202,47 @@ export const GET_POINT_OF_INTEREST = gql`
       lunches {
         id
       }
+      vouchers {
+        id
+        updatedAt
+        createdAt
+        publishedAt
+        genericType
+        title
+        categories {
+          name
+          id
+        }
+        discountType {
+          originalPrice
+          discountedPrice
+          discountPercentage
+          discountAmount
+        }
+        quota {
+          id
+          frequency
+          maxQuantity
+          maxPerPerson
+          availableQuantity
+          availableQuantityForMember(memberId: 1)
+        }
+        contentBlocks {
+          id
+          title
+          intro
+          body
+          updatedAt
+          createdAt
+        }
+        dates {
+          id
+          dateStart
+          timeStart
+          dateEnd
+          timeEnd
+        }
+      }
     }
   }
 `;

--- a/src/screens/Voucher/VoucherDetailScreen.tsx
+++ b/src/screens/Voucher/VoucherDetailScreen.tsx
@@ -7,6 +7,7 @@ import { NetworkContext } from '../../NetworkProvider';
 import {
   BoldText,
   Discount,
+  EmptyMessage,
   HtmlView,
   LoadingSpinner,
   RegularText,
@@ -18,6 +19,7 @@ import { graphqlFetchPolicy } from '../../helpers';
 import { QUERY_TYPES, getQuery } from '../../queries';
 import { TVoucherContentBlock } from '../../types';
 
+/* eslint-disable complexity */
 export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
@@ -43,7 +45,12 @@ export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
     return <LoadingSpinner loading />;
   }
 
-  const { contentBlocks, discountType, quota, id } = data[QUERY_TYPES.GENERIC_ITEM];
+  const { contentBlocks, discountType, quota, id } = data[QUERY_TYPES.GENERIC_ITEM] || data;
+
+  if (!quota) {
+    return <EmptyMessage title={texts.voucher.detailScreen.emptyMessage} />;
+  }
+
   const { availableQuantity, frequency, maxPerPerson, maxQuantity } = quota;
 
   return (
@@ -98,3 +105,4 @@ export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
     </ScrollView>
   );
 };
+/* eslint-enable complexity */

--- a/src/screens/Voucher/VoucherDetailScreen.tsx
+++ b/src/screens/Voucher/VoucherDetailScreen.tsx
@@ -45,7 +45,7 @@ export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
     return <LoadingSpinner loading />;
   }
 
-  const { contentBlocks, discountType, quota, id } = data[QUERY_TYPES.GENERIC_ITEM] || data;
+  const { contentBlocks, discountType, quota, id } = data[QUERY_TYPES.GENERIC_ITEM];
 
   if (!quota) {
     return <EmptyMessage title={texts.voucher.detailScreen.emptyMessage} />;


### PR DESCRIPTION
- added `|| data` to `listItemParser` to fix the error that occurs in POI query because the data is not in the `genericItem` object and the direct data is an array
- added `EmptyMessage` component to display the `quota` data in case it is null
- added `FlatList` to show the coupon list if there is voucher data in `DetailScreen`
- added `parseListItemsFromQuery` to convert voucher data to the format requested by `VoucherListItem`
- added the feature that if a POI has more than one voucher, instead of showing all of them, it shows 2 at the beginning and then shows 5 more by pressing the button at the bottom of the list

## Test:
Please change the server connection as the voucher feature is not available on the development server. 
Then follow this path:
Service Tab -> Stadtwerke Tile -> TreueClub Tile -> Kooperations-partner Tile -> Select any POI

## Screenshots:

|POI `DetailScreen`|vouchers list in `DetailScreen` with mehr button|vouchers list|voucher detail screen|
|--|--|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-11 at 10 19 36](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/bc5e54ef-cae6-4e57-ace5-31cc0025cb67)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-11 at 10 19 40](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/5b24f527-be51-4a8b-a3de-306743b61489)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-11 at 10 19 46](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/82640a02-f886-407d-b6b6-d59e118d220a)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-11 at 10 19 50](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/ee918a10-d7ed-4970-9e5f-f3e28b1be1e3)
