### PR TITLE
feat: add member id to query

### DIFF
--- a/src/components/vouchers/VoucherRedeem.tsx
+++ b/src/components/vouchers/VoucherRedeem.tsx
@@ -5,7 +5,7 @@ import CircularProgress from 'react-native-circular-progress-indicator';
 
 import { Icon, colors, normalize, texts } from '../../config';
 import { addToStore, readFromStore } from '../../helpers';
-import { VOUCHER_MEMBER_ID, VOUCHER_TRANSACTIONS } from '../../helpers/voucherHelper';
+import { VOUCHER_TRANSACTIONS } from '../../helpers/voucherHelper';
 import { useVoucher } from '../../hooks';
 import { REDEEM_QUOTA_OF_VOUCHER } from '../../queries/vouchers';
 import { TQuota } from '../../types';
@@ -18,7 +18,7 @@ import { Wrapper, WrapperRow, WrapperVertical } from '../Wrapper';
 const defaultTime = 15 * 60; // 15 * 60 sec.
 
 export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: string }) => {
-  const { isLoggedIn } = useVoucher();
+  const { isLoggedIn, memberId } = useVoucher();
   const [isVisible, setIsVisible] = useState(false);
   const [remainingTime, setRemainingTime] = useState(defaultTime);
   const [isRedeemingVoucher, setIsRedeemingVoucher] = useState(false);
@@ -54,13 +54,11 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
 
   const redeemVoucher = async () => {
     try {
-      const storedVoucherMemberId = await readFromStore(VOUCHER_MEMBER_ID);
-
       redeemQuotaOfVoucher({
         variables: {
           quantity,
           voucherId,
-          memberId: storedVoucherMemberId
+          memberId
         }
       });
 
@@ -68,7 +66,7 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
       const voucherTransaction = {
         quantity,
         voucherId,
-        memberId: storedVoucherMemberId,
+        memberId,
         createdAt: new Date().toISOString()
       };
 

--- a/src/helpers/voucherHelper.ts
+++ b/src/helpers/voucherHelper.ts
@@ -1,4 +1,7 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
+
+import { addToStore, readFromStore } from './storageHelper';
 
 const VOUCHER_AUTH_TOKEN = 'VOUCHER_AUTH_TOKEN';
 export const VOUCHER_MEMBER_ID = 'VOUCHER_MEMBER_ID';
@@ -26,4 +29,28 @@ export const voucherAuthToken = async () => {
   }
 
   return authToken;
+};
+
+export const storeVoucherMemberId = (memberId?: string) => {
+  if (memberId) {
+    addToStore(VOUCHER_MEMBER_ID, memberId);
+  } else {
+    addToStore(VOUCHER_MEMBER_ID);
+  }
+};
+
+export const voucherMemberId = async () => {
+  let memberId = null;
+
+  // The reason for the problem of staying in SplashScreen that occurs after the application is
+  // updated on the Android side is the inability to obtain the token here.
+  // For this reason, try/catch is used here and the problem of getting stuck in SplashScreen is solved.
+  try {
+    memberId = await readFromStore(VOUCHER_MEMBER_ID);
+  } catch {
+    // Token deleted here so that it can be recreated
+    AsyncStorage.removeItem(VOUCHER_MEMBER_ID);
+  }
+
+  return memberId;
 };

--- a/src/hooks/voucherHooks.ts
+++ b/src/hooks/voucherHooks.ts
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
 
-import { voucherAuthToken } from '../helpers/voucherHelper';
+import { voucherAuthToken, voucherMemberId } from '../helpers/voucherHelper';
 import { NetworkContext } from '../NetworkProvider';
 
 export const useVoucher = (): {
@@ -8,11 +8,13 @@ export const useVoucher = (): {
   isLoading: boolean;
   isError: boolean;
   isLoggedIn: boolean;
+  memberId: string | undefined;
 } => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [memberId, setMemberId] = useState<string>();
 
   const logInCallback = useCallback(async () => {
     setIsLoading(true);
@@ -20,8 +22,10 @@ export const useVoucher = (): {
 
     try {
       const storedVoucherAuthToken = await voucherAuthToken();
+      const storedVoucherMemberId = await voucherMemberId();
 
       setIsLoggedIn(!!storedVoucherAuthToken);
+      setMemberId(storedVoucherMemberId);
     } catch (e) {
       console.warn(e);
       setIsError(true);
@@ -43,6 +47,7 @@ export const useVoucher = (): {
     refresh: logInCallback,
     isLoading,
     isError,
-    isLoggedIn
+    isLoggedIn,
+    memberId
   };
 };

--- a/src/queries/vouchers.ts
+++ b/src/queries/vouchers.ts
@@ -3,8 +3,6 @@ import gql from 'graphql-tag';
 import { namespace, secrets } from '../config';
 import { VoucherLogin } from '../types';
 
-// TODO: memberId: 1 will be updated later. 1 will be replaced by the id of the logged in user
-//       which we can receive via `readFromStore(VOUCHER_MEMBER_ID)`
 export const GET_VOUCHERS = gql`
   query GenericItems(
     $ids: [ID]
@@ -13,6 +11,7 @@ export const GET_VOUCHERS = gql`
     $order: GenericItemOrder
     $dataProvider: String
     $categoryId: ID
+    $memberId: Int!
   ) {
     genericItems(
       ids: $ids
@@ -46,7 +45,6 @@ export const GET_VOUCHERS = gql`
         maxQuantity
         maxPerPerson
         availableQuantity
-        availableQuantityForMember(memberId: 1)
       }
       contentBlocks {
         id
@@ -62,13 +60,14 @@ export const GET_VOUCHERS = gql`
         timeStart
         dateEnd
         timeEnd
+        availableQuantityForMember(memberId: $memberId)
       }
     }
   }
 `;
 
 export const GET_VOUCHER = gql`
-  query GenericItem($id: ID!) {
+  query GenericItem($id: ID!, $memberId: Int!) {
     genericItem(id: $id) {
       id
       title
@@ -87,7 +86,7 @@ export const GET_VOUCHER = gql`
         maxQuantity
         maxPerPerson
         availableQuantity
-        availableQuantityForMember(memberId: 1)
+        availableQuantityForMember(memberId: $memberId)
       }
       contentBlocks {
         id

--- a/src/screens/Voucher/VoucherDetailScreen.tsx
+++ b/src/screens/Voucher/VoucherDetailScreen.tsx
@@ -15,10 +15,12 @@ import {
 } from '../../components';
 import { colors, texts } from '../../config';
 import { graphqlFetchPolicy } from '../../helpers';
+import { useVoucher } from '../../hooks';
 import { QUERY_TYPES, getQuery } from '../../queries';
 import { TVoucherContentBlock } from '../../types';
 
 export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
+  const { memberId } = useVoucher();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
   const [refreshing, setRefreshing] = useState(false);
@@ -27,7 +29,7 @@ export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
   const queryVariables = route.params?.queryVariables ?? {};
 
   const { data, loading, refetch } = useQuery(getQuery(query), {
-    variables: queryVariables,
+    variables: { memberId, ...queryVariables },
     fetchPolicy
   });
 

--- a/src/screens/Voucher/VoucherIndexScreen.tsx
+++ b/src/screens/Voucher/VoucherIndexScreen.tsx
@@ -38,7 +38,7 @@ const hasFilterSelection = (queryVariables: any) => {
 
 /* eslint-disable complexity */
 export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>) => {
-  const { isLoggedIn } = useVoucher();
+  const { isLoggedIn, memberId } = useVoucher();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
 
@@ -50,7 +50,7 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
 
   const { data, loading, fetchMore, refetch } = useQuery(getQuery(query), {
     fetchPolicy,
-    variables: { limit: 20, order: 'createdAt_ASC', ...queryVariables }
+    variables: { limit: 20, order: 'createdAt_ASC', memberId, ...queryVariables }
   });
 
   const { data: vouchersCategories } = useQuery(getQuery(QUERY_TYPES.VOUCHERS_CATEGORIES), {

--- a/src/screens/Voucher/VoucherLoginScreen.tsx
+++ b/src/screens/Voucher/VoucherLoginScreen.tsx
@@ -17,7 +17,11 @@ import {
 } from '../../components';
 import { colors, texts } from '../../config';
 import { addToStore } from '../../helpers';
-import { VOUCHER_MEMBER_ID, storeVoucherAuthToken } from '../../helpers/voucherHelper';
+import {
+  VOUCHER_MEMBER_ID,
+  storeVoucherAuthToken,
+  storeVoucherMemberId
+} from '../../helpers/voucherHelper';
 import { useStaticContent } from '../../hooks';
 import { logIn } from '../../queries/vouchers';
 import { ScreenName, VoucherLogin } from '../../types';
@@ -55,7 +59,7 @@ export const VoucherLoginScreen = ({ navigation }: StackScreenProps<any>) => {
 
         // save auth token and member id to global state
         storeVoucherAuthToken(responseData.member.authentication_token);
-        addToStore(VOUCHER_MEMBER_ID, responseData.member.id);
+        storeVoucherMemberId(responseData.member.id);
 
         // refreshAuth param causes the home screen to update and no longer show the login button
         navigation.navigate(ScreenName.VoucherHome, { refreshAuth: new Date().valueOf() });


### PR DESCRIPTION
- added `storeVoucherMemberId` to save `memberId` to device
- added `voucherMemberId` to read saved `memberId` data
- updated `addToStore` with `storeVoucherMemberId` to save `memberId` to device after login process
- added `memberId` value to queries as `queryVariables`
- added `memberId` to `voucherHook` to read `memberId` data from everywhere via `useVoucher` hook
- integrated `memberId` which can be read via `useVoucher` into screens and added as queryVariables

SVAK-35