### PR TITLE
feat: add `deviceToken` for redeem voucher

### DIFF
--- a/src/components/vouchers/VoucherRedeem.tsx
+++ b/src/components/vouchers/VoucherRedeem.tsx
@@ -2,10 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { useMutation } from 'react-apollo';
 import { Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
 import CircularProgress from 'react-native-circular-progress-indicator';
+import { v4 as uuid } from 'uuid';
 
 import { Icon, colors, normalize, texts } from '../../config';
 import { addToStore, readFromStore } from '../../helpers';
-import { VOUCHER_MEMBER_ID, VOUCHER_TRANSACTIONS } from '../../helpers/voucherHelper';
+import {
+  VOUCHER_DEVICE_TOKEN,
+  VOUCHER_MEMBER_ID,
+  VOUCHER_TRANSACTIONS
+} from '../../helpers/voucherHelper';
 import { useVoucher } from '../../hooks';
 import { REDEEM_QUOTA_OF_VOUCHER } from '../../queries/vouchers';
 import { TQuota } from '../../types';
@@ -55,9 +60,16 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
   const redeemVoucher = async () => {
     try {
       const storedVoucherMemberId = await readFromStore(VOUCHER_MEMBER_ID);
+      let deviceToken = await readFromStore(VOUCHER_DEVICE_TOKEN);
+
+      if (!deviceToken) {
+        deviceToken = uuid();
+        addToStore(VOUCHER_DEVICE_TOKEN, deviceToken);
+      }
 
       redeemQuotaOfVoucher({
         variables: {
+          deviceToken,
           quantity,
           voucherId,
           memberId: storedVoucherMemberId
@@ -66,6 +78,7 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
 
       const voucherTransactions = (await readFromStore(VOUCHER_TRANSACTIONS)) || [];
       const voucherTransaction = {
+        deviceToken,
         quantity,
         voucherId,
         memberId: storedVoucherMemberId,

--- a/src/helpers/voucherHelper.ts
+++ b/src/helpers/voucherHelper.ts
@@ -3,6 +3,7 @@ import * as SecureStore from 'expo-secure-store';
 const VOUCHER_AUTH_TOKEN = 'VOUCHER_AUTH_TOKEN';
 export const VOUCHER_MEMBER_ID = 'VOUCHER_MEMBER_ID';
 export const VOUCHER_TRANSACTIONS = 'VOUCHER_TRANSACTIONS';
+export const VOUCHER_DEVICE_TOKEN = 'VOUCHER_DEVICE_TOKEN';
 
 export const storeVoucherAuthToken = (authToken?: string) => {
   if (authToken) {


### PR DESCRIPTION
- added `uuid` to create a unique `deviceToken` when using voucher
- added the ability to create and save a `deviceToken` to the device if there is no `deviceToken` saved on the device

SVAK-35