### PR TITLE
fix: listing error for vouchers in favourites

### DIFF
--- a/src/components/bookmarks/BookmarkSection.tsx
+++ b/src/components/bookmarks/BookmarkSection.tsx
@@ -2,11 +2,12 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useCallback, useContext, useEffect } from 'react';
 import { useQuery } from 'react-apollo';
 
+import { NetworkContext } from '../../NetworkProvider';
 import { consts, texts } from '../../config';
 import { graphqlFetchPolicy } from '../../helpers';
 import { useRefreshTime } from '../../hooks';
-import { NetworkContext } from '../../NetworkProvider';
 import { getQuery } from '../../queries';
+import { ScreenName } from '../../types';
 import { DataListSection } from '../DataListSection';
 
 const { REFRESH_INTERVALS } = consts;
@@ -46,7 +47,7 @@ export const BookmarkSection = ({
 
   const onPressShowMore = useCallback(
     () =>
-      navigation.navigate('BookmarkCategory', {
+      navigation.navigate(ScreenName.BookmarkCategory, {
         suffix,
         query,
         title: sectionTitle,

--- a/src/components/vouchers/VoucherList.tsx
+++ b/src/components/vouchers/VoucherList.tsx
@@ -31,7 +31,7 @@ const sectionData = (data: TVoucherItem[]) => {
     const resultArray = [];
 
     for (const category in groupedData) {
-      resultArray.push(category);
+      resultArray.push({ name: category, id: groupedData?.[category]?.[0]?.categories?.[0]?.id });
       resultArray.push(...groupedData[category]);
     }
 

--- a/src/hooks/listHooks.js
+++ b/src/hooks/listHooks.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 /* eslint-disable react/prop-types */
 import { isArray } from 'lodash';
 import React, { useCallback, useContext } from 'react';
@@ -46,14 +47,14 @@ const EventSectionHeader = ({ item, navigation, options, query }) => (
 
 const VoucherCategoryHeader = ({ item, navigation, options, query }) => (
   <SectionHeader
-    title={item}
+    title={item.name}
     onPress={() =>
       navigation.push(options.queryVariables?.screenName || ScreenName.BookmarkCategory, {
         title: texts.screenTitles.voucher.index,
         query,
         queryVariables: {
           ...options.queryVariables,
-          category: item
+          categoryId: item.id
         },
         rootRouteName: ROOT_ROUTE_NAMES.VOUCHER
       })
@@ -187,7 +188,7 @@ export const useRenderItem = (query, navigation, options = {}) => {
         }
 
         if (query === QUERY_TYPES.VOUCHERS) {
-          if (typeof item === 'string') {
+          if (typeof item === 'object' && Object.keys(item).length === 2) {
             return <VoucherCategoryHeader {...{ item, navigation, options, query }} />;
           }
 
@@ -213,6 +214,7 @@ export const useRenderItem = (query, navigation, options = {}) => {
       break;
     }
   }
+  /* eslint-enable complexity */
 
   return useCallback(renderItem, [
     query,

--- a/src/hooks/listHooks.js
+++ b/src/hooks/listHooks.js
@@ -48,7 +48,7 @@ const VoucherCategoryHeader = ({ item, navigation, options, query }) => (
   <SectionHeader
     title={item}
     onPress={() =>
-      navigation.push(ScreenName.VoucherIndex, {
+      navigation.push(options.queryVariables?.screenName || ScreenName.BookmarkCategory, {
         title: texts.screenTitles.voucher.index,
         query,
         queryVariables: {

--- a/src/screens/Voucher/VoucherIndexScreen.tsx
+++ b/src/screens/Voucher/VoucherIndexScreen.tsx
@@ -124,7 +124,7 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
     <ListComponent
       navigation={navigation}
       query={query}
-      queryVariables={queryVariables}
+      queryVariables={{ ...queryVariables, screenName: ScreenName.VoucherIndex }}
       data={listItems}
       fetchMoreData={fetchMoreData}
       // TODO: replace with dropdown filter component here

--- a/src/screens/Voucher/VoucherIndexScreen.tsx
+++ b/src/screens/Voucher/VoucherIndexScreen.tsx
@@ -127,12 +127,11 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
       queryVariables={{ ...queryVariables, screenName: ScreenName.VoucherIndex }}
       data={listItems}
       fetchMoreData={fetchMoreData}
-      // TODO: replace with dropdown filter component here
       ListHeaderComponent={
         <>
           {query === QUERY_TYPES.VOUCHERS && (
             <>
-              {!!showFilter && (
+              {!!showFilter && !queryVariables.categoryId && (
                 <DropdownHeader
                   {...{
                     data: vouchersCategories?.[QUERY_TYPES.GENERIC_ITEMS],
@@ -161,7 +160,7 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
               )}
 
               {count > 0 && showFilter && (
-                <Wrapper style={styles.noPaddingTop}>
+                <Wrapper style={!queryVariables.categoryId && styles.noPaddingTop}>
                   <BoldText>
                     {count} {count === 1 ? texts.voucher.result : texts.voucher.results}
                   </BoldText>


### PR DESCRIPTION
- added a redirect to the `BookmarkCategory` screen in `listHook` to fix the problem that clicking on the title of a voucher in the favourites list opens the `VoucherIndex` screen and shows all vouchers
- added `screenName` to `queryVariables` in `VoucherIndexScreen` to find out if the voucher list is on the favourite screen or the `VoucherIndex` screen
- added category id with category name in the array parser in `VoucherList` in order to filter by category ids
- updated `queryVariables` in `listHooks` because `genericItems` query has `categoryId` variables instead of `category` variables
- updated the condition in `listHooks` because the list structure has been updated and is now an object instead of a string
- updated the condition so that the `DropdownHeader` does not appear when we list a single category

SVAK-35

the reason for the error is that we do not specify any `sectionTitle` for the `Voucher` and we show the `VoucherList` component. In this list each category has its own title. the redirection in `BookmarkSection` does not work because the `sectionTitle` is not specified. for this reason, this kind of logic must be added to the `VoucherCategoryHeader` component in `listHooks`.