### PR TITLE
fix: the dropdown hiding problem when category is selected

### DIFF
--- a/src/hooks/listHooks.js
+++ b/src/hooks/listHooks.js
@@ -54,7 +54,8 @@ const VoucherCategoryHeader = ({ item, navigation, options, query }) => (
         query,
         queryVariables: {
           ...options.queryVariables,
-          categoryId: item.id
+          categoryId: item.id,
+          category: item.name
         },
         rootRouteName: ROOT_ROUTE_NAMES.VOUCHER
       })

--- a/src/screens/Voucher/VoucherIndexScreen.tsx
+++ b/src/screens/Voucher/VoucherIndexScreen.tsx
@@ -121,10 +121,6 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
     [query, queryVariables]
   );
 
-  if (loading) {
-    return <LoadingSpinner loading />;
-  }
-
   const count = listItems.filter(({ categories }) => !!categories?.length)?.length;
 
   return (
@@ -138,7 +134,7 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
         <>
           {query === QUERY_TYPES.VOUCHERS && (
             <>
-              {!!showFilter && !queryVariables.categoryId && (
+              {!!showFilter && !queryVariables.category && (
                 <DropdownHeader
                   {...{
                     data: vouchersCategories?.[QUERY_TYPES.GENERIC_ITEMS],
@@ -167,7 +163,7 @@ export const VoucherIndexScreen = ({ navigation, route }: StackScreenProps<any>)
               )}
 
               {count > 0 && showFilter && (
-                <Wrapper style={!queryVariables.categoryId && styles.noPaddingTop}>
+                <Wrapper style={!queryVariables.category && styles.noPaddingTop}>
                   <BoldText>
                     {count} {count === 1 ? texts.voucher.result : texts.voucher.results}
                   </BoldText>


### PR DESCRIPTION
- replaced `categoryId` with `category` in `VoucherIndexScreen` to solve the dropdown disappearing problem
- added `category` to `queryVariables` in `listHooks` to ensure that the dropdown does not appear when clicking on any section
- removed the `loading` condition in `VoucherIndexScreen` to solve the problem of the whole screen refreshing when any filter is selected

SVAK-75
