### PR TITLE
feat: add time subtitle to event list

### DIFF
--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 import { useRenderItem } from '../hooks';
-
 import { QUERY_TYPES } from '../queries';
+
 import { LoadingSpinner } from './LoadingSpinner';
 
 const keyExtractor = (item, index) => `index${index}-id${item.id}`;

--- a/src/components/screens/EventRecords.js
+++ b/src/components/screens/EventRecords.js
@@ -169,7 +169,8 @@ export const EventRecords = ({ navigation, route }) => {
 
   const listItems = useMemo(() => {
     let parsedListItems = parseListItemsFromQuery(QUERY_TYPES.EVENT_RECORDS, data, undefined, {
-      withDate: false
+      withDate: false,
+      withTime: true
     });
 
     if (additionalData?.length) {

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -43,12 +43,13 @@ const filterGenericItems = (item) => {
   return true;
 };
 
-const parseEventRecords = (data, skipLastDivider, withDate) => {
+const parseEventRecords = (data, skipLastDivider, withDate, withTime) => {
   return data?.map((eventRecord, index) => ({
     id: eventRecord.id,
     subtitle: subtitle(
       withDate ? eventDate(eventRecord.listDate) : undefined,
-      eventRecord.addresses?.[0]?.addition || eventRecord.addresses?.[0]?.city
+      eventRecord.addresses?.[0]?.addition || eventRecord.addresses?.[0]?.city,
+      withTime ? eventRecord?.dates?.[0]?.timeFrom : undefined
     ),
     title: eventRecord.title,
     picture: {
@@ -381,6 +382,7 @@ const parseConsulData = (data, query, skipLastDivider) => {
  *    consentForDataProcessingText?: string;
  *    skipLastDivider?: boolean;
  *    withDate?: boolean,
+ *    withTime?: boolean,
  *    isSectioned?: boolean,
  *    queryVariables?: any
  *  }} options
@@ -395,13 +397,14 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
     consentForDataProcessingText,
     skipLastDivider = false,
     withDate = true,
+    withTime = false,
     isSectioned = false,
     queryVariables
   } = options;
 
   switch (query) {
     case QUERY_TYPES.EVENT_RECORDS:
-      return parseEventRecords(data[query], skipLastDivider, withDate);
+      return parseEventRecords(data[query], skipLastDivider, withDate, withTime);
     case QUERY_TYPES.GENERIC_ITEMS:
       return parseGenericItems(data[query], skipLastDivider, consentForDataProcessingText);
     case QUERY_TYPES.NEWS_ITEMS:

--- a/src/helpers/textHelper.js
+++ b/src/helpers/textHelper.js
@@ -2,16 +2,21 @@
  * Formatting a subtitle with a separating | if necessary
  *
  * @param {string | undefined} first text before the pipe
+ * @param {string | undefined} time text before the pipe (Uhr)
  * @param {string | undefined} last text behind the pipe
  *
- * @return {string} a formatted string `first | last` or `first` or `last`
+ * @return {string} a formatted string `first | last` or `time Uhr, last` or `time Uhr` or `first` or `last`
  */
-export const subtitle = (first, last) => {
-  if (!first && !last) return '';
+export const subtitle = (first, last, time) => {
+  if (!first && !time && !last) return '';
 
   if (first && last) return `${first} | ${last}`;
 
+  if (time && last) return `${time} Uhr, ${last}`;
+
   if (first) return first;
+
+  if (time) return `${time} Uhr`;
 
   return last;
 };


### PR DESCRIPTION
- added `withTime` option to `listItemParser` to show the event time in the event list
- added `withTime` and `dates` control to `listItemParser` to show the timing of the event in the list
- added `second` prop to `textHelper` to show the time in the list in the desired format and updated returns

SVAK-84

## Screenshots:

|with time|without time|
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-06 at 12 55 36](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/414bee43-e9da-4c97-9da1-353631c155c5)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-06 at 12 55 47](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/0e6840c3-dec8-4f61-b9fd-bf86c47868ad)

