### PR TITLE
feat: add daily check for account

### DIFF
--- a/src/helpers/voucherHelper.ts
+++ b/src/helpers/voucherHelper.ts
@@ -5,6 +5,7 @@ import { addToStore, readFromStore } from './storageHelper';
 
 const VOUCHER_AUTH_TOKEN = 'VOUCHER_AUTH_TOKEN';
 export const VOUCHER_MEMBER_ID = 'VOUCHER_MEMBER_ID';
+export const VOUCHER_MEMBER_LOGIN_INFO = 'VOUCHER_MEMBER_LOGIN_INFO';
 export const VOUCHER_TRANSACTIONS = 'VOUCHER_TRANSACTIONS';
 export const VOUCHER_DEVICE_TOKEN = 'VOUCHER_DEVICE_TOKEN';
 
@@ -54,4 +55,28 @@ export const voucherMemberId = async () => {
   }
 
   return memberId;
+};
+
+export const storeVoucherMemberLoginInfo = (memberLoginInfo?: string) => {
+  if (memberLoginInfo) {
+    addToStore(VOUCHER_MEMBER_LOGIN_INFO, memberLoginInfo);
+  } else {
+    addToStore(VOUCHER_MEMBER_LOGIN_INFO);
+  }
+};
+
+export const voucherMemberLoginInfo = async () => {
+  let memberLoginInfo = {};
+
+  // The reason for the problem of staying in SplashScreen that occurs after the application is
+  // updated on the Android side is the inability to obtain the token here.
+  // For this reason, try/catch is used here and the problem of getting stuck in SplashScreen is solved.
+  try {
+    memberLoginInfo = await readFromStore(VOUCHER_MEMBER_LOGIN_INFO);
+  } catch {
+    // Token deleted here so that it can be recreated
+    AsyncStorage.removeItem(VOUCHER_MEMBER_LOGIN_INFO);
+  }
+
+  return memberLoginInfo;
 };

--- a/src/screens/Voucher/VoucherHomeScreen.tsx
+++ b/src/screens/Voucher/VoucherHomeScreen.tsx
@@ -1,6 +1,8 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import React, { useCallback, useEffect } from 'react';
+import moment from 'moment';
+import React, { useCallback, useEffect, useState } from 'react';
 import { RefreshControl, ScrollView, StyleSheet } from 'react-native';
+import { useMutation } from 'react-query';
 
 import {
   Button,
@@ -12,11 +14,22 @@ import {
   Wrapper
 } from '../../components';
 import { colors, texts } from '../../config';
+import { addToStore, readFromStore } from '../../helpers';
+import {
+  storeVoucherAuthToken,
+  storeVoucherMemberId,
+  storeVoucherMemberLoginInfo,
+  voucherMemberLoginInfo
+} from '../../helpers/voucherHelper';
 import { useStaticContent, useVoucher } from '../../hooks';
-import { ScreenName } from '../../types';
+import { logIn } from '../../queries/vouchers';
+import { ScreenName, VoucherLogin } from '../../types';
+
+const SAVED_DATE = 'savedDate';
 
 export const VoucherHomeScreen = ({ navigation, route }: StackScreenProps<any>) => {
   const { refresh, isLoggedIn, memberId } = useVoucher();
+  const [accountCheckLoading, setAccountCheckLoading] = useState(true);
 
   const imageUri = route?.params?.headerImage;
 
@@ -37,11 +50,40 @@ export const VoucherHomeScreen = ({ navigation, route }: StackScreenProps<any>) 
   // refresh if the refreshAuth param changed, which happens after login
   useEffect(refreshAuth, [route.params?.refreshAuth]);
 
+  const { mutate: mutateLogIn } = useMutation(logIn);
+
+  useEffect(() => {
+    const accountCheck = async () => {
+      const loginData = await voucherMemberLoginInfo();
+      const savedDate = (await readFromStore(SAVED_DATE)) || moment().format('YYYY-MM-DD');
+
+      if (loginData && !moment().isSame(savedDate, 'day')) {
+        mutateLogIn(JSON.parse(loginData as string) as VoucherLogin, {
+          onSuccess: (responseData) => {
+            if (!responseData?.member) {
+              storeVoucherAuthToken();
+              storeVoucherMemberId();
+              storeVoucherMemberLoginInfo();
+              refresh();
+            }
+          }
+        });
+
+        addToStore(SAVED_DATE, moment().format('YYYY-MM-DD'));
+        setAccountCheckLoading(false);
+      } else {
+        setAccountCheckLoading(false);
+      }
+    };
+
+    accountCheck();
+  }, []);
+
   const refreshHome = useCallback(async () => {
     await refetchHomeText();
   }, []);
 
-  if (loadingHomeText) {
+  if (loadingHomeText || accountCheckLoading) {
     return <LoadingSpinner />;
   }
 

--- a/src/screens/Voucher/VoucherLoginScreen.tsx
+++ b/src/screens/Voucher/VoucherLoginScreen.tsx
@@ -16,7 +16,11 @@ import {
   Wrapper
 } from '../../components';
 import { colors, texts } from '../../config';
-import { storeVoucherAuthToken, storeVoucherMemberId } from '../../helpers/voucherHelper';
+import {
+  storeVoucherAuthToken,
+  storeVoucherMemberId,
+  storeVoucherMemberLoginInfo
+} from '../../helpers/voucherHelper';
 import { useStaticContent } from '../../hooks';
 import { logIn } from '../../queries/vouchers';
 import { ScreenName, VoucherLogin } from '../../types';
@@ -57,6 +61,9 @@ export const VoucherLoginScreen = ({ navigation, route }: StackScreenProps<any>)
         // save auth token and member id to global state
         storeVoucherAuthToken(responseData.member.authentication_token);
         storeVoucherMemberId(responseData.member.id);
+        storeVoucherMemberLoginInfo(
+          JSON.stringify({ key: loginData.key, secret: loginData.secret })
+        );
 
         // refreshAuth param causes the home screen to update and no longer show the login button
         navigation.navigate(ScreenName.VoucherHome, {


### PR DESCRIPTION
- added `accountCheck` function to `VoucherHomeScreen` to check daily if the user's account is still valid with the login credentials saved in the device
- added `moment` because if the user has not checked the account before, the `savedDate` value will be `null` and the check will not take place
- saved the date of the check to the device in `accountCheck` after checking the user account, and if the user enters `VoucherHomeScreen` again on the same day,  the account check is cancelled with the `moment().isSame` function
- checked whether the user's account is valid or not, if the account is not valid, the `refresh()` function was executed after deleting all user data in `mutateLogin`  to show the login button on the `VoucherHomeScreen`
- added two helper functions in `voucherHelper` to save the user's login details
- added `storeVoucherMemberLoginInfo` helper to `VoucherLoginScreen` to save login information to device after logging into user account

SVAK-89

## Test:

- first log in to your account and save the login details on the device
- Then call `VoucherHomeScreen` again. The login button should not appear
-  Comment out the `accountCheck` function in `VoucherHomeScreen` and add the following code inside `useEffect`
```
    const fakeLogin = { key: 'xxx', secret: 'xxxxxxxx' };
    storeVoucherMemberLoginInfo(JSON.stringify(fakeLogin));
```
- In this way, you have stored the fake login details on your device. Your own account details are no longer on the device.
- Now run the `accountCheck` function again and make the `fakeLogin` information a comment line
- Now go to `VoucherHomeScreen` again. You will notice that the Login button is still not visible
- This is because you want to check on the same day. Delete the `!` in `!moment().isSame...` in the if control
- Now go to the `VoucherHomeScreen` again. The login button should be visible again after the check