### PR TITLE
feat: add the check whether the voucher is redeemed locally

### DIFF
--- a/src/components/vouchers/VoucherRedeem.tsx
+++ b/src/components/vouchers/VoucherRedeem.tsx
@@ -81,15 +81,15 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
   const seconds = remainingTime % 60;
 
   const redeemVoucher = async () => {
+    let deviceToken = await readFromStore(VOUCHER_DEVICE_TOKEN);
+
+    if (!deviceToken) {
+      deviceToken = uuid();
+      addToStore(VOUCHER_DEVICE_TOKEN, deviceToken);
+    }
+
     try {
-      let deviceToken = await readFromStore(VOUCHER_DEVICE_TOKEN);
-
-      if (!deviceToken) {
-        deviceToken = uuid();
-        addToStore(VOUCHER_DEVICE_TOKEN, deviceToken);
-      }
-
-      redeemQuotaOfVoucher({
+      await redeemQuotaOfVoucher({
         variables: {
           deviceToken,
           quantity,
@@ -98,6 +98,9 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
         }
       });
 
+      setIsRedeemedVoucher(true);
+      setIsRedeemingVoucher(true);
+    } catch (error) {
       const voucherTransactions = (await readFromStore(VOUCHER_TRANSACTIONS)) || [];
       const voucherTransaction = {
         deviceToken,
@@ -111,7 +114,7 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
 
       setIsRedeemedVoucher(true);
       setIsRedeemingVoucher(true);
-    } catch (error) {
+
       console.error(error);
     }
   };

--- a/src/components/vouchers/VoucherRedeem.tsx
+++ b/src/components/vouchers/VoucherRedeem.tsx
@@ -42,7 +42,21 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
     if (hasNoAvailableQuantityForMember) {
       setIsRedeemedVoucher(true);
     }
-  }, [availableQuantity, availableQuantityForMember]);
+
+    localRedeemedVoucherCheck();
+  }, [availableQuantity, availableQuantityForMember, memberId]);
+
+  const localRedeemedVoucherCheck = async () => {
+    const voucherTransactions = (await readFromStore(VOUCHER_TRANSACTIONS)) || [];
+
+    if (voucherTransactions.length) {
+      const isRedeemed = voucherTransactions.some(
+        (transaction) => transaction.voucherId === voucherId && transaction.memberId === memberId
+      );
+
+      setIsRedeemedVoucher(isRedeemed);
+    }
+  };
 
   const [redeemQuotaOfVoucher] = useMutation(REDEEM_QUOTA_OF_VOUCHER);
 


### PR DESCRIPTION
- added `localRedeemedVoucherCheck` function to ensure that if a user has redeemed a voucher without an internet connection, they cannot redeem the same voucher again and updated the button to disabled if the voucher has been redeemed
- saved coupon information in the device's memory in case of a problem with the internet connection has been moved to the catch section
- moved `deviceToken` information out of the `try` blog as needed when saving voucher information
- added `redeemLocalVouchers` function to ensure that the vouchers stored in the device are sent to the server and used online in case of internet connection
- added resetting of the `voucherTransactions` array saved on the device if the exchange of information with the server has been successful

SVAK-90

## Test:

To test, create a fake error in try-cache before mutation. This error will save the coupon information in the device's memory. Then open `VoucherHomeScreen` and send the vouchers saved in the device's memory to the server. You can then see these vouchers in the list of redeemed vouchers.

```
 throw new Error('Fake error!');
```