### PR TITLE
feat: add other offers section to detail screen

### DIFF
--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -26,8 +26,8 @@ import { PriceCard } from './PriceCard';
 import { TimeTables } from './TimeTables';
 
 const { MATOMO_TRACKING } = consts;
-const INITIAL_VOUCHER_COUNT = 3;
-const INCREMENT_VOUCHER_COUNT = 5;
+export const INITIAL_VOUCHER_COUNT = 3;
+export const INCREMENT_VOUCHER_COUNT = 5;
 
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1163,6 +1163,7 @@ export const texts = {
       sheetDescription:
         'Sie haben nach Bestätigung 15 Minuten Zeit den automatisch erzeugten Coupon beim Bezahlen vorzuzeigen. Nach 15 Minuten läuft der Coupon ab. Sie brauchen keinen Internetempfang um einen Coupon zu erstellen.',
       sheetTitle: 'Möchten Sie den Gutschein einlösen?',
+      toPartnerButton: 'Zum Kooperationspartner',
       weekly: 'pro Woche',
       yearly: 'pro Jahr'
     },

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -783,6 +783,7 @@ export const texts = {
     showLunches: 'Zum aktuellen Gastro-Angebot',
     today: 'Heute',
     vouchers: 'Aktuelle Angebote',
+    vouchersMore: 'Weitere Angebote',
     yourPosition: 'Ihre Position'
   },
   pushNotifications: {

--- a/src/queries/vouchers.ts
+++ b/src/queries/vouchers.ts
@@ -155,6 +155,36 @@ export const GET_VOUCHER = gql`
           url
         }
       }
+      pointOfInterest {
+        name
+        payload
+        id
+        operatingCompany {
+          id
+          name
+          address {
+            id
+            kind
+            addition
+            street
+            zip
+            city
+          }
+          contact {
+            id
+            firstName
+            lastName
+            phone
+            email
+            fax
+            webUrls {
+              id
+              url
+              description
+            }
+          }
+        }
+      }
       payload
     }
   }

--- a/src/queries/vouchers.ts
+++ b/src/queries/vouchers.ts
@@ -184,6 +184,9 @@ export const GET_VOUCHER = gql`
             }
           }
         }
+        vouchers {
+          id
+        }
       }
       payload
     }

--- a/src/screens/Voucher/VoucherDetailScreen.tsx
+++ b/src/screens/Voucher/VoucherDetailScreen.tsx
@@ -192,7 +192,7 @@ export const VoucherDetailScreen = ({ navigation, route }: StackScreenProps<any>
 
       {!!voucherListItems?.length && (
         <>
-          <SectionHeader title={texts.pointOfInterest.vouchers} />
+          <SectionHeader title={texts.pointOfInterest.vouchersMore} />
           <FlatList
             data={voucherListItems.slice(0, loadedVoucherDataCount)}
             renderItem={({ item }) => <VoucherListItem item={item} navigation={navigation} />}

--- a/src/screens/Voucher/VoucherDetailScreen.tsx
+++ b/src/screens/Voucher/VoucherDetailScreen.tsx
@@ -6,7 +6,7 @@ import { RefreshControl, ScrollView, StyleSheet } from 'react-native';
 import { NetworkContext } from '../../NetworkProvider';
 import {
   BoldText,
-  DataProviderButton,
+  Button,
   Discount,
   HtmlView,
   ImageSection,
@@ -16,15 +16,14 @@ import {
   VoucherRedeem,
   Wrapper
 } from '../../components';
-import { DataProviderNotice } from '../../components/DataProviderNotice';
 import { colors, texts } from '../../config';
 import { graphqlFetchPolicy } from '../../helpers';
 import { useOpenWebScreen, useVoucher } from '../../hooks';
 import { QUERY_TYPES, getQuery } from '../../queries';
-import { TVoucherContentBlock } from '../../types';
+import { ScreenName, TVoucherContentBlock } from '../../types';
 
 /* eslint-disable complexity */
-export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
+export const VoucherDetailScreen = ({ navigation, route }: StackScreenProps<any>) => {
   const { memberId } = useVoucher();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
@@ -60,6 +59,7 @@ export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
     id,
     mediaContents,
     payload,
+    pointOfInterest,
     quota,
     subtitle,
     title
@@ -138,15 +138,32 @@ export const VoucherDetailScreen = ({ route }: StackScreenProps<any>) => {
         </Wrapper>
       )}
 
-      <OperatingCompany
-        openWebScreen={openWebScreen}
-        operatingCompany={dataProvider}
-        title={texts.pointOfInterest.operatingCompany}
-      />
+      {!!pointOfInterest?.operatingCompany && (
+        <>
+          <OperatingCompany
+            logo={dataProviderLogo}
+            openWebScreen={openWebScreen}
+            operatingCompany={pointOfInterest.operatingCompany}
+            title={texts.pointOfInterest.operatingCompany}
+          />
 
-      <DataProviderNotice dataProvider={dataProvider} openWebScreen={openWebScreen} />
-
-      <DataProviderButton dataProvider={dataProvider} />
+          <Wrapper>
+            <Button
+              title={texts.voucher.detailScreen.toPartnerButton}
+              onPress={() =>
+                navigation.navigate(ScreenName.Detail, {
+                  query: QUERY_TYPES.POINT_OF_INTEREST,
+                  title: pointOfInterest.name,
+                  queryVariables: {
+                    id: pointOfInterest.id
+                  }
+                })
+              }
+              invert
+            />
+          </Wrapper>
+        </>
+      )}
     </ScrollView>
   );
 };

--- a/src/screens/Voucher/VoucherDetailScreen.tsx
+++ b/src/screens/Voucher/VoucherDetailScreen.tsx
@@ -58,9 +58,13 @@ export const VoucherDetailScreen = ({ navigation, route }: StackScreenProps<any>
     title
   } = data?.[QUERY_TYPES.GENERIC_ITEM] ?? {};
 
-  const ids = pointOfInterest?.vouchers
-    .map((voucher: TVoucherItem) => voucher.id)
-    .filter((id: string) => id !== queryVariables?.id);
+  const ids = pointOfInterest?.vouchers?.reduce((acc: string[], voucher: TVoucherItem) => {
+    if (voucher.id !== queryVariables?.id) {
+      acc.push(voucher.id);
+    }
+
+    return acc;
+  }, []);
 
   const { data: actualVouchersData, refetch: actualVouchersRefetch } = useQuery(
     getQuery(QUERY_TYPES.VOUCHERS),

--- a/src/screens/Voucher/VoucherDetailScreen.tsx
+++ b/src/screens/Voucher/VoucherDetailScreen.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { useQuery } from 'react-apollo';
-import { RefreshControl, ScrollView, StyleSheet } from 'react-native';
+import { FlatList, RefreshControl, ScrollView, StyleSheet } from 'react-native';
 
 import { NetworkContext } from '../../NetworkProvider';
 import {
@@ -9,18 +9,22 @@ import {
   Button,
   Discount,
   HtmlView,
+  INCREMENT_VOUCHER_COUNT,
+  INITIAL_VOUCHER_COUNT,
   ImageSection,
   LoadingSpinner,
   OperatingCompany,
   RegularText,
+  SectionHeader,
+  VoucherListItem,
   VoucherRedeem,
   Wrapper
 } from '../../components';
 import { colors, texts } from '../../config';
-import { graphqlFetchPolicy } from '../../helpers';
+import { graphqlFetchPolicy, parseListItemsFromQuery } from '../../helpers';
 import { useOpenWebScreen, useVoucher } from '../../hooks';
 import { QUERY_TYPES, getQuery } from '../../queries';
-import { ScreenName, TVoucherContentBlock } from '../../types';
+import { ScreenName, TVoucherContentBlock, TVoucherItem } from '../../types';
 
 /* eslint-disable complexity */
 export const VoucherDetailScreen = ({ navigation, route }: StackScreenProps<any>) => {
@@ -28,6 +32,7 @@ export const VoucherDetailScreen = ({ navigation, route }: StackScreenProps<any>
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp });
   const [refreshing, setRefreshing] = useState(false);
+  const [loadedVoucherDataCount, setLoadedVoucherDataCount] = useState(INITIAL_VOUCHER_COUNT);
 
   const query = route.params?.query ?? '';
   const queryVariables = route.params?.queryVariables ?? {};
@@ -40,18 +45,6 @@ export const VoucherDetailScreen = ({ navigation, route }: StackScreenProps<any>
     fetchPolicy
   });
 
-  const refresh = useCallback(async () => {
-    setRefreshing(true);
-    if (isConnected) {
-      await refetch();
-    }
-    setRefreshing(false);
-  }, [isConnected, refetch, setRefreshing]);
-
-  if (!data || loading) {
-    return <LoadingSpinner loading />;
-  }
-
   const {
     contentBlocks,
     dataProvider,
@@ -63,7 +56,39 @@ export const VoucherDetailScreen = ({ navigation, route }: StackScreenProps<any>
     quota,
     subtitle,
     title
-  } = data[QUERY_TYPES.GENERIC_ITEM];
+  } = data?.[QUERY_TYPES.GENERIC_ITEM] ?? {};
+
+  const ids = pointOfInterest?.vouchers
+    .map((voucher: TVoucherItem) => voucher.id)
+    .filter((id: string) => id !== queryVariables?.id);
+
+  const { data: actualVouchersData, refetch: actualVouchersRefetch } = useQuery(
+    getQuery(QUERY_TYPES.VOUCHERS),
+    {
+      variables: { ids },
+      skip: !ids?.length,
+      fetchPolicy
+    }
+  );
+
+  const voucherListItems = useMemo(() => {
+    return parseListItemsFromQuery(QUERY_TYPES.VOUCHERS, actualVouchersData, undefined, {
+      withDate: false
+    });
+  }, [actualVouchersData]);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    if (isConnected) {
+      await refetch();
+      await actualVouchersRefetch();
+    }
+    setRefreshing(false);
+  }, [isConnected, refetch, setRefreshing]);
+
+  if (!data || loading) {
+    return <LoadingSpinner loading />;
+  }
 
   const dataProviderLogo = dataProvider?.logo?.url;
   const { availableQuantity, frequency, maxPerPerson, maxQuantity } = quota || {};
@@ -162,6 +187,28 @@ export const VoucherDetailScreen = ({ navigation, route }: StackScreenProps<any>
               invert
             />
           </Wrapper>
+        </>
+      )}
+
+      {!!voucherListItems?.length && (
+        <>
+          <SectionHeader title={texts.pointOfInterest.vouchers} />
+          <FlatList
+            data={voucherListItems.slice(0, loadedVoucherDataCount)}
+            renderItem={({ item }) => <VoucherListItem item={item} navigation={navigation} />}
+            ListFooterComponent={() =>
+              voucherListItems.length > loadedVoucherDataCount && (
+                <Wrapper>
+                  <Button
+                    title={texts.pointOfInterest.loadMoreVouchers}
+                    onPress={() =>
+                      setLoadedVoucherDataCount((prev) => prev + INCREMENT_VOUCHER_COUNT)
+                    }
+                  />
+                </Wrapper>
+              )
+            }
+          />
         </>
       )}
     </ScrollView>


### PR DESCRIPTION
- added `genericItems` query with `ids` variables to `VoucherDetailScreen` to show current coupons list
- added the `id` of the vouchers to the `pointOfInterest` query in `vouchers.ts` to get the `ids` variables
- added filtering with `id` to not list the voucher shown in DetailScreen
- coded the listing codes in the same way as POI detail screen

SVAK-87

## Screenshots:

|voucher detail screen|voucher detail screen actual list|
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-14 at 16 46 55](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/10dee94b-706e-475d-a2dd-26ee26ce8ea4)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-14 at 16 46 58](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/a0aef57f-a2c4-417d-84aa-a8ff70f4b9ab)
