### PR TITLE
fix: favourite list not loading completely

### DIFF
--- a/src/components/bookmarks/BookmarkSection.tsx
+++ b/src/components/bookmarks/BookmarkSection.tsx
@@ -6,7 +6,7 @@ import { NetworkContext } from '../../NetworkProvider';
 import { consts, texts } from '../../config';
 import { graphqlFetchPolicy } from '../../helpers';
 import { useRefreshTime } from '../../hooks';
-import { getQuery } from '../../queries';
+import { QUERY_TYPES, getQuery } from '../../queries';
 import { ScreenName } from '../../types';
 import { DataListSection } from '../DataListSection';
 
@@ -34,15 +34,16 @@ export const BookmarkSection = ({
   setConnectionState
 }: Props) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  // slice the first 3 entries off of the bookmark ids, to get the 3 most recently bookmarked items
+  const variables = query === QUERY_TYPES.VOUCHERS ? { ids } : { ids: ids.slice(0, 3) };
 
   const refreshTime = useRefreshTime('bookmarks', REFRESH_INTERVALS.BOOKMARKS);
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
 
-  // slice the first 3 entries off of the bookmark ids, to get the 3 most recently bookmarked items
   const { loading, data } = useQuery(getQuery(query), {
     fetchPolicy,
-    variables: { ids: ids.slice(0, 3) }
+    variables
   });
 
   const onPressShowMore = useCallback(
@@ -76,6 +77,7 @@ export const BookmarkSection = ({
       sectionTitle={sectionTitle}
       sectionTitleDetail={categoryTitleDetail}
       showButton={ids.length > 3}
+      limit={variables?.ids.length}
     />
   );
 };

--- a/src/queries/vouchers.ts
+++ b/src/queries/vouchers.ts
@@ -214,6 +214,7 @@ export const GET_VOUCHERS_REDEEMED = gql`
       genericType
       id
       title
+      subtitle: teaser
       categories {
         name
         id

--- a/src/screens/BookmarkCategoryScreen.js
+++ b/src/screens/BookmarkCategoryScreen.js
@@ -14,17 +14,19 @@ import { colors, consts, texts } from '../config';
 import { graphqlFetchPolicy, parseListItemsFromQuery } from '../helpers';
 import { useBookmarks, useMatomoTrackScreenView, useRefreshTime } from '../hooks';
 import { NetworkContext } from '../NetworkProvider';
-import { getQuery } from '../queries';
+import { getQuery, QUERY_TYPES } from '../queries';
 
 const { MATOMO_TRACKING } = consts;
 
 export const BookmarkCategoryScreen = ({ navigation, route }) => {
   const query = route.params?.query ?? '';
+  const queryKey = query === QUERY_TYPES.VOUCHERS ? QUERY_TYPES.GENERIC_ITEMS : query;
+  const queryVariables = route.params?.queryVariables ?? {};
   const suffix = route.params?.suffix ?? '';
   const categoryTitleDetail = route.params?.categoryTitleDetail ?? '';
   const bookmarks = useBookmarks(query, suffix);
 
-  const variables = { ids: bookmarks };
+  const variables = { ids: bookmarks, ...queryVariables };
 
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
 
@@ -68,7 +70,7 @@ export const BookmarkCategoryScreen = ({ navigation, route }) => {
       </Wrapper>
     );
   }
-  const listItems = parseListItemsFromQuery(query, data, categoryTitleDetail);
+  const listItems = parseListItemsFromQuery(query, data, categoryTitleDetail, { queryKey });
 
   return (
     <SafeAreaViewFlex>


### PR DESCRIPTION
- added `variables` object according to `query` in `BookmarkSection` to solve the problem of more than 3 items not being listed in favourite list
- added `limit` prop to `DataListSection` in `BookmarkSection` to show more than 3 items
- added `queryVariables` to `BookmarkCategoryScreen` to list only the favourited items of that category when the title of an item in the favourite list is pressed

SVAK-35