### PR TITLE
feat: save images captured with the camera to the gallery

### DIFF
--- a/app.json
+++ b/app.json
@@ -83,6 +83,12 @@
           }
         }
       ],
+      [
+        "expo-media-library",
+        {
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos."
+        }
+      ],
       "expo-localization",
       "sentry-expo",
       "./config-plugins/withAndroidMailQueriesAndWhatsappPackage"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "expo-linking": "~5.0.2",
     "expo-localization": "~14.3.0",
     "expo-location": "~16.1.0",
+    "expo-media-library": "~15.4.1",
     "expo-notifications": "~0.20.1",
     "expo-permissions": "~14.2.1",
     "expo-screen-orientation": "~6.0.6",

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -70,7 +70,9 @@ export const ImageSelector = ({
     undefined, // onChange
     false, // allowsEditing
     selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1], // aspect
-    undefined // quality
+    undefined, // quality
+    undefined, // mediaTypes
+    selectorType === IMAGE_SELECTOR_TYPES.SUE ? true : false // saveImage
   );
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5482,6 +5482,11 @@ expo-manifests@~0.7.0:
   dependencies:
     expo-json-utils "~0.7.0"
 
+expo-media-library@~15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/expo-media-library/-/expo-media-library-15.4.1.tgz#577efb13d912e28e9c3fcc5022156e204a59b7e8"
+  integrity sha512-lpWcT4pynWcE7TyNMUkLFH4YcueCTnq7UOJYRR0vewPEJeQXwRscka7zBtrhA+RSsJda013Q0615K+5lRLt14Q==
+
 expo-modules-autolinking@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-1.5.1.tgz#363f90c172769ce12bf56c7be9ca0897adfc7a81"


### PR DESCRIPTION
- added `expo-media-library` package needed to save images to gallery
- added `saveImage` prop to `useCaptureImage` hook so that captured images can be saved to gallery
- added the feature that if the `saveImage` prop is `true`, the picture taken is added to the album with the same name according to the albums previously created or on the device, or a new album is created and the picture is added to the new album
- added album name to be created in gallery as app name

SUE-79

A new app build needs to be created due to native dependencies.  
`yarn ios -d` or `yarn android` commands can be used.