### PR TITLE
feat(sue): connect with the area service

### DIFF
--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -91,13 +91,11 @@ export const Chat = ({
     }
   };
 
-  const { selectImage } = useSelectImage(
-    undefined, // onChange
-    false, // allowsEditing,
-    undefined, // aspect,
-    undefined, // quality,
-    MediaTypeOptions.All // mediaTypes
-  );
+  const { selectImage } = useSelectImage({
+    allowsEditing: false,
+    mediaTypes: MediaTypeOptions.All
+  });
+
   const { selectDocument } = useSelectDocument();
 
   return (

--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -1,8 +1,10 @@
+import * as Location from 'expo-location';
 import React, { useRef } from 'react';
-import { Controller } from 'react-hook-form';
+import { Controller, UseFormSetValue } from 'react-hook-form';
 import { StyleSheet, View } from 'react-native';
 
 import { consts, normalize, texts } from '../../../config';
+import { TValues } from '../../../screens';
 import { Wrapper } from '../../Wrapper';
 import { ImageSelector } from '../../consul';
 import { Input } from '../../form';
@@ -10,11 +12,21 @@ import { Input } from '../../form';
 const { IMAGE_SELECTOR_TYPES, IMAGE_SELECTOR_ERROR_TYPES } = consts;
 
 export const SueReportDescription = ({
+  areaServiceData,
   control,
-  requiredInputs
+  errorMessage,
+  requiredInputs,
+  setSelectedPosition,
+  setUpdateRegionFromImage,
+  setValue
 }: {
+  areaServiceData: { postalCodes: string[] } | undefined;
   control: any;
-  requiredInputs: string[];
+  errorMessage: string;
+  requiredInputs: keyof TValues[];
+  setSelectedPosition: (position: Location.LocationObjectCoords | undefined) => void;
+  setUpdateRegionFromImage: (value: boolean) => void;
+  setValue: UseFormSetValue<TValues>;
 }) => {
   const titleRef = useRef();
   const descriptionRef = useRef();
@@ -52,6 +64,13 @@ export const SueReportDescription = ({
             <ImageSelector
               {...{
                 control,
+                coordinateCheck: {
+                  areaServiceData,
+                  errorMessage,
+                  setSelectedPosition,
+                  setUpdateRegionFromImage,
+                  setValue
+                },
                 field,
                 isMultiImages: true,
                 selectorType: IMAGE_SELECTOR_TYPES.SUE,

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import * as Location from 'expo-location';
 import moment from 'moment';
 import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
@@ -5,7 +6,6 @@ import { UseFormGetValues, UseFormSetValue } from 'react-hook-form';
 import { Alert, StyleSheet, View } from 'react-native';
 import { useQuery } from 'react-query';
 
-import { useNavigation } from '@react-navigation/native';
 import { SettingsContext } from '../../../SettingsProvider';
 import { device, normalize, texts } from '../../../config';
 import { parseListItemsFromQuery } from '../../../helpers';
@@ -40,7 +40,8 @@ export const SueReportLocation = ({
   requiredInputs,
   selectedPosition,
   setSelectedPosition,
-  setValue
+  setValue,
+  setZipCode
 }: {
   control: any;
   getValues: UseFormGetValues<TValues>;
@@ -48,6 +49,7 @@ export const SueReportLocation = ({
   selectedPosition: Location.LocationObjectCoords | undefined;
   setSelectedPosition: (position: Location.LocationObjectCoords | undefined) => void;
   setValue: UseFormSetValue<TValues>;
+  setZipCode: any;
 }) => {
   const navigation = useNavigation();
   const { locationSettings } = useLocationSettings();
@@ -137,6 +139,7 @@ export const SueReportLocation = ({
       setValue('houseNumber', houseNumber);
       setValue('zipCode', zipCode);
       setValue('city', city);
+      setZipCode(zipCode);
     } catch (error) {
       console.error('Reverse Geocoding Error:', error);
     }

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -151,7 +151,7 @@ export const SueReportLocation = ({
       setValue('street', street);
       setValue('zipCode', zipCode);
     } catch (error) {
-      throw new Error(errorMessage);
+      throw new Error(error.message);
     }
   }, []);
 
@@ -216,7 +216,10 @@ export const SueReportLocation = ({
             ])
           }
           onMapPress={({ nativeEvent }) => {
-            if (nativeEvent.action !== 'marker-press') {
+            if (
+              nativeEvent.action !== 'marker-press' &&
+              nativeEvent.action !== 'callout-inside-press'
+            ) {
               reverseGeocode(nativeEvent.coordinate)
                 .then(() => {
                   setUpdatedRegion(false);

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -198,36 +198,38 @@ export const SueReportLocation = ({
               },
               {
                 text: texts.sue.report.alerts.yes,
-                onPress: () => {
+                onPress: async () => {
                   const location = position || lastKnownPosition;
 
                   if (location) {
-                    reverseGeocode(location.coords)
-                      .then(() => {
-                        setUpdatedRegion(true);
-                        setSelectedPosition(location.coords);
-                      })
-                      .catch((error) => {
-                        Alert.alert(texts.sue.report.alerts.hint, error.message);
-                      });
+                    setUpdatedRegion(true);
+                    setSelectedPosition(location.coords);
+
+                    try {
+                      await reverseGeocode(location.coords);
+                    } catch (error) {
+                      setSelectedPosition(undefined);
+                      Alert.alert(texts.sue.report.alerts.hint, error.message);
+                    }
                   }
                 }
               }
             ])
           }
-          onMapPress={({ nativeEvent }) => {
+          onMapPress={async ({ nativeEvent }) => {
             if (
               nativeEvent.action !== 'marker-press' &&
               nativeEvent.action !== 'callout-inside-press'
             ) {
-              reverseGeocode(nativeEvent.coordinate)
-                .then(() => {
-                  setUpdatedRegion(false);
-                  setSelectedPosition(nativeEvent.coordinate);
-                })
-                .catch((error) => {
-                  Alert.alert(texts.sue.report.alerts.hint, error.message);
-                });
+              setUpdatedRegion(false);
+              setSelectedPosition(nativeEvent.coordinate);
+
+              try {
+                await reverseGeocode(nativeEvent.coordinate);
+              } catch (error) {
+                setSelectedPosition(undefined);
+                Alert.alert(texts.sue.report.alerts.hint, error.message);
+              }
             }
           }}
           onMaximizeButtonPress={() => navigation.navigate(ScreenName.MapView, { locations })}

--- a/src/components/SUE/report/SueReportServices.tsx
+++ b/src/components/SUE/report/SueReportServices.tsx
@@ -12,7 +12,7 @@ export const SueReportServices = ({
   serviceCode,
   setServiceCode
 }: {
-  serviceCode: string;
+  serviceCode: string | undefined;
   setServiceCode: any;
 }) => {
   const [loading, setLoading] = useState(true);

--- a/src/components/SUE/report/SueReportUser.tsx
+++ b/src/components/SUE/report/SueReportUser.tsx
@@ -3,6 +3,7 @@ import { Controller } from 'react-hook-form';
 import { StyleSheet, View } from 'react-native';
 
 import { colors, consts, normalize, texts } from '../../../config';
+import { TValues } from '../../../screens';
 import { Checkbox } from '../../Checkbox';
 import { RegularText } from '../../Text';
 import { Wrapper } from '../../Wrapper';
@@ -17,7 +18,7 @@ export const SueReportUser = ({
 }: {
   control: any;
   errors: any;
-  requiredInputs: string[];
+  requiredInputs: keyof TValues[];
 }) => {
   const firstNameRef = useRef();
   const lastNameRef = useRef();

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -201,6 +201,7 @@ export const Map = ({
         )}
         {locations?.map((marker, index) => {
           const isActiveMarker = selectedMarker && marker.id === selectedMarker;
+          const calloutText = marker.title;
 
           return (
             <Marker
@@ -257,10 +258,10 @@ export const Map = ({
                 />
               )}
 
-              {calloutTextEnabled && !!marker.title && (
+              {calloutTextEnabled && !!calloutText && (
                 <Callout style={styles.callout}>
                   <RegularText smallest center>
-                    {marker.title}
+                    {calloutText}
                   </RegularText>
                 </Callout>
               )}

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -41,15 +41,23 @@ const saveImageToGallery = async (uri: string) => {
   }
 };
 
-export const useSelectImage = (
+export const useSelectImage = ({
+  allowsEditing = false,
+  aspect,
+  exif = false,
+  mediaTypes = MediaTypeOptions.Images,
+  onChange,
+  quality = 1
+}: {
+  allowsEditing?: boolean;
+  aspect?: [number, number];
+  exif?: boolean;
+  mediaTypes?: MediaTypeOptions;
   onChange?: <T>(
     setter: React.Dispatch<React.SetStateAction<T>>
-  ) => React.Dispatch<React.SetStateAction<T>>,
-  allowsEditing?: boolean,
-  aspect?: [number, number],
-  quality?: number,
-  mediaTypes?: MediaTypeOptions
-) => {
+  ) => React.Dispatch<React.SetStateAction<T>>;
+  quality?: number;
+}) => {
   const [imageUri, setImageUri] = useState<string>();
 
   const selectImage = useCallback(async () => {
@@ -63,14 +71,17 @@ export const useSelectImage = (
     // this allows for proper selecting and cropping to 1:1 images (and not videos)
     // for more details about options see: https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickermediatypeoptions
     const result = await launchImageLibraryAsync({
-      mediaTypes: mediaTypes ?? MediaTypeOptions.Images,
-      allowsEditing: allowsEditing ?? false,
+      allowsEditing,
       aspect,
-      quality: quality ?? 1
+      exif,
+      mediaTypes,
+      quality
     });
 
     if (!result.canceled) {
-      onChange ? onChange(setImageUri)(result.assets[0].uri) : setImageUri(result.assets[0].uri);
+      const uri = result.assets[0].uri;
+      onChange ? onChange(setImageUri)(uri) : setImageUri(uri);
+
       return result.assets[0];
     }
   }, [onChange]);
@@ -78,16 +89,25 @@ export const useSelectImage = (
   return { imageUri, selectImage };
 };
 
-export const useCaptureImage = (
+export const useCaptureImage = ({
+  allowsEditing = false,
+  aspect,
+  exif = false,
+  mediaTypes = MediaTypeOptions.Images,
+  onChange,
+  quality = 1,
+  saveImage = false
+}: {
+  allowsEditing?: boolean;
+  aspect?: [number, number];
+  exif?: boolean;
+  mediaTypes?: MediaTypeOptions;
   onChange?: <T>(
     setter: React.Dispatch<React.SetStateAction<T>>
-  ) => React.Dispatch<React.SetStateAction<T>>,
-  allowsEditing?: boolean,
-  aspect?: [number, number],
-  quality?: number,
-  mediaTypes?: MediaTypeOptions,
-  saveImage?: boolean
-) => {
+  ) => React.Dispatch<React.SetStateAction<T>>;
+  quality?: number;
+  saveImage?: boolean;
+}) => {
   const [imageUri, setImageUri] = useState<string>();
 
   const captureImage = useCallback(async () => {
@@ -101,10 +121,11 @@ export const useCaptureImage = (
     // this allows for proper selecting and cropping to 1:1 images (and not videos)
     // for more details about options see: https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickermediatypeoptions
     const result = await launchCameraAsync({
-      mediaTypes: mediaTypes ?? MediaTypeOptions.Images,
-      allowsEditing: allowsEditing ?? false,
+      allowsEditing,
       aspect,
-      quality: quality ?? 1
+      exif,
+      mediaTypes,
+      quality
     });
 
     if (!result.canceled) {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -19,6 +19,7 @@ export * from './personalizedTiles';
 export * from './pullToRefetch';
 export * from './PushNotification';
 export * from './TimeHooks';
+export * from './reverseGeocode';
 export * from './staticContent';
 export * from './surveyHooks';
 export * from './versionCheck';

--- a/src/hooks/reverseGeocode.ts
+++ b/src/hooks/reverseGeocode.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import { UseFormSetValue } from 'react-hook-form';
+
+import { TValues } from '../screens';
+
+export const useReverseGeocode = () => {
+  return useCallback(
+    async ({
+      areaServiceData,
+      errorMessage,
+      position,
+      setValue
+    }: {
+      areaServiceData: { postalCodes: string[] } | undefined;
+      errorMessage: string;
+      position: { latitude: number; longitude: number };
+      setValue: UseFormSetValue<TValues>;
+    }) => {
+      const { latitude, longitude } = position;
+
+      try {
+        const response = await (
+          await fetch(
+            `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}`
+          )
+        ).json();
+
+        const city = response?.address?.city || '';
+        const houseNumber = response?.address?.house_number || '';
+        const street = response?.address?.road || '';
+        const zipCode = response?.address?.postcode || '';
+
+        if (!areaServiceData?.postalCodes?.includes(zipCode)) {
+          setValue('city', '');
+          setValue('houseNumber', '');
+          setValue('street', '');
+          setValue('zipCode', '');
+
+          throw new Error(errorMessage);
+        }
+
+        setValue('city', city);
+        setValue('houseNumber', houseNumber);
+        setValue('street', street);
+        setValue('zipCode', zipCode);
+      } catch (error) {
+        throw new Error(error.message);
+      }
+    },
+    []
+  );
+};

--- a/src/queries/SUE/areaService.tsx
+++ b/src/queries/SUE/areaService.tsx
@@ -1,0 +1,24 @@
+import { storageHelper } from '../../helpers';
+
+export const areaService = async (zipCode: number) => {
+  if (!zipCode) {
+    return;
+  }
+
+  const globalSettings = await storageHelper.globalSettings();
+  const { apiConfig = {} } = globalSettings?.settings?.sue || {};
+
+  const { apiKey, serverUrl } = apiConfig.areaService || {};
+
+  const areaServiceFetchObj = {
+    method: 'GET',
+    headers: {
+      accept: 'application/json',
+      api_key: apiKey
+    }
+  };
+
+  return await (
+    await fetch(`${serverUrl}/getByPostalCode?postalCode=${zipCode}`, areaServiceFetchObj)
+  ).json();
+};

--- a/src/queries/SUE/areaService.tsx
+++ b/src/queries/SUE/areaService.tsx
@@ -1,14 +1,10 @@
 import { storageHelper } from '../../helpers';
 
-export const areaService = async (zipCode: number) => {
-  if (!zipCode) {
-    return;
-  }
-
+export const areaService = async () => {
   const globalSettings = await storageHelper.globalSettings();
   const { apiConfig = {} } = globalSettings?.settings?.sue || {};
 
-  const { apiKey, serverUrl } = apiConfig.areaService || {};
+  const { apiKey, serverUrl, id } = apiConfig.areaService || {};
 
   const areaServiceFetchObj = {
     method: 'GET',
@@ -19,6 +15,6 @@ export const areaService = async (zipCode: number) => {
   };
 
   return await (
-    await fetch(`${serverUrl}/getByPostalCode?postalCode=${zipCode}`, areaServiceFetchObj)
+    await fetch(`${serverUrl}/${id}?selectAttributes=postalCodes`, areaServiceFetchObj)
   ).json();
 };

--- a/src/queries/SUE/index.ts
+++ b/src/queries/SUE/index.ts
@@ -1,3 +1,4 @@
+export * from './areaService';
 export * from './priorities';
 export * from './requests';
 export * from './requestsWithServiceRequestId';

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,6 +1,13 @@
 // IMPORT TYPES
 // IMPORT CREATE QUERIES
-import { priorities, requests, requestsWithServiceRequestId, services, statuses } from './SUE';
+import {
+  areaService,
+  priorities,
+  requests,
+  requestsWithServiceRequestId,
+  services,
+  statuses
+} from './SUE';
 import { CREATE_APP_USER_CONTENT } from './appUserContent';
 // IMPORT GET QUERIES
 import { GET_CATEGORIES } from './categories';
@@ -91,6 +98,7 @@ export const getQuery = (query, filterOptions = {}) => {
     [QUERY_TYPES.CONSUL.USER]: USER,
 
     // SUE QUERIES
+    [QUERY_TYPES.SUE.AREA_SERVICE]: areaService,
     [QUERY_TYPES.SUE.PRIORITIES]: priorities,
     [QUERY_TYPES.SUE.REQUESTS]: requests,
     [QUERY_TYPES.SUE.REQUESTS_WITH_SERVICE_REQUEST_ID]: requestsWithServiceRequestId,

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -52,6 +52,7 @@ export const QUERY_TYPES = {
   STATIC_CONTENT_LIST: 'staticContentList',
   TOUR: 'tour',
   SUE: {
+    AREA_SERVICE: 'areaService',
     PRIORITIES: 'priorities',
     REQUESTS: 'requests',
     REQUESTS_WITH_SERVICE_REQUEST_ID: 'requestsWithServiceRequestId',

--- a/src/screens/EncounterDataScreen.tsx
+++ b/src/screens/EncounterDataScreen.tsx
@@ -71,7 +71,7 @@ export const EncounterDataScreen = ({ navigation }: StackScreenProps<any>) => {
     []
   );
 
-  const { imageUri, selectImage } = useSelectImage(onChange);
+  const { imageUri, selectImage } = useSelectImage({ onChange });
 
   const {
     error: errorSupportId,

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -58,7 +58,9 @@ type TContent = {
   errorMessage: string;
   errors: any;
   selectedPosition: Location.LocationObjectCoords | undefined;
-  setSelectedPosition: any;
+  setSelectedPosition: (position: Location.LocationObjectCoords | undefined) => void;
+  setUpdateRegionFromImage: (value: boolean) => void;
+  updateRegionFromImage: boolean;
   setValue: UseFormSetValue<TValues>;
   getValues: UseFormGetValues<TValues>;
 };
@@ -75,22 +77,36 @@ const Content = ({
   serviceCode,
   setSelectedPosition,
   setServiceCode,
-  setValue
+  setUpdateRegionFromImage,
+  setValue,
+  updateRegionFromImage
 }: TContent) => {
   switch (content) {
     case 'description':
-      return <SueReportDescription control={control} requiredInputs={requiredInputs} />;
+      return (
+        <SueReportDescription
+          areaServiceData={areaServiceData}
+          control={control}
+          errorMessage={errorMessage}
+          requiredInputs={requiredInputs}
+          setSelectedPosition={setSelectedPosition}
+          setUpdateRegionFromImage={setUpdateRegionFromImage}
+          setValue={setValue}
+        />
+      );
     case 'location':
       return (
         <SueReportLocation
+          areaServiceData={areaServiceData}
           control={control}
           errorMessage={errorMessage}
           getValues={getValues}
-          areaServiceData={areaServiceData}
           requiredInputs={requiredInputs}
           selectedPosition={selectedPosition}
           setSelectedPosition={setSelectedPosition}
+          setUpdateRegionFromImage={setUpdateRegionFromImage}
           setValue={setValue}
+          updateRegionFromImage={updateRegionFromImage}
         />
       );
     case 'user':
@@ -150,6 +166,7 @@ export const SueReportScreen = ({
   const [selectedPosition, setSelectedPosition] = useState<Location.LocationObjectCoords>();
   const [isDone, setIsDone] = useState(false);
   const [storedValues, setStoredValues] = useState<TReports>();
+  const [updateRegionFromImage, setUpdateRegionFromImage] = useState(false);
 
   const scrollViewRef = useRef(null);
   const scrollViewContentRef = useRef(null);
@@ -497,6 +514,8 @@ export const SueReportScreen = ({
                   errors,
                   selectedPosition,
                   setSelectedPosition,
+                  setUpdateRegionFromImage,
+                  updateRegionFromImage,
                   setValue,
                   getValues
                 })

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -195,7 +195,7 @@ export const SueReportScreen = ({
     }
   });
 
-  const { data: areaServiceData } = useQuery(
+  const { data: areaServiceData, isLoading: areaServiceLoading } = useQuery(
     [QUERY_TYPES.SUE.AREA_SERVICE],
     () => getQuery(QUERY_TYPES.SUE.AREA_SERVICE)(),
     { enabled: !!limitOfCity }
@@ -306,7 +306,7 @@ export const SueReportScreen = ({
             return texts.sue.report.alerts.zipCode;
           }
 
-          if (!!limitOfCity && !areaServiceData?.postalCodes?.includes(getValues('zipCode'))) {
+          if (!areaServiceData?.postalCodes?.includes(getValues('zipCode'))) {
             return errorMessage;
           }
         }
@@ -450,7 +450,7 @@ export const SueReportScreen = ({
     }
   }, [storedValues, serviceCode, selectedPosition]);
 
-  if (loading) {
+  if (loading || areaServiceLoading) {
     return (
       <LoadingContainer>
         <ActivityIndicator color={colors.refreshControl} />


### PR DESCRIPTION
- added `apiKey` and `serverUrl` information to add connection with field service can be updated via main-server as `requests` request
- added `zipCode` state due to late change of `getValue('zipCode')` and no data from area service
- added rules that `limitOfCity` must be true and `zipCode` must be 5 digits to activate an area service request
- added rule to show `errorMessage` alert that can be updated via main server in case the `limitOfCity` value that can be updated via main server does not match with area service
- updated area service link with `id` instead of `getByPostalCode`
- added comparing postcode data from area service with the postcodes of the location selected from the map
- added errors in the `reverseGeocode` function to catch the error message
- updated `onMapPress` and `onMyLocationButtonPress` props with then-catch structure to catch errors added to `reverseGeocode` function
- added `areaServiceLoading` to fix the problem of the warning that you are outside the area that appears when clicking on the desired area on the map because the data in the area service is not loaded correctly
- extended the control in the Map component to fix the problem of empty `calloutText` when clicking on the marker in the marked area
- extended the control within `onMapPress` in `SueReportLocation` to fix the location not found warning that appears when `calloutText` is pressed

SUE-57