### PR TITLE
feat: move category descriptions to next tab

### DIFF
--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -3,6 +3,8 @@ import { Controller } from 'react-hook-form';
 import { StyleSheet, View } from 'react-native';
 
 import { consts, normalize, texts } from '../../../config';
+import { TService } from '../../../screens';
+import { BoldText, RegularText } from '../../Text';
 import { Wrapper } from '../../Wrapper';
 import { ImageSelector } from '../../consul';
 import { Input } from '../../form';
@@ -11,16 +13,26 @@ const { IMAGE_SELECTOR_TYPES, IMAGE_SELECTOR_ERROR_TYPES } = consts;
 
 export const SueReportDescription = ({
   control,
-  requiredInputs
+  requiredInputs,
+  service
 }: {
   control: any;
   requiredInputs: string[];
+  service: TService;
 }) => {
   const titleRef = useRef();
   const descriptionRef = useRef();
 
   return (
     <View style={styles.container}>
+      {!!service?.description && (
+        <Wrapper style={styles.noPaddingTop}>
+          <BoldText>{service.serviceName}</BoldText>
+
+          {!!service.description && <RegularText smallest>{service.description}</RegularText>}
+        </Wrapper>
+      )}
+
       <Wrapper style={styles.noPaddingTop}>
         <Input
           name="title"

--- a/src/components/SUE/report/SueReportServices.tsx
+++ b/src/components/SUE/report/SueReportServices.tsx
@@ -5,15 +5,16 @@ import { useQuery } from 'react-query';
 import { colors, device, normalize } from '../../../config';
 import { imageHeight } from '../../../helpers';
 import { QUERY_TYPES, getQuery } from '../../../queries';
+import { TService } from '../../../screens';
 import { LoadingSpinner } from '../../LoadingSpinner';
-import { BoldText, RegularText } from '../../Text';
+import { BoldText } from '../../Text';
 
 export const SueReportServices = ({
-  serviceCode,
-  setServiceCode
+  service,
+  setService
 }: {
-  serviceCode: string;
-  setServiceCode: any;
+  service: TService;
+  setService: any;
 }) => {
   const [loading, setLoading] = useState(true);
 
@@ -36,13 +37,13 @@ export const SueReportServices = ({
 
   return (
     <View style={styles.container}>
-      {data?.map((item, index) => {
-        const selected = serviceCode === item.serviceCode;
+      {data?.map((item: TService, index: number) => {
+        const selected = service?.serviceCode === item.serviceCode;
 
         return (
           <TouchableOpacity
             key={index}
-            onPress={() => setServiceCode(item.serviceCode)}
+            onPress={() => setService(item)}
             style={[
               styles.tile,
               {
@@ -52,12 +53,6 @@ export const SueReportServices = ({
             ]}
           >
             <BoldText center>{item.serviceName}</BoldText>
-
-            {!!item.description && (
-              <RegularText center smallest numberOfLines={3}>
-                {item.description}
-              </RegularText>
-            )}
           </TouchableOpacity>
         );
       })}


### PR DESCRIPTION
- updated the structure of the state where we only set the `serviceCode` to the object and named it as `setService` in order to move the descriptions of the categories to the next step
- updated `SueReportDescription` component to show description and category name in second step

SUE-89

## Screenshots:

|before|after|before|after|
|--|--|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-24 at 14 31 42](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/f670edd6-47d7-4b98-b16c-03210b41f88e)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-24 at 14 31 25](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/6212e42c-8acc-4a5c-a444-1e8d571a0272)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-24 at 14 31 45](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/781a0094-cb58-45c7-9d88-6c9864fba04e)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-24 at 14 31 29](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/6035a3ab-456d-423e-9e23-8f8186332bb1)
