### PR TITLE
feat: remove the question whether to change the picture for android

### DIFF
--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -32,9 +32,9 @@ const saveImageToGallery = async (uri: string) => {
     const album = await getAlbumAsync(appName);
 
     if (!album) {
-      await createAlbumAsync(appName, asset, false);
+      await createAlbumAsync(appName, asset, true);
     } else {
-      await addAssetsToAlbumAsync([asset], album, false);
+      await addAssetsToAlbumAsync([asset], album, true);
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
- updated `copyAsset` value from `false` to `true` in order to remove the alert whether the image should be changed while saving after the image is taken on the android platform

SUE-79
