### PR TITLE
fix: settings screen not loading problem

### DIFF
--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -293,17 +293,15 @@ export const SettingsScreen = ({ navigation, route }) => {
               settingsList.push({
                 data: ['augmentedRealitySettings']
               });
-
-              setData(settingsList);
             }
           );
         } catch (error) {
           // if Viro is not integrated, we need to catch the error for `isARSupportedOnDevice of null`
           console.warn(error);
         }
-      } else {
-        setData(settingsList);
       }
+
+      setData(settingsList);
     };
 
     setting == '' && updateData();


### PR DESCRIPTION
- moved `setData` out of the `if` control to fix the problem of the settings screen not loading in apps with augmented reality feature if the device does not support augmented reality feature

SVA-1356
