### PR TITLE
chore: extend normalize function update

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -169,7 +169,8 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.lightestText,
-    fontFamily: 'bold'
+    fontFamily: 'bold',
+    fontSize: normalize(18)
   },
   titleInvert: {
     color: colors.primary

--- a/src/config/normalize.js
+++ b/src/config/normalize.js
@@ -1,12 +1,14 @@
-import { Dimensions } from 'react-native';
+import { Dimensions, PixelRatio } from 'react-native';
 
-// Default guideline sizes are based on standard ~6.12" screen mobile device (iPhone 14 Pro)
 const guidelineBaseWidth = 393;
+const guidelineBaseHeight = 852;
 
 export const normalize = (size, factor = 1) => {
-  const { width, height } = Dimensions.get('window');
-  const shortDimension = width < height ? width : height;
-  const scale = (shortDimension / guidelineBaseWidth) * size;
+   const { width, height } = Dimensions.get('window');
+   const widthScale = width / guidelineBaseWidth;
+   const heightScale = height / guidelineBaseHeight;
+   const scale = Math.min(widthScale, heightScale); // Takes the smaller ratio to avoid excess.
 
-  return size + (scale - size) * factor;
+   const newSize = size * scale;
+   return PixelRatio.roundToNearestPixel(newSize * factor);
 };

--- a/src/config/normalize.js
+++ b/src/config/normalize.js
@@ -1,14 +1,14 @@
 import { Dimensions, PixelRatio } from 'react-native';
 
+// Default guideline sizes are based on standard ~6.12" screen mobile device (iPhone 15 Pro)
 const guidelineBaseWidth = 393;
 const guidelineBaseHeight = 852;
 
 export const normalize = (size, factor = 1) => {
-   const { width, height } = Dimensions.get('window');
-   const widthScale = width / guidelineBaseWidth;
-   const heightScale = height / guidelineBaseHeight;
-   const scale = Math.min(widthScale, heightScale); // Takes the smaller ratio to avoid excess.
+  const { width, height } = Dimensions.get('window');
+  const widthScale = width / guidelineBaseWidth;
+  const heightScale = height / guidelineBaseHeight;
+  const scale = Math.min(widthScale, heightScale);
 
-   const newSize = size * scale;
-   return PixelRatio.roundToNearestPixel(newSize * factor);
+  return PixelRatio.roundToNearestPixel(size * scale * factor);
 };


### PR DESCRIPTION
- added `guidelineBaseHeight` and `PixelRatio` to cover devices with different aspect ratios.
worked it out with an idea I had and ChatGPT

SVA-1351

## Screenshots:
<p float=" left">
  <img src="https://github.com/smart-village-solutions/smart-village-app-app/assets/105894697/ef7be6c9-5264-40e6-adbb-c660a77d5015" width="24%" />
  <img src="https://github.com/smart-village-solutions/smart-village-app-app/assets/105894697/e7c94c95-5ed4-4549-93e9-3792e04fb1a4" width="24%" /> 
  <img src="https://github.com/smart-village-solutions/smart-village-app-app/assets/105894697/47519dbc-3753-44a9-9058-b03733597045" width="24%" />
  <img src="https://github.com/smart-village-solutions/smart-village-app-app/assets/105894697/b22ac440-576b-49fc-8ece-db9a571ef7fe" width="24%" />
</p>
<p float="right">
  <img src="https://github.com/smart-village-solutions/smart-village-app-app/assets/105894697/27bfb085-6fcd-49fe-bd39-6ecd1f8de6c3" width="24%" />
  <img src="https://github.com/smart-village-solutions/smart-village-app-app/assets/105894697/711b0e91-590a-459c-959e-c1a668d58a9d" width="24%" /> 
  <img src="https://github.com/smart-village-solutions/smart-village-app-app/assets/105894697/aff01236-0e40-438e-85ac-d9a801dc1255" width="24%" />
  <img src="https://github.com/smart-village-solutions/smart-village-app-app/assets/105894697/0228c351-bf5a-4e41-bea9-94df58e96d63" width="24%" />
</p>




