### PR TITLE
feat: get coordinate data in the image

### DIFF
--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -91,13 +91,11 @@ export const Chat = ({
     }
   };
 
-  const { selectImage } = useSelectImage(
-    undefined, // onChange
-    false, // allowsEditing,
-    undefined, // aspect,
-    undefined, // quality,
-    MediaTypeOptions.All // mediaTypes
-  );
+  const { selectImage } = useSelectImage({
+    allowsEditing: false,
+    mediaTypes: MediaTypeOptions.All
+  });
+
   const { selectDocument } = useSelectDocument();
 
   return (

--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -59,6 +59,11 @@ export const SueReportDescription = ({
             <ImageSelector
               {...{
                 control,
+                coordinateCheck: {
+                  areaServiceData,
+                  errorMessage,
+                  setValue
+                },
                 field,
                 isMultiImages: true,
                 selectorType: IMAGE_SELECTOR_TYPES.SUE,

--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -1,3 +1,4 @@
+import * as Location from 'expo-location';
 import React, { useRef } from 'react';
 import { Controller, UseFormSetValue } from 'react-hook-form';
 import { StyleSheet, View } from 'react-native';
@@ -15,12 +16,16 @@ export const SueReportDescription = ({
   control,
   errorMessage,
   requiredInputs,
+  setSelectedPosition,
+  setUpdateRegionFromImage,
   setValue
 }: {
   areaServiceData: { postalCodes: string[] } | undefined;
   control: any;
   errorMessage: string;
   requiredInputs: keyof TValues[];
+  setSelectedPosition: (position: Location.LocationObjectCoords | undefined) => void;
+  setUpdateRegionFromImage: (value: boolean) => void;
   setValue: UseFormSetValue<TValues>;
 }) => {
   const titleRef = useRef();
@@ -62,6 +67,8 @@ export const SueReportDescription = ({
                 coordinateCheck: {
                   areaServiceData,
                   errorMessage,
+                  setSelectedPosition,
+                  setUpdateRegionFromImage,
                   setValue
                 },
                 field,

--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -1,8 +1,9 @@
 import React, { useRef } from 'react';
-import { Controller } from 'react-hook-form';
+import { Controller, UseFormSetValue } from 'react-hook-form';
 import { StyleSheet, View } from 'react-native';
 
 import { consts, normalize, texts } from '../../../config';
+import { TValues } from '../../../screens';
 import { Wrapper } from '../../Wrapper';
 import { ImageSelector } from '../../consul';
 import { Input } from '../../form';
@@ -10,11 +11,17 @@ import { Input } from '../../form';
 const { IMAGE_SELECTOR_TYPES, IMAGE_SELECTOR_ERROR_TYPES } = consts;
 
 export const SueReportDescription = ({
+  areaServiceData,
   control,
-  requiredInputs
+  errorMessage,
+  requiredInputs,
+  setValue
 }: {
+  areaServiceData: { postalCodes: string[] } | undefined;
   control: any;
-  requiredInputs: string[];
+  errorMessage: string;
+  requiredInputs: keyof TValues[];
+  setValue: UseFormSetValue<TValues>;
 }) => {
   const titleRef = useRef();
   const descriptionRef = useRef();

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -13,6 +13,7 @@ import {
   useLastKnownPosition,
   useLocationSettings,
   usePosition,
+  useReverseGeocode,
   useSystemPermission
 } from '../../../hooks';
 import { QUERY_TYPES, getQuery } from '../../../queries';
@@ -32,54 +33,6 @@ enum SueStatus {
   WAIT_REQUESTOR = 'TICKET_STATUS_WAIT_REQUESTOR',
   WAIT_THIRDPARTY = 'TICKET_STATUS_WAIT_THIRDPARTY'
 }
-
-export const useReverseGeocode = () => {
-  return useCallback(
-    async ({
-      areaServiceData,
-      errorMessage,
-      position,
-      setValue
-    }: {
-      areaServiceData: { postalCodes: string[] } | undefined;
-      errorMessage: string;
-      position: { latitude: number; longitude: number };
-      setValue: UseFormSetValue<TValues>;
-    }) => {
-      const { latitude, longitude } = position;
-
-      try {
-        const response = await (
-          await fetch(
-            `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}`
-          )
-        ).json();
-
-        const city = response?.address?.city || '';
-        const houseNumber = response?.address?.house_number || '';
-        const street = response?.address?.road || '';
-        const zipCode = response?.address?.postcode || '';
-
-        if (!areaServiceData?.postalCodes?.includes(zipCode)) {
-          setValue('city', '');
-          setValue('houseNumber', '');
-          setValue('street', '');
-          setValue('zipCode', '');
-
-          throw new Error(errorMessage);
-        }
-
-        setValue('city', city);
-        setValue('houseNumber', houseNumber);
-        setValue('street', street);
-        setValue('zipCode', zipCode);
-      } catch (error) {
-        throw new Error(error.message);
-      }
-    },
-    []
-  );
-};
 
 /* eslint-disable complexity */
 export const SueReportLocation = ({

--- a/src/components/SUE/report/SueReportServices.tsx
+++ b/src/components/SUE/report/SueReportServices.tsx
@@ -12,7 +12,7 @@ export const SueReportServices = ({
   serviceCode,
   setServiceCode
 }: {
-  serviceCode: string;
+  serviceCode: string | undefined;
   setServiceCode: any;
 }) => {
   const [loading, setLoading] = useState(true);

--- a/src/components/SUE/report/SueReportUser.tsx
+++ b/src/components/SUE/report/SueReportUser.tsx
@@ -3,6 +3,7 @@ import { Controller } from 'react-hook-form';
 import { StyleSheet, View } from 'react-native';
 
 import { colors, consts, normalize, texts } from '../../../config';
+import { TValues } from '../../../screens';
 import { Checkbox } from '../../Checkbox';
 import { RegularText } from '../../Text';
 import { Wrapper } from '../../Wrapper';
@@ -17,7 +18,7 @@ export const SueReportUser = ({
 }: {
   control: any;
   errors: any;
-  requiredInputs: string[];
+  requiredInputs: keyof TValues[];
 }) => {
   const firstNameRef = useRef();
   const lastNameRef = useRef();

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -17,7 +17,6 @@ import { Input } from '../../form';
 import { Image } from '../../Image';
 import { Modal } from '../../Modal';
 import { BoldText, RegularText } from '../../Text';
-import { Touchable } from '../../Touchable';
 import { WrapperRow, WrapperVertical } from '../../Wrapper';
 
 const { IMAGE_SELECTOR_TYPES, IMAGE_TYPE_REGEX, URL_REGEX } = consts;
@@ -59,21 +58,16 @@ export const ImageSelector = ({
     client: ConsulClient
   });
 
-  const { selectImage } = useSelectImage(
-    undefined, // onChange
-    false, // allowsEditing
-    selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1], // aspect
-    undefined // quality
-  );
+  const { selectImage } = useSelectImage({
+    allowsEditing: false,
+    aspect: selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1]
+  });
 
-  const { captureImage } = useCaptureImage(
-    undefined, // onChange
-    false, // allowsEditing
-    selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1], // aspect
-    undefined, // quality
-    undefined, // mediaTypes
-    selectorType === IMAGE_SELECTOR_TYPES.SUE ? true : false // saveImage
-  );
+  const { captureImage } = useCaptureImage({
+    allowsEditing: false,
+    aspect: selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1],
+    saveImage: selectorType === IMAGE_SELECTOR_TYPES.SUE
+  });
 
   useEffect(() => {
     onChange(JSON.stringify(imagesAttributes));

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -60,12 +60,14 @@ export const ImageSelector = ({
 
   const { selectImage } = useSelectImage({
     allowsEditing: false,
-    aspect: selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1]
+    aspect: selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1],
+    exif: selectorType === IMAGE_SELECTOR_TYPES.SUE
   });
 
   const { captureImage } = useCaptureImage({
     allowsEditing: false,
     aspect: selectorType === IMAGE_SELECTOR_TYPES.SUE ? undefined : [1, 1],
+    exif: selectorType === IMAGE_SELECTOR_TYPES.SUE,
     saveImage: selectorType === IMAGE_SELECTOR_TYPES.SUE
   });
 
@@ -103,7 +105,8 @@ export const ImageSelector = ({
   };
 
   const imageSelect = async (imageFunction = selectImage) => {
-    const { uri, type } = await imageFunction();
+    const { uri, type, exif } = await imageFunction();
+
     const { size } = await FileSystem.getInfoAsync(uri);
 
     /* used to specify the mimeType when uploading to the server */
@@ -114,7 +117,7 @@ export const ImageSelector = ({
 
     errorTextGenerator({ errorType, infoAndErrorText, mimeType, setInfoAndErrorText, uri });
 
-    setImagesAttributes([...imagesAttributes, { uri, mimeType, imageName, size }]);
+    setImagesAttributes([...imagesAttributes, { uri, mimeType, imageName, size, exif }]);
     setIsModalVisible(!isModalVisible);
   };
 

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -14,6 +14,7 @@ import {
   useCaptureImage,
   useLastKnownPosition,
   usePosition,
+  useReverseGeocode,
   useSelectImage,
   useSystemPermission
 } from '../../../hooks';
@@ -23,7 +24,6 @@ import { Button } from '../../Button';
 import { Input } from '../../form';
 import { Image } from '../../Image';
 import { Modal } from '../../Modal';
-import { useReverseGeocode } from '../../SUE';
 import { BoldText, RegularText } from '../../Text';
 import { WrapperRow, WrapperVertical } from '../../Wrapper';
 
@@ -129,9 +129,9 @@ export const ImageSelector = ({
 
     const location = {
       latitude:
-        GPSLatitude || lastKnownPosition?.coords?.latitude || position?.coords?.latitude || 0,
+        GPSLatitude || position?.coords?.latitude || lastKnownPosition?.coords?.latitude || 0,
       longitude:
-        GPSLongitude || lastKnownPosition?.coords?.longitude || position?.coords?.longitude || 0
+        GPSLongitude || position?.coords?.longitude || lastKnownPosition?.coords?.longitude || 0
     };
     const { areaServiceData = {}, errorMessage = '', setValue = () => {} } = coordinateCheck || {};
 

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -143,6 +143,9 @@ export const ImageSelector = ({
           position: location,
           setValue
         });
+
+        coordinateCheck.setSelectedPosition(location);
+        coordinateCheck.setUpdateRegionFromImage(true);
       } catch (error) {
         return Alert.alert(texts.sue.report.alerts.hint, error.message);
       } finally {

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -122,11 +122,11 @@ export const ImageSelector = ({
   };
 
   const imageSelect = async (imageFunction = selectImage) => {
+    setIsModalVisible(!isModalVisible);
+
     const { uri, type, exif } = await imageFunction();
     const { GPSLatitude, GPSLongitude } = exif || {};
-
     const { size } = await FileSystem.getInfoAsync(uri);
-
     const location = {
       latitude:
         GPSLatitude || position?.coords?.latitude || lastKnownPosition?.coords?.latitude || 0,
@@ -148,8 +148,6 @@ export const ImageSelector = ({
         coordinateCheck.setUpdateRegionFromImage(true);
       } catch (error) {
         return Alert.alert(texts.sue.report.alerts.hint, error.message);
-      } finally {
-        setIsModalVisible(!isModalVisible);
       }
     }
 

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -44,12 +44,14 @@ const saveImageToGallery = async (uri: string) => {
 export const useSelectImage = ({
   allowsEditing = false,
   aspect,
+  exif = false,
   mediaTypes = MediaTypeOptions.Images,
   onChange,
   quality = 1
 }: {
   allowsEditing?: boolean;
   aspect?: [number, number];
+  exif?: boolean;
   mediaTypes?: MediaTypeOptions;
   onChange?: <T>(
     setter: React.Dispatch<React.SetStateAction<T>>
@@ -71,12 +73,15 @@ export const useSelectImage = ({
     const result = await launchImageLibraryAsync({
       allowsEditing,
       aspect,
+      exif,
       mediaTypes,
       quality
     });
 
     if (!result.canceled) {
-      onChange ? onChange(setImageUri)(result.assets[0].uri) : setImageUri(result.assets[0].uri);
+      const uri = result.assets[0].uri;
+      onChange ? onChange(setImageUri)(uri) : setImageUri(uri);
+
       return result.assets[0];
     }
   }, [onChange]);
@@ -87,6 +92,7 @@ export const useSelectImage = ({
 export const useCaptureImage = ({
   allowsEditing = false,
   aspect,
+  exif = false,
   mediaTypes = MediaTypeOptions.Images,
   onChange,
   quality = 1,
@@ -94,6 +100,7 @@ export const useCaptureImage = ({
 }: {
   allowsEditing?: boolean;
   aspect?: [number, number];
+  exif?: boolean;
   mediaTypes?: MediaTypeOptions;
   onChange?: <T>(
     setter: React.Dispatch<React.SetStateAction<T>>
@@ -116,6 +123,7 @@ export const useCaptureImage = ({
     const result = await launchCameraAsync({
       allowsEditing,
       aspect,
+      exif,
       mediaTypes,
       quality
     });

--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -41,15 +41,21 @@ const saveImageToGallery = async (uri: string) => {
   }
 };
 
-export const useSelectImage = (
+export const useSelectImage = ({
+  allowsEditing = false,
+  aspect,
+  mediaTypes = MediaTypeOptions.Images,
+  onChange,
+  quality = 1
+}: {
+  allowsEditing?: boolean;
+  aspect?: [number, number];
+  mediaTypes?: MediaTypeOptions;
   onChange?: <T>(
     setter: React.Dispatch<React.SetStateAction<T>>
-  ) => React.Dispatch<React.SetStateAction<T>>,
-  allowsEditing?: boolean,
-  aspect?: [number, number],
-  quality?: number,
-  mediaTypes?: MediaTypeOptions
-) => {
+  ) => React.Dispatch<React.SetStateAction<T>>;
+  quality?: number;
+}) => {
   const [imageUri, setImageUri] = useState<string>();
 
   const selectImage = useCallback(async () => {
@@ -63,10 +69,10 @@ export const useSelectImage = (
     // this allows for proper selecting and cropping to 1:1 images (and not videos)
     // for more details about options see: https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickermediatypeoptions
     const result = await launchImageLibraryAsync({
-      mediaTypes: mediaTypes ?? MediaTypeOptions.Images,
-      allowsEditing: allowsEditing ?? false,
+      allowsEditing,
       aspect,
-      quality: quality ?? 1
+      mediaTypes,
+      quality
     });
 
     if (!result.canceled) {
@@ -78,16 +84,23 @@ export const useSelectImage = (
   return { imageUri, selectImage };
 };
 
-export const useCaptureImage = (
+export const useCaptureImage = ({
+  allowsEditing = false,
+  aspect,
+  mediaTypes = MediaTypeOptions.Images,
+  onChange,
+  quality = 1,
+  saveImage = false
+}: {
+  allowsEditing?: boolean;
+  aspect?: [number, number];
+  mediaTypes?: MediaTypeOptions;
   onChange?: <T>(
     setter: React.Dispatch<React.SetStateAction<T>>
-  ) => React.Dispatch<React.SetStateAction<T>>,
-  allowsEditing?: boolean,
-  aspect?: [number, number],
-  quality?: number,
-  mediaTypes?: MediaTypeOptions,
-  saveImage?: boolean
-) => {
+  ) => React.Dispatch<React.SetStateAction<T>>;
+  quality?: number;
+  saveImage?: boolean;
+}) => {
   const [imageUri, setImageUri] = useState<string>();
 
   const captureImage = useCallback(async () => {
@@ -101,10 +114,10 @@ export const useCaptureImage = (
     // this allows for proper selecting and cropping to 1:1 images (and not videos)
     // for more details about options see: https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickermediatypeoptions
     const result = await launchCameraAsync({
-      mediaTypes: mediaTypes ?? MediaTypeOptions.Images,
-      allowsEditing: allowsEditing ?? false,
+      allowsEditing,
       aspect,
-      quality: quality ?? 1
+      mediaTypes,
+      quality
     });
 
     if (!result.canceled) {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -19,6 +19,7 @@ export * from './personalizedTiles';
 export * from './pullToRefetch';
 export * from './PushNotification';
 export * from './TimeHooks';
+export * from './reverseGeocode';
 export * from './staticContent';
 export * from './surveyHooks';
 export * from './versionCheck';

--- a/src/hooks/reverseGeocode.ts
+++ b/src/hooks/reverseGeocode.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import { UseFormSetValue } from 'react-hook-form';
+
+import { TValues } from '../screens';
+
+export const useReverseGeocode = () => {
+  return useCallback(
+    async ({
+      areaServiceData,
+      errorMessage,
+      position,
+      setValue
+    }: {
+      areaServiceData: { postalCodes: string[] } | undefined;
+      errorMessage: string;
+      position: { latitude: number; longitude: number };
+      setValue: UseFormSetValue<TValues>;
+    }) => {
+      const { latitude, longitude } = position;
+
+      try {
+        const response = await (
+          await fetch(
+            `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}`
+          )
+        ).json();
+
+        const city = response?.address?.city || '';
+        const houseNumber = response?.address?.house_number || '';
+        const street = response?.address?.road || '';
+        const zipCode = response?.address?.postcode || '';
+
+        if (!areaServiceData?.postalCodes?.includes(zipCode)) {
+          setValue('city', '');
+          setValue('houseNumber', '');
+          setValue('street', '');
+          setValue('zipCode', '');
+
+          throw new Error(errorMessage);
+        }
+
+        setValue('city', city);
+        setValue('houseNumber', houseNumber);
+        setValue('street', street);
+        setValue('zipCode', zipCode);
+      } catch (error) {
+        throw new Error(error.message);
+      }
+    },
+    []
+  );
+};

--- a/src/screens/EncounterDataScreen.tsx
+++ b/src/screens/EncounterDataScreen.tsx
@@ -71,7 +71,7 @@ export const EncounterDataScreen = ({ navigation }: StackScreenProps<any>) => {
     []
   );
 
-  const { imageUri, selectImage } = useSelectImage(onChange);
+  const { imageUri, selectImage } = useSelectImage({ onChange });
 
   const {
     error: errorSupportId,

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -79,7 +79,15 @@ const Content = ({
 }: TContent) => {
   switch (content) {
     case 'description':
-      return <SueReportDescription control={control} requiredInputs={requiredInputs} />;
+      return (
+        <SueReportDescription
+          areaServiceData={areaServiceData}
+          errorMessage={errorMessage}
+          setValue={setValue}
+          control={control}
+          requiredInputs={requiredInputs}
+        />
+      );
     case 'location':
       return (
         <SueReportLocation

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -58,7 +58,9 @@ type TContent = {
   errorMessage: string;
   errors: any;
   selectedPosition: Location.LocationObjectCoords | undefined;
-  setSelectedPosition: any;
+  setSelectedPosition: (position: Location.LocationObjectCoords | undefined) => void;
+  setUpdateRegionFromImage: (value: boolean) => void;
+  updateRegionFromImage: boolean;
   setValue: UseFormSetValue<TValues>;
   getValues: UseFormGetValues<TValues>;
 };
@@ -75,30 +77,36 @@ const Content = ({
   serviceCode,
   setSelectedPosition,
   setServiceCode,
-  setValue
+  setUpdateRegionFromImage,
+  setValue,
+  updateRegionFromImage
 }: TContent) => {
   switch (content) {
     case 'description':
       return (
         <SueReportDescription
           areaServiceData={areaServiceData}
-          errorMessage={errorMessage}
-          setValue={setValue}
           control={control}
+          errorMessage={errorMessage}
           requiredInputs={requiredInputs}
+          setSelectedPosition={setSelectedPosition}
+          setUpdateRegionFromImage={setUpdateRegionFromImage}
+          setValue={setValue}
         />
       );
     case 'location':
       return (
         <SueReportLocation
+          areaServiceData={areaServiceData}
           control={control}
           errorMessage={errorMessage}
           getValues={getValues}
-          areaServiceData={areaServiceData}
           requiredInputs={requiredInputs}
           selectedPosition={selectedPosition}
           setSelectedPosition={setSelectedPosition}
+          setUpdateRegionFromImage={setUpdateRegionFromImage}
           setValue={setValue}
+          updateRegionFromImage={updateRegionFromImage}
         />
       );
     case 'user':
@@ -158,6 +166,7 @@ export const SueReportScreen = ({
   const [selectedPosition, setSelectedPosition] = useState<Location.LocationObjectCoords>();
   const [isDone, setIsDone] = useState(false);
   const [storedValues, setStoredValues] = useState<TReports>();
+  const [updateRegionFromImage, setUpdateRegionFromImage] = useState(false);
 
   const scrollViewRef = useRef(null);
   const scrollViewContentRef = useRef(null);
@@ -505,6 +514,8 @@ export const SueReportScreen = ({
                   errors,
                   selectedPosition,
                   setSelectedPosition,
+                  setUpdateRegionFromImage,
+                  updateRegionFromImage,
                   setValue,
                   getValues
                 })


### PR DESCRIPTION
- converted props in `imagePicker` to object format to avoid confusion in props
- returned the reverseGeocode function to the hook and exported it so that it can be used in other parts of the code
- added the props needed by the `useReverseGeocode` hook for location control to `SueReportDescription`
- added `coordinateCheck` prop to check when the image is selected in `ImageSelector`
- added `usePosition` and `useLastKnownPosition` hooks to `ImageSelector` to use the current location of the device since location information cannot always be obtained from the image
- added location control to `ImageSelector` by `useReverseGeocode` hook with location information from image or device location information
- prevented the image from being added to the report if the image is not in the desired position

SUE-76