### PR TITLE
feat(sue): make feedback form adjustable from main server

### DIFF
--- a/src/components/SUE/report/SueReportSend.tsx
+++ b/src/components/SUE/report/SueReportSend.tsx
@@ -30,8 +30,9 @@ export const SueReportSend = ({
   isLoading: boolean;
   navigation: any;
 }) => {
-  const { appDesignSystem = {} } = useContext(ConfigurationsContext);
+  const { appDesignSystem = {}, sueConfig = {} } = useContext(ConfigurationsContext);
   const { sueReportScreen = {} } = appDesignSystem;
+  const { showFeedbackSection } = sueConfig;
   const { reportSendDone = {}, reportSendLoading = {} } = sueReportScreen;
   const { title: loadingTitle = '', subtitle: loadingSubtitle = '' } = reportSendLoading;
   const { title: doneTitle = '', subtitle: doneSubtitle = '' } = reportSendDone;
@@ -99,59 +100,65 @@ export const SueReportSend = ({
               title={texts.sue.report.sendReportDone.toEntryList}
             />
 
-            <Divider />
+            {showFeedbackSection && (
+              <>
+                <Divider />
 
-            <View style={styles.feedbackContainer}>
-              <View style={styles.headerContainer}>
-                <BoldText>{texts.sue.report.sendReportDone.feedbackHeader}</BoldText>
-              </View>
+                <View style={styles.feedbackContainer}>
+                  <View style={styles.headerContainer}>
+                    <BoldText>{texts.sue.report.sendReportDone.feedbackHeader}</BoldText>
+                  </View>
 
-              <View style={styles.ratingContainer}>
-                <RegularText small style={styles.ratingContainer}>
-                  {texts.sue.report.sendReportDone.ratingTitle}
-                </RegularText>
+                  <View style={styles.ratingContainer}>
+                    <RegularText small style={styles.ratingContainer}>
+                      {texts.sue.report.sendReportDone.ratingTitle}
+                    </RegularText>
 
-                <Controller
-                  name="ratingCount"
-                  render={({ field: { onChange, value } }) => (
-                    <Rating
-                      imageSize={normalize(24)}
-                      onFinishRating={onChange}
-                      ratingColor={colors.primary}
-                      startingValue={value}
-                      style={styles.rating}
-                      tintColor={colors.lighterPrimary}
-                      type="custom"
+                    <Controller
+                      name="ratingCount"
+                      render={({ field: { onChange, value } }) => (
+                        <Rating
+                          imageSize={normalize(24)}
+                          onFinishRating={onChange}
+                          ratingColor={colors.primary}
+                          startingValue={value}
+                          style={styles.rating}
+                          tintColor={colors.lighterPrimary}
+                          type="custom"
+                        />
+                      )}
+                      control={control}
                     />
-                  )}
-                  control={control}
-                />
-              </View>
+                  </View>
 
-              <View style={styles.headerContainer}>
-                <Input
-                  control={control}
-                  inputContainerStyle={styles.inputContainer}
-                  inputStyle={styles.textArea}
-                  label={texts.sue.report.sendReportDone.messageTitle}
-                  multiline
-                  name="message"
-                  onFocus={() => scrollViewRef.current?.scrollTo({ x: 0, y: 250, animated: true })}
-                  placeholder={texts.sue.report.sendReportDone.messagePlaceholder}
-                  textAlignVertical="top"
-                />
-              </View>
+                  <View style={styles.headerContainer}>
+                    <Input
+                      control={control}
+                      inputContainerStyle={styles.inputContainer}
+                      inputStyle={styles.textArea}
+                      label={texts.sue.report.sendReportDone.messageTitle}
+                      multiline
+                      name="message"
+                      onFocus={() =>
+                        scrollViewRef.current?.scrollTo({ x: 0, y: 250, animated: true })
+                      }
+                      placeholder={texts.sue.report.sendReportDone.messagePlaceholder}
+                      textAlignVertical="top"
+                    />
+                  </View>
 
-              <Button
-                disabled={loading}
-                onPress={handleSubmit(onSubmit)}
-                title={
-                  loading
-                    ? texts.feedbackScreen.sendButton.disabled
-                    : texts.sue.report.sendReportDone.sendButton
-                }
-              />
-            </View>
+                  <Button
+                    disabled={loading}
+                    onPress={handleSubmit(onSubmit)}
+                    title={
+                      loading
+                        ? texts.feedbackScreen.sendButton.disabled
+                        : texts.sue.report.sendReportDone.sendButton
+                    }
+                  />
+                </View>
+              </>
+            )}
           </Wrapper>
         )}
       </ScrollView>

--- a/src/config/sue/default.ts
+++ b/src/config/sue/default.ts
@@ -55,6 +55,8 @@ const requiredFieldsDefaults = {
   }
 };
 
+const showFeedbackSectionDefaults = false;
+
 const sueProgressDefaults = [
   {
     content: '',
@@ -71,5 +73,6 @@ export const defaultSueAppConfig = {
   limitation: limitationDefaults,
   limitOfArea: limitOfAreaDefaults,
   requiredFields: requiredFieldsDefaults,
+  showFeedbackSection: showFeedbackSectionDefaults,
   sueProgress: sueProgressDefaults
 };


### PR DESCRIPTION
- connected to the `showFeedbackSection` value in `ConfigurationsContext` to make the feedback section shown after sending a report adjustable from main-server

SUE-78

## Tests:

To test, set the if condition in line 437 of `SueReporScreen` to `true`.

`if (isDone || isLoading) {...` -> `if (true) {...`

Then set the condition on line 98 in the `SueReportSend` component to `true`.

`{!isLoading && isDone && (...` -> `{true && (...`

Then, when you go to the report sending screen in the app, you will see the feedback form.