### PR TITLE
feat(sue): add warning when address inputs are filled from the image

### DIFF
--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -163,6 +163,8 @@ export const ImageSelector = ({
         coordinateCheck.setSelectedPosition(location);
         coordinateCheck.setUpdateRegionFromImage(true);
       } catch (error) {
+        coordinateCheck.setSelectedPosition(undefined);
+        coordinateCheck.setUpdateRegionFromImage(false);
         return Alert.alert(texts.sue.report.alerts.hint, error.message);
       }
     }

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -947,6 +947,7 @@ export const texts = {
         hint: 'Hinweis',
         imageType: 'Der verwendete Dateityp wird nicht unterstützt.',
         imageGreater10MBError: 'Das ausgewählte Bild darf maximal 10 MB groß sein.',
+        imageLocation: 'Die Adresse wurde dem Bild entnommen',
         imagesGreater30MBError:
           'Die ausgewählten Bilder dürfen insgesamt nicht größer als 30 MB sein.',
         imageSelectAlert: {

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -374,6 +374,10 @@ export const SueReportScreen = ({
         if (isAnyInputMissing) {
           return texts.sue.report.alerts.missingAnyInput;
         }
+
+        if (selectedPosition) {
+          Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.imageLocation);
+        }
         break;
       case 2:
         if (getValues().houseNumber && !getValues().street) {


### PR DESCRIPTION
SUE-100

## Test:
You can only get this warning if you add an image of the specified location in the config. Otherwise this feature will not work. 

To do this:
Go to areaService.tsx and update the id to 18116.
Then select a photo taken in Kiel from the gallery. If the address information is loaded correctly, you will not receive an error warning. Press the Continue button and see the new warning.

## Screenshots:

<img width="432" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/240ee1f4-83cf-478f-8c5c-785bf49ad7bb">
