### PR TITLE
feat: add location selection on full screen map

### DIFF
--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -197,7 +197,9 @@ export const SueReportLocation = ({
     }
   };
 
-  const onMyLocationButtonPress = async (isFullScreenMap = false) => {
+  const onMyLocationButtonPress = async ({ isFullScreenMap = false }) => {
+    const currentPosition = position || lastKnownPosition;
+
     if (!isFullScreenMap) {
       Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.myLocation, [
         {
@@ -206,15 +208,13 @@ export const SueReportLocation = ({
         {
           text: texts.sue.report.alerts.yes,
           onPress: async () => {
-            const location = position || lastKnownPosition;
-
-            if (location) {
+            if (currentPosition) {
               setUpdatedRegion(true);
               setUpdateRegionFromImage(false);
-              setSelectedPosition(location.coords);
+              setSelectedPosition(currentPosition.coords);
 
               try {
-                await handleGeocode(location.coords);
+                await handleGeocode(currentPosition.coords);
               } catch (error) {
                 setSelectedPosition(undefined);
                 Alert.alert(texts.sue.report.alerts.hint, error.message);
@@ -224,15 +224,13 @@ export const SueReportLocation = ({
         }
       ]);
     } else {
-      const location = position || lastKnownPosition;
-
-      if (location) {
+      if (currentPosition) {
         setUpdatedRegion(true);
         setUpdateRegionFromImage(false);
-        setSelectedPosition(location.coords);
+        setSelectedPosition(currentPosition.coords);
 
         try {
-          await handleGeocode(location.coords);
+          await handleGeocode(currentPosition.coords);
         } catch (error) {
           setSelectedPosition(undefined);
           Alert.alert(texts.sue.report.alerts.hint, error.message);
@@ -252,7 +250,7 @@ export const SueReportLocation = ({
           locations={locations}
           mapCenterPosition={mapCenterPosition}
           mapStyle={styles.map}
-          onMyLocationButtonPress={() => onMyLocationButtonPress()}
+          onMyLocationButtonPress={onMyLocationButtonPress}
           onMapPress={onMapPress}
           onMaximizeButtonPress={() =>
             navigation.navigate(ScreenName.SueReportMapView, {

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -185,9 +185,9 @@ export const SueReportLocation = ({
     nativeEvent: { action: string; coordinate: Location.LocationObjectCoords };
   }) => {
     if (nativeEvent.action !== 'marker-press' && nativeEvent.action !== 'callout-inside-press') {
+      setSelectedPosition(nativeEvent.coordinate);
       setUpdatedRegion(false);
       setUpdateRegionFromImage(false);
-      setSelectedPosition(nativeEvent.coordinate);
 
       try {
         await handleGeocode(nativeEvent.coordinate);
@@ -209,9 +209,9 @@ export const SueReportLocation = ({
           text: texts.sue.report.alerts.yes,
           onPress: async () => {
             if (currentPosition) {
+              setSelectedPosition(currentPosition.coords);
               setUpdatedRegion(true);
               setUpdateRegionFromImage(false);
-              setSelectedPosition(currentPosition.coords);
 
               try {
                 await handleGeocode(currentPosition.coords);
@@ -225,9 +225,9 @@ export const SueReportLocation = ({
       ]);
     } else {
       if (currentPosition) {
+        setSelectedPosition(currentPosition.coords);
         setUpdatedRegion(true);
         setUpdateRegionFromImage(false);
-        setSelectedPosition(currentPosition.coords);
 
         try {
           await handleGeocode(currentPosition.coords);

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -177,6 +177,26 @@ export const SueReportLocation = ({
     return <LoadingSpinner loading />;
   }
 
+  const onMapPress = async ({
+    nativeEvent
+  }: {
+    nativeEvent: { action: string; coordinate: Location.LocationObjectCoords };
+  }) => {
+    if (nativeEvent.action !== 'marker-press' && nativeEvent.action !== 'callout-inside-press') {
+      setUpdatedRegion(false);
+      setUpdateRegionFromImage(false);
+      setSelectedPosition(nativeEvent.coordinate);
+
+      try {
+        await handleGeocode(nativeEvent.coordinate);
+      } catch (error) {
+        setSelectedPosition(undefined);
+        Alert.alert(texts.sue.report.alerts.hint, error.message);
+        throw new Error(error.message);
+      }
+    }
+  };
+
   return (
     <View style={styles.container}>
       <WrapperHorizontal>
@@ -213,27 +233,13 @@ export const SueReportLocation = ({
               }
             ])
           }
-          onMapPress={async ({ nativeEvent }) => {
-            if (
-              nativeEvent.action !== 'marker-press' &&
-              nativeEvent.action !== 'callout-inside-press'
-            ) {
-              setUpdatedRegion(false);
-              setUpdateRegionFromImage(false);
-              setSelectedPosition(nativeEvent.coordinate);
-
-              try {
-                await handleGeocode(nativeEvent.coordinate);
-              } catch (error) {
-                setSelectedPosition(undefined);
-                Alert.alert(texts.sue.report.alerts.hint, error.message);
-              }
-            }
-          }}
+          onMapPress={onMapPress}
           onMaximizeButtonPress={() =>
             navigation.navigate(ScreenName.MapView, {
               calloutTextEnabled: true,
-              locations
+              locations,
+              onMapPress,
+              selectedPosition
             })
           }
           updatedRegion={

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -197,6 +197,51 @@ export const SueReportLocation = ({
     }
   };
 
+  const onMyLocationButtonPress = async (isFullScreenMap = false) => {
+    if (!isFullScreenMap) {
+      Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.myLocation, [
+        {
+          text: texts.sue.report.alerts.no
+        },
+        {
+          text: texts.sue.report.alerts.yes,
+          onPress: async () => {
+            const location = position || lastKnownPosition;
+
+            if (location) {
+              setUpdatedRegion(true);
+              setUpdateRegionFromImage(false);
+              setSelectedPosition(location.coords);
+
+              try {
+                await handleGeocode(location.coords);
+              } catch (error) {
+                setSelectedPosition(undefined);
+                Alert.alert(texts.sue.report.alerts.hint, error.message);
+              }
+            }
+          }
+        }
+      ]);
+    } else {
+      const location = position || lastKnownPosition;
+
+      if (location) {
+        setUpdatedRegion(true);
+        setUpdateRegionFromImage(false);
+        setSelectedPosition(location.coords);
+
+        try {
+          await handleGeocode(location.coords);
+        } catch (error) {
+          setSelectedPosition(undefined);
+          Alert.alert(texts.sue.report.alerts.hint, error.message);
+          throw new Error(error.message);
+        }
+      }
+    }
+  };
+
   return (
     <View style={styles.container}>
       <WrapperHorizontal>
@@ -207,39 +252,20 @@ export const SueReportLocation = ({
           locations={locations}
           mapCenterPosition={mapCenterPosition}
           mapStyle={styles.map}
-          onMyLocationButtonPress={() =>
-            Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.myLocation, [
-              {
-                text: texts.sue.report.alerts.no
-              },
-              {
-                text: texts.sue.report.alerts.yes,
-                onPress: async () => {
-                  const location = position || lastKnownPosition;
-
-                  if (location) {
-                    setUpdatedRegion(true);
-                    setUpdateRegionFromImage(false);
-                    setSelectedPosition(location.coords);
-
-                    try {
-                      await handleGeocode(location.coords);
-                    } catch (error) {
-                      setSelectedPosition(undefined);
-                      Alert.alert(texts.sue.report.alerts.hint, error.message);
-                    }
-                  }
-                }
-              }
-            ])
-          }
+          onMyLocationButtonPress={() => onMyLocationButtonPress()}
           onMapPress={onMapPress}
           onMaximizeButtonPress={() =>
             navigation.navigate(ScreenName.MapView, {
               calloutTextEnabled: true,
+              currentPosition: position || lastKnownPosition,
+              isMyLocationButtonVisible: !!locationService,
+              isSue: true,
               locations,
+              mapCenterPosition: selectedPosition || mapCenterPosition,
               onMapPress,
-              selectedPosition
+              onMyLocationButtonPress,
+              selectedPosition,
+              showsUserLocation: true
             })
           }
           updatedRegion={

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -75,6 +75,8 @@ export const SueReportLocation = ({
   const { position: lastKnownPosition } = useLastKnownPosition(
     systemPermission?.status !== Location.PermissionStatus.GRANTED
   );
+  const currentPosition = position || lastKnownPosition;
+
   const [updatedRegion, setUpdatedRegion] = useState(false);
 
   useEffect(() => {
@@ -198,8 +200,6 @@ export const SueReportLocation = ({
   };
 
   const onMyLocationButtonPress = async ({ isFullScreenMap = false }) => {
-    const currentPosition = position || lastKnownPosition;
-
     if (!isFullScreenMap) {
       Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.myLocation, [
         {
@@ -255,7 +255,7 @@ export const SueReportLocation = ({
           onMaximizeButtonPress={() =>
             navigation.navigate(ScreenName.SueReportMapView, {
               calloutTextEnabled: true,
-              currentPosition: position || lastKnownPosition,
+              currentPosition,
               isMyLocationButtonVisible: !!locationService,
               locations,
               mapCenterPosition: selectedPosition || mapCenterPosition,

--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -255,11 +255,10 @@ export const SueReportLocation = ({
           onMyLocationButtonPress={() => onMyLocationButtonPress()}
           onMapPress={onMapPress}
           onMaximizeButtonPress={() =>
-            navigation.navigate(ScreenName.MapView, {
+            navigation.navigate(ScreenName.SueReportMapView, {
               calloutTextEnabled: true,
               currentPosition: position || lastKnownPosition,
               isMyLocationButtonVisible: !!locationService,
-              isSue: true,
               locations,
               mapCenterPosition: selectedPosition || mapCenterPosition,
               onMapPress,

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -48,6 +48,7 @@ import {
   SettingsScreen,
   SueListScreen,
   SueMapScreen,
+  SueMapViewScreen,
   SueReportScreen,
   SurveyDetailScreen,
   SurveyOverviewScreen,
@@ -373,6 +374,11 @@ export const defaultStackConfig = ({
         query: QUERY_TYPES.SUE.REQUESTS,
         usedAsInitialScreen: true
       }
+    },
+    {
+      routeName: ScreenName.SueReportMapView,
+      screenComponent: SueMapViewScreen,
+      screenOptions: { title: texts.screenTitles.mapView }
     },
     {
       routeName: ScreenName.SurveyDetail,

--- a/src/screens/MapViewScreen.js
+++ b/src/screens/MapViewScreen.js
@@ -9,28 +9,16 @@ import { navigationToArtworksDetailScreen } from '../helpers';
 
 export const MapViewScreen = ({ navigation, route }) => {
   const {
-    calloutTextEnabled,
-    currentPosition,
     geometryTourData,
     isAugmentedReality,
     isMaximizeButtonVisible,
-    isMyLocationButtonVisible,
-    isSue,
     locations,
-    mapCenterPosition,
-    onMapPress,
     onMarkerPress,
-    onMyLocationButtonPress,
-    selectedPosition,
     showsUserLocation
   } = route?.params ?? {};
 
   const { globalSettings } = useContext(SettingsContext);
   const { navigation: navigationType } = globalSettings;
-
-  const [position, setPosition] = useState(selectedPosition);
-  const [locationsWithPin, setLocationsWithPin] = useState(locations);
-  const [updatedRegion, setUpdatedRegion] = useState();
 
   /* the improvement in the next comment line has been added for augmented reality feature. */
   const { data } = route?.params?.augmentedRealityData ?? [];
@@ -45,63 +33,17 @@ export const MapViewScreen = ({ navigation, route }) => {
   }, [modelId]);
   /* end of augmented reality feature */
 
-  useEffect(() => {
-    if (isSue) {
-      setLocationsWithPin((prevData) =>
-        prevData.map((item) =>
-          item?.iconName === 'location' ? { iconName: 'location', position } : item
-        )
-      );
-    }
-  }, [position]);
-
   return (
     <>
       <Map
         {...{
-          calloutTextEnabled,
           geometryTourData,
           isMaximizeButtonVisible,
-          isMyLocationButtonVisible,
-          locations: [...locationsWithPin, { position }],
-          mapCenterPosition,
-          mapStyle: styles.map,
+          locations,
+          mapStyle: styles.mapStyle,
           onMarkerPress: isAugmentedReality ? setModelId : onMarkerPress,
           showsUserLocation
         }}
-        onMyLocationButtonPress={async () => {
-          if (isSue) {
-            setPosition(currentPosition.coords);
-            setUpdatedRegion(true);
-
-            try {
-              await onMyLocationButtonPress(true);
-            } catch (error) {
-              setPosition(undefined);
-            }
-          }
-        }}
-        onMapPress={async ({ nativeEvent }) => {
-          if (
-            nativeEvent.action !== 'marker-press' &&
-            nativeEvent.action !== 'callout-inside-press' &&
-            isSue
-          ) {
-            setPosition(nativeEvent.coordinate);
-            setUpdatedRegion(false);
-
-            try {
-              await onMapPress({ nativeEvent });
-            } catch (error) {
-              setPosition(undefined);
-            }
-          }
-        }}
-        updatedRegion={
-          !!position && updatedRegion && isSue
-            ? { ...position, latitudeDelta: 0.01, longitudeDelta: 0.01 }
-            : undefined
-        }
       />
 
       {isAugmentedReality && modelData && (
@@ -134,7 +76,7 @@ const styles = StyleSheet.create({
   augmentedRealityInfoContainer: {
     width: '90%'
   },
-  map: {
+  mapStyle: {
     width: '100%',
     height: '100%'
   },

--- a/src/screens/MapViewScreen.js
+++ b/src/screens/MapViewScreen.js
@@ -40,7 +40,7 @@ export const MapViewScreen = ({ navigation, route }) => {
           geometryTourData,
           isMaximizeButtonVisible,
           locations,
-          mapStyle: styles.mapStyle,
+          mapStyle: styles.map,
           onMarkerPress: isAugmentedReality ? setModelId : onMarkerPress,
           showsUserLocation
         }}
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
   augmentedRealityInfoContainer: {
     width: '90%'
   },
-  mapStyle: {
+  map: {
     width: '100%',
     height: '100%'
   },

--- a/src/screens/SUE/SueMapViewScreen.tsx
+++ b/src/screens/SUE/SueMapViewScreen.tsx
@@ -1,0 +1,131 @@
+import { StackNavigationProp } from '@react-navigation/stack';
+import React, { useContext, useEffect, useState } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { SettingsContext } from '../../SettingsProvider';
+import { Map } from '../../components';
+import { colors, normalize } from '../../config';
+
+export const SueMapViewScreen = ({
+  navigation,
+  route
+}: {
+  navigation: StackNavigationProp<any>;
+  route: any;
+}) => {
+  const {
+    calloutTextEnabled,
+    currentPosition,
+    geometryTourData,
+    isMaximizeButtonVisible,
+    isMyLocationButtonVisible,
+    locations,
+    mapCenterPosition,
+    onMapPress,
+    onMarkerPress,
+    onMyLocationButtonPress,
+    selectedPosition,
+    showsUserLocation
+  } = route?.params ?? {};
+
+  const { globalSettings } = useContext(SettingsContext);
+  const { navigation: navigationType } = globalSettings;
+
+  const [position, setPosition] = useState(selectedPosition);
+  const [locationsWithPin, setLocationsWithPin] = useState(locations);
+  const [updatedRegion, setUpdatedRegion] = useState();
+
+  useEffect(() => {
+    setLocationsWithPin((prevData) =>
+      prevData.map((item) =>
+        item?.iconName === 'location' ? { iconName: 'location', position } : item
+      )
+    );
+  }, [position]);
+
+  return (
+    <>
+      <Map
+        {...{
+          calloutTextEnabled,
+          geometryTourData,
+          isMaximizeButtonVisible,
+          isMyLocationButtonVisible,
+          locations: [...locationsWithPin, { position }],
+          mapCenterPosition,
+          mapStyle: styles.map,
+          onMarkerPress: onMarkerPress,
+          showsUserLocation
+        }}
+        onMyLocationButtonPress={async () => {
+          setPosition(currentPosition.coords);
+          setUpdatedRegion(true);
+
+          try {
+            await onMyLocationButtonPress(true);
+          } catch (error) {
+            setPosition(undefined);
+          }
+        }}
+        onMapPress={async ({ nativeEvent }) => {
+          if (
+            nativeEvent.action !== 'marker-press' &&
+            nativeEvent.action !== 'callout-inside-press'
+          ) {
+            setPosition(nativeEvent.coordinate);
+            setUpdatedRegion(false);
+
+            try {
+              await onMapPress({ nativeEvent });
+            } catch (error) {
+              setPosition(undefined);
+            }
+          }
+        }}
+        updatedRegion={
+          !!position && updatedRegion
+            ? { ...position, latitudeDelta: 0.01, longitudeDelta: 0.01 }
+            : undefined
+        }
+      />
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  augmentedRealityInfoContainer: {
+    width: '90%'
+  },
+  map: {
+    width: '100%',
+    height: '100%'
+  },
+  marginTop: {
+    marginTop: normalize(14)
+  },
+  listItemContainer: {
+    backgroundColor: colors.surface,
+    borderRadius: normalize(12),
+    left: '4%',
+    position: 'absolute',
+    right: '4%',
+    width: '92%',
+    // shadow:
+    elevation: 2,
+    shadowColor: colors.shadowRgba,
+    shadowOffset: {
+      height: 5,
+      width: 0
+    },
+    shadowOpacity: 0.5,
+    shadowRadius: 3
+  }
+});
+
+const stylesWithProps = ({ navigationType }) => {
+  return StyleSheet.create({
+    position: {
+      bottom: navigationType === 'drawer' ? '8%' : '4%'
+    }
+  });
+};

--- a/src/screens/SUE/index.ts
+++ b/src/screens/SUE/index.ts
@@ -1,4 +1,5 @@
 export * from './SueDetailScreen';
 export * from './SueListScreen';
 export * from './SueMapScreen';
+export * from './SueMapViewScreen';
 export * from './SueReportScreen';

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -55,6 +55,7 @@ export enum ScreenName {
   SueList = 'SueList',
   SueMap = 'SueMap',
   SueReport = 'SueReport',
+  SueReportMapView = 'SueReportMapView',
   SurveyDetail = 'SurveyDetail',
   SurveyOverview = 'SurveyOverview',
   TilesScreen = 'TilesScreen',


### PR DESCRIPTION
- turned `onMapPress` into a separate method to send it as param to `MapViewScreen`
- added `position` state to `MapViewScreen` to add pins to the map
- updated the `locationsWithPin` state in the `useEffect` to prevent two pins from being added when clicking on the map in `MapViewScreen`
- added `onMyLocationButtonPress` as an extra method to use the current location information on the full screen map
- added `updateRegion` to refresh the map when the user presses the current location button

SUE-80

## Screenshots:

|||
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-12 at 20 50 13](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/48bba43d-5e15-4c60-834a-c02dcca5b35c)|![image](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/8c2a734c-8810-4705-a153-a5b74bb9aed1)
