### PR TITLE
fix: the problem that the button in the feedback section does not appear

### DIFF
--- a/src/components/SUE/report/SueReportSend.tsx
+++ b/src/components/SUE/report/SueReportSend.tsx
@@ -6,7 +6,8 @@ import { Alert, Keyboard, ScrollView, StyleSheet, View } from 'react-native';
 import { Divider, Rating } from 'react-native-elements';
 
 import { ConfigurationsContext } from '../../../ConfigurationsProvider';
-import { colors, normalize, texts } from '../../../config';
+import { colors, device, normalize, texts } from '../../../config';
+import { useKeyboardHeight } from '../../../hooks';
 import { QUERY_TYPES, createQuery } from '../../../queries';
 import { ScreenName } from '../../../types';
 import { Button } from '../../Button';
@@ -37,6 +38,7 @@ export const SueReportSend = ({
   const { title: loadingTitle = '', subtitle: loadingSubtitle = '' } = reportSendLoading;
   const { title: doneTitle = '', subtitle: doneSubtitle = '' } = reportSendDone;
 
+  const keyboardHeight = useKeyboardHeight();
   const scrollViewRef = useRef(null);
 
   const { control, reset, handleSubmit } = useForm({
@@ -159,6 +161,10 @@ export const SueReportSend = ({
                     }
                   />
                 </View>
+
+                {device.platform === 'android' && (
+                  <View style={{ height: normalize(keyboardHeight) * 0.8 }} />
+                )}
               </>
             )}
           </Wrapper>


### PR DESCRIPTION
- added a `View` up to the height of the keyboard to fix the problem of the button staying behind the keyboard when the keyboard is opened on the android platform

SUE-78

## Screenshots:

|before|after|
|--|--|
![Screenshot_20240613-090921](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/e6ad5958-2462-4d92-b047-1498dcbe57a8)|![Screenshot_20240613-090948](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/4a383694-39bb-44fd-b203-fc6ddc1d091d)
