### PR TITLE
fix(sue): the problem of the app crashing when taking a picture

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,6 +26,7 @@
         "NSCameraUsageDescription": "Diese App nutzt die Kamera um QR-Codes zu scannen.",
         "NSPhotoLibraryUsageDescription": "Diese App nutzt die Medienbibliothek für die Auswahl eines Profilbildes.",
         "NSLocationWhenInUseUsageDescription": "Diese App kann die Standortbestimmung nutzen, um Ihre aktuelle Position auf der Karte darzustellen und Inhalte nach Entfernung zu sortieren.",
+        "NSMicrophoneUsageDescription": "Diese App benötigt Zugriff auf das Mikrofon, um die Kamera zu benutzen",
         "CFBundleLocalizations": ["de"],
         "CFBundleDevelopmentRegion": "de_DE",
         "LSApplicationQueriesSchemes": ["whatsapp"]
@@ -60,13 +61,7 @@
       [
         "expo-camera",
         {
-          "microphonePermission": false
-        }
-      ],
-      [
-        "expo-image-picker",
-        {
-          "microphonePermission": false
+          "recordAudioAndroid": false
         }
       ],
       [
@@ -91,6 +86,7 @@
       ],
       "expo-asset",
       "expo-font",
+      "expo-image-picker",
       "expo-localization",
       "expo-secure-store",
       "./config-plugins/withAndroidMailQueriesAndWhatsappPackage"


### PR DESCRIPTION
- updated `microphonePermission` in `app.json` to prevent the app from crashing due to insufficient permissions when taking enough pictures for the iOS platform

SUE-108

![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-27 at 16 08 18](https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/89303250-216e-4604-a69c-50b4ed8dbccc)

