### PR TITLE
feat(sentry): reduce sentry logs

### DIFF
--- a/App.js
+++ b/App.js
@@ -15,10 +15,8 @@ const sentryApi = secrets[namespace].sentryApi;
 
 if (sentryApi?.dsn) {
   Sentry.init({
-    dsn: sentryApi.dsn,
-    enableNative: true, // NOTE: Native crash reporting is not available with the classic build system (expo build:[ios|android]), but is available via EAS Build.
-    // enableInExpoDevelopment: true, // NOTE: Use this to enable temporarily tracking errors in development
-    debug: __DEV__ // NOTE: If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
+    dsn: sentryApi.dsn
+    // debug: __DEV__ // NOTE: If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event.
   });
 }
 


### PR DESCRIPTION
- updated the `debug` section in `Sentry.init` to the comment line so that the sentry log is not generated
  on every click in development mode defaults to `false`
  - https://docs.sentry.io/platforms/react-native/configuration/options/#debug
- deleted `enableNative` value because it has `true` value by default

SVA-1383