### PR TITLE
feat: update total image size format

### DIFF
--- a/src/components/augmentedReality/ARObjectList.js
+++ b/src/components/augmentedReality/ARObjectList.js
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { Alert, FlatList } from 'react-native';
 
 import { texts } from '../../config';
-import { deleteAllData, downloadAllData, formatSizeForAugmentedReality } from '../../helpers';
+import { deleteAllData, downloadAllData, formatSizeStandard } from '../../helpers';
 import { Button } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { SectionHeader } from '../SectionHeader';
@@ -71,7 +71,7 @@ export const ARObjectList = ({
 
   const checkFreeStorage = async () => {
     const storage = await FileSystem.getFreeDiskStorageAsync();
-    setFreeSize(formatSizeForAugmentedReality(storage));
+    setFreeSize(formatSizeStandard(storage));
   };
 
   const downloadAll = async () => {

--- a/src/helpers/augmentedReality/progressSizeGenerator.js
+++ b/src/helpers/augmentedReality/progressSizeGenerator.js
@@ -1,4 +1,4 @@
-import { formatSizeForAugmentedReality } from '../fileSizeHelper';
+import { formatSizeStandard } from '../fileSizeHelper';
 
 /**
  * display bytes downloaded per second in different formats
@@ -10,10 +10,8 @@ import { formatSizeForAugmentedReality } from '../fileSizeHelper';
  */
 export const progressSizeGenerator = (progressSize, totalSize) => {
   if (!progressSize) {
-    return formatSizeForAugmentedReality(totalSize);
+    return formatSizeStandard(totalSize);
   }
 
-  return `${formatSizeForAugmentedReality(progressSize)} / ${formatSizeForAugmentedReality(
-    totalSize
-  )}`;
+  return `${formatSizeStandard(progressSize)} / ${formatSizeStandard(totalSize)}`;
 };

--- a/src/helpers/fileSizeHelper.ts
+++ b/src/helpers/fileSizeHelper.ts
@@ -11,7 +11,7 @@ export const formatSize = (size: number, decimals = 1) => {
 };
 
 // thanks for : https://gist.github.com/zentala/1e6f72438796d74531803cc3833c039c
-export const formatSizeForAugmentedReality = (bytes: number, decimals = 1) => {
+export const formatSizeStandard = (bytes: number, decimals = 1) => {
   if (bytes == 0) return '0 Bytes';
 
   const sizes = ['Bytes', 'KB', 'MB', 'GB'];

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -27,7 +27,7 @@ import {
   Wrapper
 } from '../../components';
 import { colors, consts, device, normalize, texts } from '../../config';
-import { addToStore, formatSize, readFromStore } from '../../helpers';
+import { addToStore, formatSizeStandard, readFromStore } from '../../helpers';
 import { useKeyboardHeight } from '../../hooks';
 import { QUERY_TYPES, getQuery } from '../../queries';
 import { postRequests } from '../../queries/SUE';
@@ -405,7 +405,9 @@ export const SueReportScreen = ({
 
           /* the server does not support files larger than 30 MB in total of all files. */
           if (totalSize >= totalSizeLimit) {
-            return texts.sue.report.alerts.imagesTotalSizeError(formatSize(totalSizeLimit, 0));
+            return texts.sue.report.alerts.imagesTotalSizeError(
+              formatSizeStandard(totalSizeLimit, 0)
+            );
           }
         }
 


### PR DESCRIPTION
- updated `formatSizeForAugmentedReality` helper to `formatSizeStandard` to use in different parts of the code and to avoid name confusion
- updated the `formatSize` helper in `SueReportScreen` with `formatSizeStandard` because it provides a more accurate calculation

SUE-90

<img width="454" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/dd0614f4-44e3-4e7f-8862-060e6bbeea0b">

<img width="755" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-app/assets/11755668/2a4fb215-2d59-44c1-8be8-96d9d081e6b6">
