### PR TITLE
feat: add control to open times on detail screen

### DIFF
--- a/src/components/infoCard/InfoCard.tsx
+++ b/src/components/infoCard/InfoCard.tsx
@@ -27,6 +27,7 @@ type Props = WebUrlProps & {
   name?: string;
   openingHours?: OpeningHour[];
   openWebScreen: (link: string) => void;
+  showOpeningTimes: boolean;
 };
 
 /* TODO: add a logic to display info category and url that fit the screen even if long text
@@ -38,9 +39,10 @@ export const InfoCard = ({
   contact,
   contacts,
   name,
-  webUrls,
   openingHours,
-  openWebScreen
+  openWebScreen,
+  showOpeningTimes,
+  webUrls
 }: Props) => (
   <View>
     {!!name && (
@@ -58,7 +60,7 @@ export const InfoCard = ({
       </InfoBox>
     )}
 
-    <OpenStatus openingHours={openingHours} />
+    {showOpeningTimes && <OpenStatus openingHours={openingHours} />}
 
     <AddressSection address={address} addresses={addresses} openWebScreen={openWebScreen} />
 

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -19,6 +19,7 @@ import { InfoCard } from '../infoCard';
 import { Map } from '../map';
 import { VoucherListItem } from '../vouchers';
 
+import { SettingsContext } from '../../SettingsProvider';
 import { AvailableVehicles } from './AvailableVehicles';
 import { OpeningTimesCard } from './OpeningTimesCard';
 import { OperatingCompany } from './OperatingCompany';
@@ -33,6 +34,9 @@ export const INCREMENT_VOUCHER_COUNT = 5;
 /* NOTE: we need to check a lot for presence, so this is that complex */
 export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
+  const { globalSettings } = useContext(SettingsContext);
+  const { settings = {} } = globalSettings;
+  const { showFilterByOpeningTimes: showOpeningTimes = true } = settings;
   const [loadedVoucherDataCount, setLoadedVoucherDataCount] = useState(INITIAL_VOUCHER_COUNT);
   const {
     addresses,
@@ -95,11 +99,12 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
         {!!logo && <Logo source={{ uri: logo }} />}
 
         <InfoCard
-          category={category}
           addresses={addresses}
+          category={category}
           contact={contact}
           openingHours={openingHours}
           openWebScreen={openWebScreen}
+          showOpeningTimes={showOpeningTimes}
           webUrls={webUrls}
         />
       </Wrapper>


### PR DESCRIPTION
- added that if `showFilterByOpeningTimes` is set to false in main-server, not only the filter is not shown, but also the opening times in `DetailScreen` are hidden
- updated `showFilterByOpeningTimes` to `showOpeningTimes` in `PointOfInterest` to improve code clarity

SVA-1395

## Screenshots:

|before|after|
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-19 at 10 30 34](https://github.com/user-attachments/assets/ea9525e1-92e3-4f40-8c24-e9eab533e432)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-19 at 10 38 07](https://github.com/user-attachments/assets/94cf7a19-306b-4fcd-832f-c6df2f7d93b9)
