### PR TITLE
fix: http pages not opening on ios platform

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,6 +23,7 @@
       "supportsTablet": true,
       "requireFullScreen": true,
       "infoPlist": {
+        "NSAppTransportSecurity": { "NSAllowsArbitraryLoads": true },
         "NSCameraUsageDescription": "Diese App nutzt die Kamera um QR-Codes zu scannen.",
         "NSPhotoLibraryUsageDescription": "Diese App nutzt die Medienbibliothek für die Auswahl eines Profilbildes.",
         "NSLocationWhenInUseUsageDescription": "Diese App kann die Standortbestimmung nutzen, um Ihre aktuelle Position auf der Karte darzustellen und Inhalte nach Entfernung zu sortieren.",


### PR DESCRIPTION
- added `NSAppTransportSecurity` to `infoPlist` in `app.json` to fix http sites not opening on ios platform

SVA-1400
