### PR TITLE
fix(config): app not loading problem

### DIFF
--- a/src/ConfigurationsProvider.tsx
+++ b/src/ConfigurationsProvider.tsx
@@ -45,16 +45,19 @@ export const ConfigurationsProvider = ({ children }: { children?: ReactNode }) =
   const { data: sueProgress } = useStaticContent({
     refreshTimeKey: 'publicJsonFile-sueReportProgress',
     name: 'sueReportProgress',
-    type: 'json'
+    type: 'json',
+    skip: !Object.keys(sue).length
   });
 
   const mergedConfig = useMemo(() => {
-    const config = {
+    if (!Object.keys(sue).length) {
+      return defaultConfiguration;
+    }
+
+    return mergeDefaultConfiguration(defaultConfiguration, {
       appDesignSystem,
       sueConfig: { ...sue, ...sueConfigData, sueProgress }
-    };
-
-    return mergeDefaultConfiguration({ ...defaultConfiguration }, config);
+    });
   }, [appDesignSystem, sue, sueConfigData, sueProgress]);
 
   useEffect(() => {


### PR DESCRIPTION
- added control to `useEffect` to fix the problem of entering an infinite loop when the app first starts if there is no sue object in `globalSettings`
- added skip to prevent loading of `sueReportProgress` staticContent if sue object is not in `globalSettings`

SVA-1403

## How to test:

I added a new `globalSettings` of version 4.1.0 to main-server. This version does not contain sue object. You can try by changing the version in `app.json` to 4.1.0.