### PR TITLE
fix(sue): required input problem in config

### DIFF
--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -113,8 +113,8 @@ export const ImageSelector = ({
       const { selectedPosition, setValue = () => {} } = coordinateCheck || {};
 
       if (
-        selectedPosition.latitude === GPSLatitude &&
-        selectedPosition.longitude === GPSLongitude
+        selectedPosition?.latitude === GPSLatitude &&
+        selectedPosition?.longitude === GPSLongitude
       ) {
         coordinateCheck.setSelectedPosition(undefined);
         coordinateCheck.setUpdateRegionFromImage(false);

--- a/src/config/sue/default.ts
+++ b/src/config/sue/default.ts
@@ -42,17 +42,10 @@ const limitationDefaults = {
 };
 
 const requiredFieldsDefaults = {
-  address: {
-    city: false,
-    street: false,
-    zipCode: false
-  },
-  contact: {
-    email: false,
-    familyName: false,
-    name: false,
-    phone: false
-  }
+  email: false,
+  firstName: false,
+  lastName: false,
+  phone: false
 };
 
 const sueReportScreenDefaults = {

--- a/src/queries/SUE/configurations.tsx
+++ b/src/queries/SUE/configurations.tsx
@@ -36,7 +36,7 @@ export const configurations = async () => {
         return acc;
       }, {});
     const geoMap = mapKeysToCamelCase(geoMapResponse);
-    const requiredFields = mapKeysToCamelCase(requiredFieldResponse);
+    const requiredFields = mapKeysToCamelCase(requiredFieldResponse?.contact);
 
     return {
       geoMap,

--- a/src/queries/SUE/requests.tsx
+++ b/src/queries/SUE/requests.tsx
@@ -32,16 +32,16 @@ export const postRequests = async (data: any) => {
   const formData = new FormData();
 
   if (data) {
-    formData.append('address_string', data.addressString);
-    formData.append('description', data.description);
-    formData.append('email', data.email);
-    formData.append('first_name', data.firstName);
-    formData.append('last_name', data.lastName);
-    formData.append('lat', data.lat);
-    formData.append('long', data.long);
-    formData.append('phone', data.phone);
-    formData.append('service_code', data.serviceCode);
-    formData.append('title', data.title);
+    data.addressString && formData.append('address_string', data.addressString);
+    data.description && formData.append('description', data.description);
+    data.email && formData.append('email', data.email);
+    data.firstName && formData.append('first_name', data.firstName);
+    data.lastName && formData.append('last_name', data.lastName);
+    data.lat && formData.append('lat', data.lat);
+    data.long && formData.append('long', data.long);
+    data.phone && formData.append('phone', data.phone);
+    data.serviceCode && formData.append('service_code', data.serviceCode);
+    data.title && formData.append('title', data.title);
   }
 
   const images = JSON.parse(data?.images) || [];

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -558,7 +558,7 @@ export const SueReportScreen = ({
         long: selectedPosition?.longitude,
         serviceCode: service?.serviceCode,
         ...sueReportData,
-        phone: parsePhoneNumber(sueReportData.phone, 'DE')?.formatInternational(),
+        phone: parsePhoneNumber(sueReportData.phone, 'DE')?.formatInternational() || '',
         description: sueReportData.description || '-'
       };
 

--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -58,9 +58,9 @@ const sueProgressWithRequiredInputs = (
 ): TProgress[] => {
   const requiredInputs: { [key: string]: boolean } = {};
 
-  if (requiredFields?.contact) {
-    for (const field in requiredFields.contact) {
-      requiredInputs[field] = requiredFields.contact[field];
+  if (requiredFields) {
+    for (const field in requiredFields) {
+      requiredInputs[field] = requiredFields[field];
     }
   }
 


### PR DESCRIPTION
- removed from `requiredFieldsDefaults` object because `geoMap` config is used to set the input requirement instead of `address` values from config
- parse the `contact` object in the `mapKeysToCamelCase` function in `configurations.tsx` since the address config is no longer needed
- removed from control because there is no `contact` object in `SueReportScreen`

SUE-97

## Screenshots:

config:
```
    "contact": {
      "email": true,
      "first_name": true,
      "last_name": true,
      "phone": true
    }
```

|before|after|
|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-01 at 10 16 05](https://github.com/user-attachments/assets/7a9965b9-49dd-496f-82a9-2e9fcd5ede8e)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-01 at 10 15 30](https://github.com/user-attachments/assets/6929d3b7-a6fb-4f88-a756-ed5471b5f3ed)
