### PR TITLE
fix(sue): phone number undefined error

### DIFF
--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -558,7 +558,7 @@ export const SueReportScreen = ({
         long: selectedPosition?.longitude,
         serviceCode: service?.serviceCode,
         ...sueReportData,
-        phone: parsePhoneNumber(sueReportData.phone, 'DE')?.formatInternational(),
+        phone: parsePhoneNumber(sueReportData.phone, 'DE')?.formatInternational() || '',
         description: sueReportData.description || '-'
       };
 


### PR DESCRIPTION
- added empty string because of the problem that the server is not able to handle the report when the phone number is `undefined`

SUE-113
