### PR TITLE
feat(noticeboard): add the ability to add noticeboards in different categories

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -503,11 +503,6 @@ export const texts = {
       noticeboardType: 'Bitte wählen Sie den Typ Ihres Eintrags aus.',
       termsOfService: 'Bitte stimmen Sie der Verarbeitung Ihrer Daten zu.'
     },
-    categoryNames: {
-      neighbourlyHelp: 'Nachbarschaftshilfe',
-      offer: 'Angebot',
-      search: 'Gesuch'
-    },
     emptyTitle: 'Im Moment gibt es nichts zu sehen. Bitte versuchen Sie es später noch einmal.',
     expiryDate: 'Ablaufdatum',
     inputCheckbox: 'Einverständnis zur Datenverarbeitung',

--- a/src/screens/Noticeboard/NoticeboardFormScreen.tsx
+++ b/src/screens/Noticeboard/NoticeboardFormScreen.tsx
@@ -34,6 +34,7 @@ export const NoticeboardFormScreen = ({
   const name = route?.params?.name ?? '';
   const isNewEntryForm = route?.params?.isNewEntryForm ?? false;
   const details = route?.params?.details ?? {};
+  const queryVariables = route?.params?.queryVariables ?? {};
 
   const {
     data: dataHtml,
@@ -105,7 +106,7 @@ export const NoticeboardFormScreen = ({
             </Wrapper>
           )}
 
-          <Component {...{ data: details, navigation, route }} />
+          <Component {...{ data: details, navigation, route, queryVariables }} />
         </ScrollView>
       </DefaultKeyboardAvoidingView>
     </SafeAreaViewFlex>

--- a/src/screens/Noticeboard/NoticeboardIndexScreen.tsx
+++ b/src/screens/Noticeboard/NoticeboardIndexScreen.tsx
@@ -26,6 +26,7 @@ export const NoticeboardIndexScreen = ({ navigation, route }: StackScreenProps<a
     fetchPolicy,
     variables: queryVariables
   });
+
   const listItems = parseListItemsFromQuery(query, data, '', {
     consentForDataProcessingText,
     queryVariables


### PR DESCRIPTION
- added categories query to `NoticeboardCreateForm` to add noticeboard in different categories
- deleted `NOTICEBOARD_TYPE_OPTIONS` because we obtained categories with categories query
- updated `categoryName` because we use category names from query instead of customized category name in `onSubmit`
- added `queryVariables` as a prop to `NoticeboardFormScreen` because we need `queryVariables` in `NoticeboardCreateForm`
- deleted `categoryNames` in `texts` because we don't need them

SVAK-51

## Test:

- To see the categories set in main-server in the app, upgrade the version in `app.json` to `5.1.3`
- Switch to the Service Tab and you can see the noticeboard lists for level 2 or level 3

## Screenshots:

|2. level create form|3. level create form|2. level category list|3. level category list|
|--|--|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-06 at 09 20 27](https://github.com/user-attachments/assets/901cc7f7-37e4-4022-bc9e-b1d9e61a9e8e)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-06 at 09 20 39](https://github.com/user-attachments/assets/ff51f1ef-f70f-4af7-a352-b72e3f414d4b)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-06 at 09 20 31](https://github.com/user-attachments/assets/172922b5-a8be-47ff-80cc-5d9f16dc237b)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-06 at 09 20 42](https://github.com/user-attachments/assets/49b31368-7c86-4129-a5a2-fa7775e3350d)
