### PR TITLE
feat: add border option for pins

### DIFF
--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -108,7 +108,7 @@ export const SueReportLocation = ({
   const systemPermission = useSystemPermission();
   const { appDesignSystem = {} } = useContext(ConfigurationsContext);
   const { sueStatus = {} } = appDesignSystem;
-  const { statusViewColors = {}, statusTextColors = {} } = sueStatus;
+  const { statusBorderColors = {}, statusTextColors = {}, statusViewColors = {} } = sueStatus;
 
   const { position } = usePosition(
     systemPermission?.status !== Location.PermissionStatus.GRANTED || !locationServiceEnabled
@@ -146,8 +146,9 @@ export const SueReportLocation = ({
         parseListItemsFromQuery(QUERY_TYPES.SUE.REQUESTS_WITH_SERVICE_REQUEST_ID, data, undefined, {
           appDesignSystem
         }),
-        statusViewColors,
-        statusTextColors
+        statusBorderColors,
+        statusTextColors,
+        statusViewColors
       ) || [],
     [data]
   );

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -39,15 +39,26 @@ const CIRCLE_SIZES = [60, 50, 40, 30];
 const MapIcon = ({
   iconColor,
   iconName = 'location',
-  iconSize = MARKER_ICON_SIZE
+  iconSize = MARKER_ICON_SIZE,
+  strokeColor,
+  strokeWidth = normalize(0.5)
 }: {
   iconColor?: string;
   iconName?: string;
   iconSize?: number;
+  strokeColor?: string;
+  strokeWidth?: number;
 }) => {
   const MarkerIcon = Icon[_upperFirst(iconName) as keyof typeof Icon];
 
-  return <MarkerIcon color={iconColor} size={iconSize} />;
+  return (
+    <MarkerIcon
+      color={iconColor}
+      size={iconSize}
+      strokeColor={strokeColor}
+      strokeWidth={strokeWidth}
+    />
+  );
 };
 
 type TCluster = {
@@ -232,6 +243,7 @@ export const Map = ({
                         ? colors.accent
                         : undefined
                     }
+                    strokeColor={marker.iconBorderColor}
                   />
                   <View
                     style={[
@@ -254,6 +266,7 @@ export const Map = ({
                       }
                       iconName={marker.iconName}
                       iconSize={MARKER_ICON_SIZE / 3.25}
+                      strokeColor={marker.iconBorderColor}
                     />
                   </View>
                 </>
@@ -261,6 +274,7 @@ export const Map = ({
                 <MapIcon
                   iconColor={isActiveMarker ? colors.accent : undefined}
                   iconName={marker.iconName ? marker.iconName : undefined}
+                  strokeColor={marker.iconBorderColor}
                 />
               )}
 

--- a/src/config/Icon.tsx
+++ b/src/config/Icon.tsx
@@ -67,6 +67,8 @@ export type IconProps = {
   color?: string;
   iconStyle?: StyleProp<ViewStyle>;
   size?: number;
+  strokeColor?: string;
+  strokeWidth?: number;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -89,12 +91,19 @@ const SvgIcon = ({
   color = colors.primary,
   iconStyle,
   size = normalize(24),
+  strokeColor,
+  strokeWidth,
   style,
   xml
-}: IconProps & { xml: (color: string) => string }) => {
+}: IconProps & { xml: (color: string, strokeColor?: string, strokeWidth?: number) => string }) => {
   return (
     <View style={style} hitSlop={getHitSlops(size)}>
-      <SvgXml xml={xml(color)} width={size} height={size} style={iconStyle} />
+      <SvgXml
+        xml={xml(color, strokeColor, strokeWidth)}
+        width={size}
+        height={size}
+        style={iconStyle}
+      />
     </View>
   );
 };

--- a/src/icons/location.js
+++ b/src/icons/location.js
@@ -1,4 +1,4 @@
-export const location = (color) => `
+export const location = (color, strokeColor, strokeWidth) => `
   <?xml version="1.0" encoding="UTF-8"?>
   <svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -6,7 +6,7 @@ export const location = (color) => `
         C12,22 5.01955307,14.2 5.01955307,9 C5.01955307,5.1 8.11089385,2 12,2 Z M12,11.5
         C13.3960894,11.5 14.4930168,10.4 14.4930168,9 C14.4930168,7.6 13.3960894,6.5 12,6.5
         C10.6039106,6.5 9.50698324,7.6 9.50698324,9 C9.50698324,10.4 10.6039106,11.5 12,11.5 Z"
-        fill-rule="nonzero" fill="${color}"></path>
+        fill-rule="nonzero" fill="${color}" stroke="${strokeColor}" stroke-width="${strokeWidth}"></path>
     </g>
   </svg>
 `;

--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -50,14 +50,16 @@ type ItemProps = {
 
 export const mapToMapMarkers = (
   items: ItemProps[],
-  statusViewColors: Record<string, string | undefined>,
-  statusTextColors: Record<string, string | undefined>
+  statusBorderColors: Record<string, string | undefined>,
+  statusTextColors: Record<string, string | undefined>,
+  statusViewColors: Record<string, string | undefined>
 ): MapMarker[] | undefined =>
   items
     ?.filter((item) => item.lat && item.long)
     ?.map((item: ItemProps) => ({
       ...item,
       iconBackgroundColor: statusViewColors?.[item.status],
+      iconBorderColor: statusBorderColors?.[item.status],
       iconColor: statusTextColors?.[item.status],
       iconName: `Sue${_upperFirst(item.iconName)}`,
       id: item.serviceRequestId,
@@ -89,7 +91,7 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
     systemPermission?.status !== Location.PermissionStatus.GRANTED
   );
 
-  const { statusViewColors = {}, statusTextColors = {} } = sueStatus;
+  const { statusBorderColors = {}, statusTextColors = {}, statusViewColors = {} } = sueStatus;
   const queryVariables = route.params?.queryVariables ?? {
     start_date: '1900-01-01T00:00:00+01:00'
   };
@@ -110,8 +112,9 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
         parseListItemsFromQuery(QUERY_TYPES.SUE.REQUESTS_WITH_SERVICE_REQUEST_ID, data, undefined, {
           appDesignSystem
         }),
-        statusViewColors,
-        statusTextColors
+        statusBorderColors,
+        statusTextColors,
+        statusViewColors
       ),
     [data]
   );

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -3,6 +3,7 @@ import { Point } from 'react-native-maps';
 export type MapMarker = {
   iconAnchor?: Point;
   iconBackgroundColor?: string;
+  iconBorderColor?: string;
   iconColor?: string;
   iconName?: string;
   id?: string;


### PR DESCRIPTION
- added border to `location` icon to increase the contrast with the map
- added `strokeColor` and `strokeWidth` props to `SvgXml` to send border option to `xml`
- added `strokeColor` and `strokeWidth` to `MapIcon` component to add border to pins
- added `iconBorderColor` to `mapToMapMarkers` function in `SueMapScreen` to add border to pins
- added `statusBorderColors` to `sueStatus` in `globalSettings` so that border colors can be updated from server

SUE-131

## Screenshots:

|before|after|before|after|pin without border||
|--|--|--|--|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-13 at 13 50 14](https://github.com/user-attachments/assets/655e336f-70a5-4a28-a9cf-2a996c87f5b1)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-13 at 13 50 01](https://github.com/user-attachments/assets/70818fff-0008-486e-9c9d-9058da9c1a5d)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-13 at 13 50 52](https://github.com/user-attachments/assets/7d0e2806-7d6b-4660-aa80-3fd7af38811e)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-13 at 13 50 46](https://github.com/user-attachments/assets/e916fb5a-1ac4-4dc7-94d1-e598f1214c7a)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-13 at 13 51 08](https://github.com/user-attachments/assets/e47ee654-c0ee-43ce-bedf-55f892276080)|![image](https://github.com/user-attachments/assets/fd3b2c36-7298-4b5a-990c-eac93e69e2eb)
