### PR TITLE
feat(bbBus): set filter from main-server

### DIFF
--- a/src/screens/BB-BUS/IndexScreen.js
+++ b/src/screens/BB-BUS/IndexScreen.js
@@ -32,15 +32,28 @@ const INITIAL_FILTER = [
   { id: 4, title: texts.bbBus.initialFilter.aToZ, selected: false }
 ];
 
+const FILTER_IDS = {
+  TOP10: 1,
+  SEARCH: 3,
+  ATOZ: 4
+};
+
 export const IndexScreen = ({ navigation }) => {
   const [refreshTime, setRefreshTime] = useState();
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const { globalSettings } = useContext(SettingsContext);
-  const [areaId, setAreaId] = useState(globalSettings?.settings?.busBb?.v2?.areaId?.toString());
-  const [filter, setFilter] = useState(INITIAL_FILTER);
+  const { settings = {} } = globalSettings;
+  const { busBb = {} } = settings;
+  const [areaId, setAreaId] = useState(busBb?.v2?.areaId?.toString());
+  const [filter, setFilter] = useState(
+    busBb?.initialFilter?.map((entry, index) => ({
+      id: FILTER_IDS[entry.toUpperCase()],
+      title: texts.bbBus.initialFilter[entry],
+      selected: index === 0
+    })) || INITIAL_FILTER
+  );
   const [refreshing, setRefreshing] = useState(false);
-  const [client] = useState(BBBusClient(globalSettings?.settings?.busBb?.uri));
-
+  const [client] = useState(BBBusClient(busBb?.uri));
   useMatomoTrackScreenView(MATOMO_TRACKING.SCREEN_VIEW.BB_BUS);
 
   useEffect(() => {


### PR DESCRIPTION
- added `initialFilter` array in `settings.busBb` object to update the filter from main-server
- added `FILTER_IDS` to use the ids in the initial filter correctly
- added const for `busBb` object to avoid code repetition

SVAK-118

## Tests:
If you want to update the filters, an array initialFilter must be added to the settings.busBb object in globalSettings.
This array can be as follows.
```
      "initialFilter": [
        "top10",
        "search",
        "aToZ"
      ]
```

To quickly test whether the code works:
- go to `src/screens/BB-BUS/IndexScreen.js`
- copy the `initialFilter` array and paste it as a const into the code.
```
  const initialFilter = ['top10', 'search', 'aToZ'];
```
- remove `busBb?.` from `busBb?.initialFilter?...` in filter state
```
  const [filter, setFilter] = useState(
    initialFilter?.map((entry, index) => ({
      id: FILTER_IDS[entry.toUpperCase()],
      title: texts.bbBus.initialFilter[entry],
      selected: index === 0
    })) || INITIAL_FILTER
  );
```
- now you can quickly test locally instead of updating values in `globalSettings` for testing

## Screenshots:

|before|after - one of the filters has been deleted|after - filters relocated|
|--|--|--|
![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-20 at 11 36 55](https://github.com/user-attachments/assets/e1fb5556-b443-4c69-ba59-1180da7d9ec9)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-20 at 11 37 22](https://github.com/user-attachments/assets/84e8c2c5-e6e7-4b5c-b64e-74c1c4137006)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-20 at 11 37 42](https://github.com/user-attachments/assets/f9424e68-ae69-4feb-8e46-7145a1133f9a)
