### PR TITLE
fix: the problem with the area service request

### DIFF
--- a/src/queries/SUE/areaService.tsx
+++ b/src/queries/SUE/areaService.tsx
@@ -1,3 +1,5 @@
+import _uniq from 'lodash/uniq';
+
 import { storageHelper } from '../../helpers';
 
 export const areaService = async () => {
@@ -17,7 +19,15 @@ export const areaService = async () => {
     }
   };
 
-  return await (
-    await fetch(`${serverUrl}/${id}?selectAttributes=postalCodes`, areaServiceFetchObj)
+  const rs = (
+    await (await fetch(`${serverUrl}/${id}?selectAttributes=rs`, areaServiceFetchObj)).json()
+  )?.rs;
+
+  const postalCodes = await (
+    await fetch(`${serverUrl}/getByRs?rs=${rs}*&selectAttributes=postalCodes`, areaServiceFetchObj)
   ).json();
+
+  return {
+    postalCodes: _uniq(postalCodes?.values?.flatMap((item: any) => item.postalCodes || []))
+  };
 };


### PR DESCRIPTION
- updated `areaService` to access zip codes via `rs` since not all zip codes are available via `id`
- added `postalCodes` object in the return section to get all postal codes obtained via getByRs in the desired format
- added `_uniq` to remove repeated zip codes from the array

SUE-133

Log:
```
 {"postalCodes": ["24011", "24012", "24013", "24014", "24015", "24016", "24017", "24018", "24019", "24020", "24021", "24022", "24023", "24024", "24025", "24026", "24027", "24028", "24029", "24030", "24031", "24032", "24033", "24034", "24035", "24036", "24037", "24038", "24039", "24040", "24041", "24042", "24043", "24044", "24046", "24047", "24048", "24049", "24062", "24063", "24065", "24103", "24105", "24106", "24107", "24109", "24111", "24113", "24114", "24116", "24118", "24143", "24145", "24146", "24147", "24148", "24149", "24154", "24159", "24170", "24171"]}
```