### PR TITLE
fix: the problem of personalized tiles not being sorted correctly

### DIFF
--- a/src/components/screens/DraggableGrid.tsx
+++ b/src/components/screens/DraggableGrid.tsx
@@ -58,7 +58,7 @@ export const DraggableGrid = ({ children, onDragEnd }: Props) => {
         <DraggableItem
           key={child.props.key}
           positions={positions}
-          id={child.props.draggableId?.replace('​', '')}
+          id={child.props.draggableId}
           onDragEnd={onDragEnd}
           scrollView={scrollView}
           scrollY={scrollY}

--- a/src/components/screens/Service.tsx
+++ b/src/components/screens/Service.tsx
@@ -17,7 +17,7 @@ import { ServiceTile, TServiceTile } from './ServiceTile';
 
 const { MATOMO_TRACKING, UMLAUT_REGEX } = consts;
 
-const umlautSwitcher = (text: string) => {
+export const umlautSwitcher = (text: string) => {
   if (!text) return;
 
   const umlautReplacements = {
@@ -30,7 +30,9 @@ const umlautSwitcher = (text: string) => {
     ß: 'ss'
   };
 
-  const replacedText = text.replace(UMLAUT_REGEX, (match: string) => umlautReplacements[match]);
+  const replacedText = text
+    .replace(UMLAUT_REGEX, (match: string) => umlautReplacements[match])
+    ?.replace('​', '');
 
   return replacedText;
 };

--- a/src/hooks/personalizedTiles.ts
+++ b/src/hooks/personalizedTiles.ts
@@ -1,7 +1,7 @@
 import { useIsFocused } from '@react-navigation/native';
 import { useCallback, useEffect, useState } from 'react';
 
-import { TServiceTile } from '../components';
+import { TServiceTile, umlautSwitcher } from '../components';
 import { Positions } from '../components/screens/DraggableItem';
 import { addToStore, readFromStore } from '../helpers';
 
@@ -44,8 +44,8 @@ export const usePersonalizedTiles = (
     if (sorter) {
       personalizedTiles = personalizedTiles.sort((a: TServiceTile, b: TServiceTile) => {
         const sortTitles = {
-          a: a.title?.replace('​', '') || a.accessibilityLabel,
-          b: b.title?.replace('​', '') || b.accessibilityLabel
+          a: umlautSwitcher(a.title) || umlautSwitcher(a.accessibilityLabel),
+          b: umlautSwitcher(b.title) || umlautSwitcher(b.accessibilityLabel)
         };
         const sortA =
           sorter?.[sortTitles.a] ?? tiles.findIndex((d: TServiceTile) => d.title === a.title);


### PR DESCRIPTION
- updated `sortTitles` values in `personalizedTiles` with `umlautSwitcher` to bring mismatched titles into the same format to fix a bug where personalized tiles were not sorted correctly after saving
- removed `replace` from `id` in `DraggableGrid` because `replace` was added at the end of the `umlautSwitcher` function

SVA-1291

Before update:
|before save|update|after save|
|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-10 at 16 57 06](https://github.com/user-attachments/assets/67e58601-cfaf-46c6-8304-f12e36c1099d)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-10 at 16 57 19](https://github.com/user-attachments/assets/feb0b838-bd29-4ea6-8d9c-49fc35cb99df)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-10 at 16 57 22](https://github.com/user-attachments/assets/08cfc341-c9b2-4d57-a446-ab665bc58af5)

After update:
|before save|update|after save|
|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-10 at 17 00 35](https://github.com/user-attachments/assets/b50f6164-e131-4ed6-ad65-328d3856a81a)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-10 at 17 00 53](https://github.com/user-attachments/assets/4c178789-ea35-4f48-acc9-bf9a29f8011f)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-10 at 17 01 41](https://github.com/user-attachments/assets/22059a40-2f89-4d9c-96e8-c4c21424be74)

