### PR TITLE
feat: add `autoplayInterval` to slider

### DIFF
--- a/src/components/ImagesCarousel.js
+++ b/src/components/ImagesCarousel.js
@@ -28,7 +28,7 @@ export const ImagesCarousel = ({
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
-  const { sliderPauseButton = {} } = settings;
+  const { sliderPauseButton = {}, sliderSettings = {} } = settings;
   const {
     horizontalPosition = 'right',
     show: showSliderPauseButton = false,
@@ -62,7 +62,7 @@ export const ImagesCarousel = ({
   const itemWidth = imageWidth();
 
   const renderItem = useCallback(
-    ({ item }) => {
+    ({ item, refreshInterval }) => {
       const { routeName: name, params } = item.picture || {};
 
       // params are available, but missing `shareContent` and `details`
@@ -104,7 +104,7 @@ export const ImagesCarousel = ({
                   containerStyle={styles.imageContainer}
                   message={item.message}
                   navigation={navigation}
-                  refreshInterval={item.refreshInterval}
+                  refreshInterval={item.refreshInterval || refreshInterval}
                   source={item.picture}
                 />
               );
@@ -120,7 +120,7 @@ export const ImagesCarousel = ({
           containerStyle={styles.imageContainer}
           message={item.message}
           navigation={navigation}
-          refreshInterval={item.refreshInterval}
+          refreshInterval={item.refreshInterval || refreshInterval}
           source={item.picture}
         />
       );
@@ -147,14 +147,16 @@ export const ImagesCarousel = ({
       <Carousel
         data={carouselData}
         ref={carouselRef}
-        renderItem={renderItem}
+        renderItem={({ item }) =>
+          renderItem({ item, refreshInterval: sliderSettings.refreshInterval })
+        }
         sliderWidth={dimensions.width}
         itemWidth={itemWidth}
         inactiveSlideScale={1}
         autoplay
         loop
         autoplayDelay={0}
-        autoplayInterval={autoplayInterval || 4000}
+        autoplayInterval={autoplayInterval || sliderSettings.autoplayInterval || 4000}
         containerCustomStyle={styles.center}
         onScrollIndexChanged={setCarouselImageIndex}
       />


### PR DESCRIPTION
- added `autoplayInterval` to give more customization options to the slider
- added options to customize the slider with the `sliderSettings` object added inside the `globalSettings.settings` object
  - autoplayInterval: this value is used to set how many milliseconds the slider will scroll to the next image
  - refreshInterval: allows the image in the slider to be displayed without being cached and refreshes the image after the milliseconds entered here

EP-21

```
{
 ...
  "sliderSettings": {
    "autoplayInterval": 3000,
    "refreshInterval": 3000
  }
},
...
```

before

https://github.com/user-attachments/assets/312db700-8d65-4f78-a878-76b15f6259a7

after

https://github.com/user-attachments/assets/7b6719a6-d59b-4138-8c7b-c5693c33a261