### PR TITLE
fix: the problem of tiles hiding

### DIFF
--- a/src/hooks/personalizedTiles.ts
+++ b/src/hooks/personalizedTiles.ts
@@ -29,7 +29,8 @@ export const usePersonalizedTiles = (
       // if we are not in edit mode we want to filter out tiles entirely.
       // if there is no entry in `toggles`, it means that the tile is new or never toggled, so we
       // want to show it.
-      const isVisible = (item: TServiceTile) => toggles[item.title || item.accessibilityLabel] ?? 1;
+      const isVisible = (item: TServiceTile) =>
+        toggles[umlautSwitcher(item.title) || umlautSwitcher(item.accessibilityLabel)] ?? 1;
 
       if (isEditMode) {
         personalizedTiles = personalizedTiles.map((item: TServiceTile) => ({


### PR DESCRIPTION
- added `umlautSwitcher` to the keys of the `toggles` array because the toggles keys in the `isVisible` constant do not match, causing the tiles not to be hidden

SVA-1291
