### PR TITLE
feat: add the minimum version value for macOS platform

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,7 +30,8 @@
         "NSMicrophoneUsageDescription": "Diese App benötigt Zugriff auf das Mikrofon, um die Kamera zu benutzen",
         "CFBundleLocalizations": ["de"],
         "CFBundleDevelopmentRegion": "de_DE",
-        "LSApplicationQueriesSchemes": ["whatsapp"]
+        "LSApplicationQueriesSchemes": ["whatsapp"],
+        "LSMinimumSystemVersion": "12.0"
       },
       "config": {
         "usesNonExemptEncryption": false


### PR DESCRIPTION
- added minimum version value required for apple silicon processor support to `app.json`

SVA-1384