### PR TITLE
fix: home section query with react-query

### DIFF
--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -1,9 +1,10 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
-import { useQuery } from 'react-apollo';
+import { useQuery } from 'react-query';
 
 import { useHomeRefresh, useVolunteerData } from '../hooks';
 import { getQuery, QUERY_TYPES } from '../queries';
+import { ReactQueryClient } from '../ReactQueryClient';
 
 import { DataListSection } from './DataListSection';
 
@@ -29,7 +30,6 @@ type Props = {
 
 export const HomeSection = ({
   buttonTitle,
-  fetchPolicy,
   isIndexStartingAt1 = false,
   navigate,
   navigation,
@@ -40,13 +40,10 @@ export const HomeSection = ({
   title,
   titleDetail
 }: Props) => {
-  const {
-    data,
-    loading: isLoading,
-    refetch
-  } = useQuery(getQuery(query), {
-    variables: queryVariables,
-    fetchPolicy
+  const { data, isLoading, refetch } = useQuery([query, queryVariables], async () => {
+    const client = await ReactQueryClient();
+
+    return await client.request(getQuery(query), queryVariables);
   });
 
   const isCalendarWithVolunteerEvents = query === QUERY_TYPES.EVENT_RECORDS && showVolunteerEvents;

--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -106,7 +106,6 @@ export const GET_EVENT_RECORDS_WITHOUT_DATE_FRAGMENT = gql`
   }
 `;
 
-
 export const GET_EVENT_RECORDS = gql`
   query EventRecords(
     $ids: [ID]

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,4 +1,5 @@
 import { DeviceEventEmitter } from 'expo-modules-core';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { FlatList, RefreshControl, StyleSheet } from 'react-native';
@@ -36,6 +37,10 @@ import { QUERY_TYPES, getQueryType } from '../queries';
 import { ScreenName } from '../types';
 
 const { MATOMO_TRACKING, ROOT_ROUTE_NAMES } = consts;
+
+const today = moment().format('YYYY-MM-DD');
+// we need to set a date range to correctly sort the results by list date, so we set it far in the future
+const todayIn10Years = moment().add(10, 'years').format('YYYY-MM-DD');
 
 const renderItem = ({ item }) => {
   const {
@@ -305,7 +310,7 @@ export const HomeScreen = ({ navigation, route }) => {
       navigate: 'EVENT_RECORDS_INDEX',
       navigation,
       query: QUERY_TYPES.EVENT_RECORDS,
-      queryVariables: { limit: 3, order: 'listDate_ASC' },
+      queryVariables: { limit: 3, order: 'listDate_ASC', dateRange: [today, todayIn10Years] },
       showData: showEvents,
       showVolunteerEvents,
       title: headlineEvents


### PR DESCRIPTION
- react-apollo is not able to handle the new `date` field, which we forgot to use for home section queries

SVASD-10