### PR TITLE
fix: event category query not working

### DIFF
--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -161,6 +161,7 @@ export const GET_EVENT_RECORDS_AND_CATEGORIES = gql`
   query EventRecordsAndCategories {
     eventRecords {
       id
+      ...dateFields
     }
     categories {
       id


### PR DESCRIPTION
- added `dateFilelds` section missing in the query to fix the problem that the category filter on the event list screen does not appear due to data not loading

SVA-1388

|before|after|
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-24 at 10 10 59](https://github.com/user-attachments/assets/5201521d-dc22-4647-8867-272fefb5949f)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-24 at 10 10 42](https://github.com/user-attachments/assets/08654a0c-9c3d-46ff-b305-c22607dd4213)
