### PR TITLE
fix: category naming problem

### DIFF
--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -91,6 +91,12 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
 
   const businessAccount = dataProvider?.dataType === 'business_account';
 
+  const categoryName = route.params?.queryVariables?.categoryName;
+  let nestedCategory;
+  if (categoryName) {
+    nestedCategory = categories.find((category) => category.name === categoryName);
+  }
+
   return (
     <View>
       <ImageSection mediaContents={mediaContents} />
@@ -100,7 +106,7 @@ export const PointOfInterest = ({ data, hideMap, navigation, route }) => {
 
         <InfoCard
           addresses={addresses}
-          category={category}
+          category={nestedCategory}
           contact={contact}
           openingHours={openingHours}
           openWebScreen={openWebScreen}

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -144,11 +144,11 @@ const parseNewsItems = (data, skipLastDivider, titleDetail, bookmarkable) => {
   }));
 };
 
-const parsePointOfInterest = (data, skipLastDivider) => {
+const parsePointOfInterest = (data, skipLastDivider, queryVariables = undefined) => {
   return data?.map((pointOfInterest, index) => ({
     id: pointOfInterest.id,
     title: pointOfInterest.title || pointOfInterest.name,
-    subtitle: pointOfInterest.category?.name,
+    subtitle: queryVariables?.category || pointOfInterest.category?.name,
     picture: {
       url: mainImageOfMediaContents(pointOfInterest.mediaContents)
     },
@@ -156,7 +156,7 @@ const parsePointOfInterest = (data, skipLastDivider) => {
     params: {
       title: texts.detailTitles.pointOfInterest,
       query: QUERY_TYPES.POINT_OF_INTEREST,
-      queryVariables: { id: `${pointOfInterest.id}` },
+      queryVariables: { id: `${pointOfInterest.id}`, categoryName: queryVariables?.category },
       rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS,
       shareContent: {
         message: shareMessage(pointOfInterest, QUERY_TYPES.POINT_OF_INTEREST)
@@ -278,7 +278,7 @@ export const parseListItemsFromQuery = (query, data, titleDetail, options = {}) 
       return parseNewsItems(data[query], skipLastDivider, titleDetail, bookmarkable);
     case QUERY_TYPES.POINT_OF_INTEREST:
     case QUERY_TYPES.POINTS_OF_INTEREST:
-      return parsePointOfInterest(data[query], skipLastDivider);
+      return parsePointOfInterest(data[query], skipLastDivider, queryVariables);
     case QUERY_TYPES.TOURS:
       return parseTours(data[query], skipLastDivider);
     case QUERY_TYPES.CATEGORIES:

--- a/src/queries/pointsOfInterest.js
+++ b/src/queries/pointsOfInterest.js
@@ -96,6 +96,11 @@ export const GET_POINT_OF_INTEREST = gql`
       id
       title: name
       payload
+      categories {
+        id
+        name
+        iconName
+      }
       category {
         id
         name


### PR DESCRIPTION
- added `nestedCategory` to fix the category naming problem on the `DetailScreen`
- added `queryVariables?.category` to the `subtitle` section in `listItemParser` to fix the category naming problem in list view
- added `categories` to `pointOfInterest` query to get all categories that the content contains

SVA-1348

|parent category|before child category|after child category|before DetailScreen|after DetailScreen|
|--|--|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-25 at 14 30 50](https://github.com/user-attachments/assets/a82f3c34-70fa-449a-8603-8d449a8ee31d)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-25 at 14 31 19](https://github.com/user-attachments/assets/cc9fc556-438e-44d7-8b98-ca27a3fb7b76)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-25 at 14 29 41](https://github.com/user-attachments/assets/5f1c31ab-9089-46da-b0ae-8c51fa4b12ff)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-25 at 14 31 21](https://github.com/user-attachments/assets/08b69532-58ea-48b6-84cc-68cf83470583)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-25 at 14 29 40](https://github.com/user-attachments/assets/8f3a889a-b534-4cc2-8e4d-f44125803306)
