### PR TITLE
fix: header left problem on subcategory screen

### DIFF
--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -222,6 +222,7 @@ const parseCategories = (data, skipLastDivider, routeName, queryVariables) => {
         category: `${category.name}`,
         location: queryVariables?.location
       },
+      usedAsInitialScreen: false,
       rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS
     },
     bottomDivider: !skipLastDivider || index !== data.length - 1


### PR DESCRIPTION
- added `usedAsInitialScreen` value as false to `parseCategories` to fix the problem that if `BOTTOM_FLOATING_BUTTON` is active when switching to the subcategory screen, the upper left close button does not return to the back button

SVAK-92

before

https://github.com/user-attachments/assets/bad12777-3d7c-459a-914e-cf5897734482

after

https://github.com/user-attachments/assets/c29f9601-1a4f-48c4-a488-61bea5bc4994

