### PR TITLE
feat: add image upload feature for noticeboard

### DIFF
--- a/src/components/SUE/report/SueReportDescription.tsx
+++ b/src/components/SUE/report/SueReportDescription.tsx
@@ -41,7 +41,13 @@ export const SueReportDescription = ({
 
   const imageSelectorProps = useMemo(
     () => ({
-      configuration,
+      configuration: {
+        ...configuration,
+        limitation: {
+          ...configuration.limitation,
+          maxCount: configuration?.limitation?.maxFileUploads?.value
+        }
+      },
       control,
       coordinateCheck: {
         areaServiceData,

--- a/src/components/consul/selectors/DocumentSelector.js
+++ b/src/components/consul/selectors/DocumentSelector.js
@@ -9,7 +9,6 @@ import {
   deleteArrayItem,
   documentErrorMessageGenerator,
   formatSize,
-  formatSizeStandard,
   jsonParser
 } from '../../../helpers';
 import { useSelectDocument } from '../../../hooks';
@@ -39,9 +38,10 @@ const deleteDocumentAlert = (onPress) =>
     ]
   );
 
-export const DocumentSelector = ({ control, field, isVolunteer, item, maxFileSize }) => {
+export const DocumentSelector = ({ configuration, control, field, isVolunteer, item }) => {
   const { buttonTitle, infoText } = item;
   const { name, onChange, value } = field;
+  const { maxCount, maxFileSize } = configuration?.limitation;
 
   const [infoAndErrorText, setInfoAndErrorText] = useState(JSON.parse(value));
   const [documentsAttributes, setDocumentsAttributes] = useState(JSON.parse(value));
@@ -147,9 +147,6 @@ export const DocumentSelector = ({ control, field, isVolunteer, item, maxFileSiz
   return (
     <>
       <Input {...item} control={control} hidden name={name} value={JSON.stringify(value)} />
-      <RegularText smallest placeholder>
-        {infoText}
-      </RegularText>
 
       {values?.map((item, index) => (
         <View key={index} style={styles.container}>
@@ -174,11 +171,20 @@ export const DocumentSelector = ({ control, field, isVolunteer, item, maxFileSiz
         </View>
       ))}
 
-      {/* users can upload a maximum of 3 PDF files
-          if 3 PDFs are selected, the new add button will not be displayed. */}
-      {!value || values.length < 3 ? (
-        <Button title={buttonTitle} invert onPress={documentSelect} />
-      ) : null}
+      <Button
+        icon={<Icon.Document size={normalize(16)} strokeWidth={normalize(2)} />}
+        disabled={maxCount && values?.length >= parseInt(maxCount)}
+        iconPosition="left"
+        invert
+        onPress={documentSelect}
+        title={buttonTitle}
+      />
+
+      {!!infoText && (
+        <RegularText small style={styles.infoText}>
+          {infoText}
+        </RegularText>
+      )}
     </>
   );
 };
@@ -186,6 +192,10 @@ export const DocumentSelector = ({ control, field, isVolunteer, item, maxFileSiz
 const styles = StyleSheet.create({
   container: {
     marginVertical: normalize(10)
+  },
+  infoText: {
+    marginTop: normalize(-7),
+    marginBottom: normalize(5)
   },
   volunteerContainer: {
     marginBottom: normalize(8)
@@ -205,6 +215,7 @@ const styles = StyleSheet.create({
 });
 
 DocumentSelector.propTypes = {
+  configuration: PropTypes.object,
   control: PropTypes.object,
   field: PropTypes.object,
   isVolunteer: PropTypes.bool,

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -23,6 +23,7 @@ import { calendarDeleteFile } from '../../../queries/volunteer';
 import { Button } from '../../Button';
 import { Input } from '../../form';
 import { Image } from '../../Image';
+import { LoadingSpinner } from '../../LoadingSpinner';
 import { Modal } from '../../Modal';
 import { BoldText, RegularText } from '../../Text';
 import { WrapperRow, WrapperVertical } from '../../Wrapper';
@@ -78,6 +79,7 @@ export const ImageSelector = ({
   const [infoAndErrorText, setInfoAndErrorText] = useState(JSON.parse(value));
   const [imagesAttributes, setImagesAttributes] = useState(JSON.parse(value));
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const [deleteImage] = useMutation(DELETE_IMAGE, {
     client: ConsulClient
@@ -148,6 +150,7 @@ export const ImageSelector = ({
   };
 
   const imageSelect = async (imageFunction, from = IMAGE_FROM.GALLERY) => {
+    setLoading(true);
     const { uri, type, exif } = await imageFunction();
 
     setIsModalVisible(!isModalVisible);
@@ -182,6 +185,7 @@ export const ImageSelector = ({
 
       if (!configuration.limitation.allowedAttachmentTypes.value.includes(extension)) {
         setIsModalVisible(!isModalVisible);
+        setLoading(false);
         return Alert.alert(texts.sue.report.alerts.hint, texts.sue.report.alerts.imageType);
       }
 
@@ -214,6 +218,7 @@ export const ImageSelector = ({
 
     setImagesAttributes([...imagesAttributes, { uri, mimeType, imageName, size, exif }]);
     setIsModalVisible(!isModalVisible);
+    setLoading(false);
   };
 
   const values = jsonParser(value);
@@ -278,6 +283,7 @@ export const ImageSelector = ({
             onModalVisible={() => setIsModalVisible(false)}
             closeButton={
               <TouchableOpacity
+                disabled={loading}
                 onPress={() => setIsModalVisible(false)}
                 style={styles.overlayCloseButton}
               >
@@ -300,20 +306,28 @@ export const ImageSelector = ({
             </WrapperVertical>
 
             <WrapperVertical>
-              <Button
-                icon={<Icon.Camera size={normalize(16)} strokeWidth={normalize(2)} />}
-                iconPosition="left"
-                invert
-                onPress={() => imageSelect(captureImage, IMAGE_FROM.CAMERA)}
-                title={texts.sue.report.alerts.imageSelectAlert.camera}
-              />
-              <Button
-                icon={<Icon.Albums size={normalize(16)} strokeWidth={normalize(2)} />}
-                iconPosition="left"
-                invert
-                onPress={() => imageSelect(selectImage)}
-                title={texts.sue.report.alerts.imageSelectAlert.gallery}
-              />
+              {loading ? (
+                <LoadingSpinner loading={loading} />
+              ) : (
+                <>
+                  <Button
+                    icon={<Icon.Camera size={normalize(16)} strokeWidth={normalize(2)} />}
+                    disabled={loading}
+                    iconPosition="left"
+                    invert
+                    onPress={() => imageSelect(captureImage, IMAGE_FROM.CAMERA)}
+                    title={texts.sue.report.alerts.imageSelectAlert.camera}
+                  />
+                  <Button
+                    icon={<Icon.Albums size={normalize(16)} strokeWidth={normalize(2)} />}
+                    disabled={loading}
+                    iconPosition="left"
+                    invert
+                    onPress={() => imageSelect(selectImage)}
+                    title={texts.sue.report.alerts.imageSelectAlert.gallery}
+                  />
+                </>
+              )}
             </WrapperVertical>
           </Modal>
         </>

--- a/src/components/consul/selectors/ImageSelector.js
+++ b/src/components/consul/selectors/ImageSelector.js
@@ -73,6 +73,7 @@ export const ImageSelector = ({
 
   const { buttonTitle, infoText } = item;
   const { name, onChange, value } = field;
+  const { maxCount, maxFileSize } = configuration?.limitation;
 
   const [infoAndErrorText, setInfoAndErrorText] = useState(JSON.parse(value));
   const [imagesAttributes, setImagesAttributes] = useState(JSON.parse(value));
@@ -202,7 +203,14 @@ export const ImageSelector = ({
       }
     }
 
-    errorTextGenerator({ errorType, infoAndErrorText, mimeType, setInfoAndErrorText, uri });
+    errorTextGenerator({
+      errorType,
+      infoAndErrorText,
+      maxFileSize,
+      mimeType,
+      setInfoAndErrorText,
+      uri
+    });
 
     setImagesAttributes([...imagesAttributes, { uri, mimeType, imageName, size, exif }]);
     setIsModalVisible(!isModalVisible);
@@ -211,14 +219,17 @@ export const ImageSelector = ({
   const values = jsonParser(value);
 
   if (isMultiImages) {
-    if (selectorType === IMAGE_SELECTOR_TYPES.SUE) {
+    if (
+      selectorType === IMAGE_SELECTOR_TYPES.SUE ||
+      selectorType === IMAGE_SELECTOR_TYPES.NOTICEBOARD
+    ) {
       return (
         <>
           <Input {...item} control={control} hidden name={name} value={JSON.parse(value)} />
 
           <Button
-            disabled={values?.length >= parseInt(configuration?.limitation?.maxFileUploads?.value)}
-            icon={<Icon.Camera size={normalize(16)} />}
+            disabled={maxCount && values?.length >= parseInt(maxCount)}
+            icon={<Icon.Camera size={normalize(16)} strokeWidth={normalize(2)} />}
             iconPosition="left"
             invert
             onPress={() => setIsModalVisible(!isModalVisible)}
@@ -290,14 +301,14 @@ export const ImageSelector = ({
 
             <WrapperVertical>
               <Button
-                icon={<Icon.Camera size={normalize(16)} />}
+                icon={<Icon.Camera size={normalize(16)} strokeWidth={normalize(2)} />}
                 iconPosition="left"
                 invert
                 onPress={() => imageSelect(captureImage, IMAGE_FROM.CAMERA)}
                 title={texts.sue.report.alerts.imageSelectAlert.camera}
               />
               <Button
-                icon={<Icon.Albums size={normalize(16)} />}
+                icon={<Icon.Albums size={normalize(16)} strokeWidth={normalize(2)} />}
                 iconPosition="left"
                 invert
                 onPress={() => imageSelect(selectImage)}

--- a/src/components/noticeboard/NoticeboardCreateForm.tsx
+++ b/src/components/noticeboard/NoticeboardCreateForm.tsx
@@ -341,11 +341,27 @@ export const NoticeboardCreateForm = ({
             control={control}
             render={({ field }) => (
               <DocumentSelector
-                {...{ control, field }}
-                maxFileSize={documentMaxSizes.file}
+                {...{
+                  configuration: {
+                    limitation: {
+                      maxCount: maxDocumentCount,
+                      maxFileSize: documentMaxSizes?.file
+                    }
+                  },
+                  control,
+                  field
+                }}
                 item={{
                   buttonTitle: texts.noticeboard.addDocuments,
-                  infoTitle: texts.noticeboard.documentsInfo
+                  infoText:
+                    maxDocumentCount && texts.noticeboard.alerts.documentHint(maxDocumentCount)
+                }}
+              />
+            )}
+          />
+        </Wrapper>
+      )}
+
       {showImage && (
         <Wrapper style={styles.noPaddingTop}>
           <Controller

--- a/src/components/noticeboard/NoticeboardCreateForm.tsx
+++ b/src/components/noticeboard/NoticeboardCreateForm.tsx
@@ -12,6 +12,7 @@ import {
   DateTimeInput,
   DocumentSelector,
   HtmlView,
+  ImageSelector,
   Input,
   LoadingSpinner,
   RegularText,
@@ -32,7 +33,7 @@ import { uploadMediaContent } from '../../queries/mediaContent';
 import { SettingsContext } from '../../SettingsProvider';
 import { NOTICEBOARD_TYPES } from '../../types';
 
-const { EMAIL_REGEX, MEDIA_TYPES } = consts;
+const { EMAIL_REGEX, MEDIA_TYPES, IMAGE_SELECTOR_TYPES, IMAGE_SELECTOR_ERROR_TYPES } = consts;
 const extendedMoment = extendMoment(moment);
 
 type TNoticeboardCreateData = {
@@ -62,7 +63,14 @@ export const NoticeboardCreateForm = ({
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
   const { showNoticeboardMediaContent = {} } = settings;
-  const { document: showDocument = false, documentMaxSizes = {} } = showNoticeboardMediaContent;
+  const {
+    document: showDocument = false,
+    documentMaxSizes = {},
+    image: showImage = false,
+    imageMaxSizes = {},
+    maxDocumentCount = 0,
+    maxImageCount = 0
+  } = showNoticeboardMediaContent;
   const consentForDataProcessingText = route?.params?.consentForDataProcessingText ?? '';
   const genericType = route?.params?.genericType ?? '';
   const requestedDateDifference = route?.params?.requestedDateDifference ?? 3;
@@ -87,6 +95,7 @@ export const NoticeboardCreateForm = ({
       dateEnd: new Date(),
       dateStart: new Date(),
       documents: '[]',
+      images: '[]',
       email: '',
       name: '',
       noticeboardType: '',
@@ -337,6 +346,30 @@ export const NoticeboardCreateForm = ({
                 item={{
                   buttonTitle: texts.noticeboard.addDocuments,
                   infoTitle: texts.noticeboard.documentsInfo
+      {showImage && (
+        <Wrapper style={styles.noPaddingTop}>
+          <Controller
+            name="images"
+            control={control}
+            render={({ field }) => (
+              <ImageSelector
+                {...{
+                  control,
+                  configuration: {
+                    limitation: {
+                      maxCount: maxImageCount,
+                      maxFileSize: imageMaxSizes?.file
+                    }
+                  },
+                  errorType: IMAGE_SELECTOR_ERROR_TYPES.NOTICEBOARD,
+                  field,
+                  isMultiImages: true,
+                  item: {
+                    buttonTitle: texts.noticeboard.addImage,
+                    infoText: maxImageCount && texts.noticeboard.alerts.imageHint(maxImageCount),
+                    name: 'images'
+                  },
+                  selectorType: IMAGE_SELECTOR_TYPES.NOTICEBOARD
                 }}
               />
             )}

--- a/src/components/screens/PointOfInterest.js
+++ b/src/components/screens/PointOfInterest.js
@@ -3,6 +3,7 @@ import React, { useContext, useMemo, useState } from 'react';
 import { FlatList, View } from 'react-native';
 
 import { NetworkContext } from '../../NetworkProvider';
+import { SettingsContext } from '../../SettingsProvider';
 import { consts, texts } from '../../config';
 import { matomoTrackingString, parseListItemsFromQuery } from '../../helpers';
 import { useMatomoTrackScreenView, useOpenWebScreen } from '../../hooks';
@@ -19,7 +20,6 @@ import { InfoCard } from '../infoCard';
 import { Map } from '../map';
 import { VoucherListItem } from '../vouchers';
 
-import { SettingsContext } from '../../SettingsProvider';
 import { AvailableVehicles } from './AvailableVehicles';
 import { OpeningTimesCard } from './OpeningTimesCard';
 import { OperatingCompany } from './OperatingCompany';

--- a/src/components/screens/consul/Proposals/NewProposal.js
+++ b/src/components/screens/consul/Proposals/NewProposal.js
@@ -414,7 +414,18 @@ export const NewProposal = ({ navigation, data, query }) => {
                     }}
                   />
                 ) : (
-                  <DocumentSelector {...{ control, field, item }} />
+                  <DocumentSelector
+                    {...{
+                      configuration: {
+                        limitation: {
+                          maxCount: 3
+                        }
+                      },
+                      control,
+                      field,
+                      item
+                    }}
+                  />
                 )
               }
             />

--- a/src/config/Icon.tsx
+++ b/src/config/Icon.tsx
@@ -124,7 +124,7 @@ const NamedIcon = ({
   color = colors.primary,
   iconStyle,
   name,
-  stroke = 1,
+  strokeWidth = 1,
   size = normalize(26),
   style
 }: IconProps & {
@@ -142,7 +142,7 @@ const NamedIcon = ({
 
   return (
     <View accessibilityLabel={accessibilityLabel} style={style} hitSlop={getHitSlops(size)}>
-      <IconComponent name={name} size={size} color={color} style={iconStyle} stroke={stroke} />
+      <IconComponent name={name} size={size} color={color} style={iconStyle} stroke={strokeWidth} />
     </View>
   );
 };

--- a/src/config/consts.js
+++ b/src/config/consts.js
@@ -137,11 +137,13 @@ export const consts = {
 
   IMAGE_SELECTOR_ERROR_TYPES: {
     CONSUL: 'Consul',
+    NOTICEBOARD: 'Noticeboard',
     SUE: 'Sue',
     VOLUNTEER: 'Volunteer'
   },
 
   IMAGE_SELECTOR_TYPES: {
+    NOTICEBOARD: 'Noticeboard',
     SUE: 'Sue'
   },
 

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -519,6 +519,7 @@ export const texts = {
       imageHint: (count) => `ⓘ Es können bis zu ${count} Bilder hochgeladen werden.`,
       imageSizeError: (size) => `Das ausgewählte Bild darf maximal ${size} groß sein.`,
       imagesSizeError: (size) => `Die ausgewählten Bilder dürfen maximal ${size} groß sein.`,
+      imageUploadError: 'Beim Hochladen des Bildes ist ein Fehler aufgetreten.',
       noticeboardType: 'Bitte wählen Sie den Typ Ihres Eintrags aus.',
       termsOfService: 'Bitte stimmen Sie der Verarbeitung Ihrer Daten zu.'
     },

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -507,6 +507,7 @@ export const texts = {
   noticeboard: {
     abort: 'Abbrechen',
     addDocuments: 'Dokumente hinzufügen',
+    addImage: 'Bild hinzufügen',
     alerts: {
       dateDifference: 'Bitte wählen Sie eine maximale Laufzeit von drei Monaten.',
       documentsSizeError: (size) => `Die ausgewählten Dokumente dürfen maximal ${size} groß sein.`,
@@ -514,6 +515,9 @@ export const texts = {
       documentUploadError: 'Beim Hochladen des Dokuments ist ein Fehler aufgetreten.',
       error: 'Bitte versuchen Sie es erneut.',
       hint: 'Hinweis',
+      imageHint: (count) => `ⓘ Es können bis zu ${count} Bilder hochgeladen werden.`,
+      imageSizeError: (size) => `Das ausgewählte Bild darf maximal ${size} groß sein.`,
+      imagesSizeError: (size) => `Die ausgewählten Bilder dürfen maximal ${size} groß sein.`,
       noticeboardType: 'Bitte wählen Sie den Typ Ihres Eintrags aus.',
       termsOfService: 'Bitte stimmen Sie der Verarbeitung Ihrer Daten zu.'
     },

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -510,8 +510,9 @@ export const texts = {
     addImage: 'Bild hinzufügen',
     alerts: {
       dateDifference: 'Bitte wählen Sie eine maximale Laufzeit von drei Monaten.',
-      documentsSizeError: (size) => `Die ausgewählten Dokumente dürfen maximal ${size} groß sein.`,
+      documentHint: (count) => `ⓘ Es können bis zu ${count} Dokumente hochgeladen werden.`,
       documentSizeError: (size) => `Das ausgewählte Dokument darf maximal ${size} groß sein.`,
+      documentsSizeError: (size) => `Die ausgewählten Dokumente dürfen maximal ${size} groß sein.`,
       documentUploadError: 'Beim Hochladen des Dokuments ist ein Fehler aufgetreten.',
       error: 'Bitte versuchen Sie es erneut.',
       hint: 'Hinweis',
@@ -522,8 +523,6 @@ export const texts = {
       termsOfService: 'Bitte stimmen Sie der Verarbeitung Ihrer Daten zu.'
     },
     documents: 'Dokumente',
-    documentsInfo:
-      'Sie können maximal 3 Dokumente des folgenden Inhalttyps hochladen: pdf, bis zu 3 MB pro Datei.',
     emptyTitle: 'Im Moment gibt es nichts zu sehen. Bitte versuchen Sie es später noch einmal.',
     expiryDate: 'Ablaufdatum',
     inputCheckbox: 'Einverständnis zur Datenverarbeitung',

--- a/src/helpers/consul/dataErrorMessageGenerator.js
+++ b/src/helpers/consul/dataErrorMessageGenerator.js
@@ -45,6 +45,7 @@ export const imageErrorMessageGenerator = async (uri) => {
 export const errorTextGenerator = async ({
   errorType,
   infoAndErrorText,
+  maxFileSize,
   mimeType,
   setInfoAndErrorText,
   uri
@@ -83,6 +84,17 @@ export const errorTextGenerator = async ({
         ...infoAndErrorText,
         {
           errorText: size > 10485760 && texts.sue.report.alerts.imageGreater10MBError
+        }
+      ]);
+      break;
+    case IMAGE_SELECTOR_ERROR_TYPES.NOTICEBOARD:
+      setInfoAndErrorText([
+        ...infoAndErrorText,
+        {
+          errorText:
+            maxFileSize &&
+            size > maxFileSize &&
+            texts.noticeboard.alerts.imageSizeError(formatSizeStandard(maxFileSize))
         }
       ]);
       break;

--- a/src/screens/Noticeboard/NoticeboardFormScreen.tsx
+++ b/src/screens/Noticeboard/NoticeboardFormScreen.tsx
@@ -9,6 +9,7 @@ import {
   DefaultKeyboardAvoidingView,
   DocumentList,
   HtmlView,
+  ImageSection,
   LoadingContainer,
   NoticeboardCreateForm,
   NoticeboardMessageForm,
@@ -83,6 +84,7 @@ export const NoticeboardFormScreen = ({
             />
           }
         >
+          <ImageSection mediaContents={details?.mediaContents} />
           <SectionHeader title={details?.contentBlocks?.[0]?.title} />
 
           {!!html && (


### PR DESCRIPTION
- added `ImageSelector` component to add images on the noticeboard creation screen
- updated the `showNoticeboardMediaContent` object to set the maximum size and count of images via main-server
- updated `stroke` prop to `strokeWidth` to make `NamedIcon` props the same as `IconProps`
- added noticeboard types required for `ImageSelector` to `consts`
- added texts needed for images to `texts`
- added error messages for noticeboard to `dataErrorMessageGenerator`
- updated `ImageSelector` component according to noticeboard
- updated `SueReportDescription` to apply the changes in the configuration prop updated with `ImageSelector` to sue
- added `configuration` prop to `DocumentSelector` to make `ImageSelector` and `DocumentSelector` the same and understandable
- added the ability to `disabled` the button according to the maximum count that can be set via main-server for documents
- updated `InfoText` to be the same as `ImageSelector` in design
- updated `DocumentSelector` props in `NoticeboardCreateForm` with new props
- added `LoadingSpinner` to prevent selecting different images at the same time while adding images
- updated the `onSubmit` function to be similar to the document upload feature to be able to upload images
- added `ImageSection` component to `NoticeboardFormScreen` to show the uploaded image on the detail screen
- fixed minor import bugs

SVAK-45

for testing, add/update the following object to the `settings` object in the `globalSettings` on main-server
```
"settings": {
  "showNoticeboardMediaContent": {
    "document": true,
    "maxDocumentCount": 5,
    "documentMaxSizes": {
      "total": 26214400,
      "file": 5242880
    },
    "image": true,
    "maxImageCount": 5,
    "imageMaxSizes": {
      "total": 10,
      "file": 10
    }
  }
  ...
}
```

after this update, the image upload feature will appear on the noticeboard create screen

The following settings can be made on the main server:
- max image count
- max image file size
- max image total size

|create screen|modal|image added|
|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-19 at 16 11 00](https://github.com/user-attachments/assets/2edcb666-94ff-41fe-9af9-c6f8d32ffc44)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-19 at 16 11 02](https://github.com/user-attachments/assets/a6d14d73-ef12-4496-b02c-a3acfeedfabe)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-19 at 16 11 09](https://github.com/user-attachments/assets/ad90724a-49ec-46cc-9701-2581e210245c)




