### PR TITLE
feat: add link that opens from browser

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,7 +30,7 @@
         "NSMicrophoneUsageDescription": "Diese App benötigt Zugriff auf das Mikrofon, um die Kamera zu benutzen",
         "CFBundleLocalizations": ["de"],
         "CFBundleDevelopmentRegion": "de_DE",
-        "LSApplicationQueriesSchemes": ["whatsapp"],
+        "LSApplicationQueriesSchemes": ["whatsapp", "youtube"],
         "LSMinimumSystemVersion": "12.0"
       },
       "config": {

--- a/src/components/MultiButtonWithSubQuery.tsx
+++ b/src/components/MultiButtonWithSubQuery.tsx
@@ -17,6 +17,7 @@ export const navigateWithSubQuery = ({
   title?: string;
   params?:
     | {
+        isExternal?: boolean;
         routeName: string;
         webUrl: string;
         paramsForButton?: {
@@ -55,6 +56,7 @@ export const navigateWithSubQuery = ({
     // if `params` is an object and does not contain the `paramsForButton` object,
     // it contains a `routeName` and a `webUrl`
     return navigation.push(params.routeName, {
+      isExternal: params.isExternal,
       rootRouteName,
       title,
       webUrl: params.webUrl
@@ -68,6 +70,7 @@ export const navigateWithSubQuery = ({
   // will be ignored
   return navigation.push(subQuery.routeName, {
     ...subParams,
+    isExternal: subQuery.isExternal,
     rootRouteName,
     title,
     webUrl: subQuery.webUrl

--- a/src/screens/WebScreen.js
+++ b/src/screens/WebScreen.js
@@ -1,12 +1,13 @@
 import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect } from 'react';
-import { ActivityIndicator, StyleSheet } from 'react-native';
+import { ActivityIndicator } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 import appJson from '../../app.json';
 import { LoadingContainer, SafeAreaViewFlex } from '../components';
-import { colors, consts, normalize } from '../config';
+import { colors, consts } from '../config';
+import { openLink } from '../helpers';
 import { useTrackScreenViewAsync } from '../hooks';
 import { NetworkContext } from '../NetworkProvider';
 
@@ -17,6 +18,7 @@ export const WebScreen = ({ navigation, route }) => {
   const trackScreenViewAsync = useTrackScreenViewAsync();
   const webUrl = route.params?.webUrl ?? '';
   const injectedJavaScript = route.params?.injectedJavaScript ?? '';
+  const isExternal = route.params?.isExternal ?? '';
 
   // NOTE: we cannot use the `useMatomoTrackScreenView` hook here, as we need the `webUrl`
   //       dependency
@@ -24,7 +26,14 @@ export const WebScreen = ({ navigation, route }) => {
     isConnected && webUrl && trackScreenViewAsync(`${MATOMO_TRACKING.SCREEN_VIEW.WEB} / ${webUrl}`);
   }, [webUrl]);
 
-  if (!webUrl) return null;
+  useEffect(() => {
+    if (isExternal) {
+      openLink(webUrl);
+      navigation.goBack();
+    }
+  }, []);
+
+  if (!webUrl || isExternal) return null;
 
   return (
     <SafeAreaViewFlex>
@@ -49,16 +58,6 @@ export const WebScreen = ({ navigation, route }) => {
     </SafeAreaViewFlex>
   );
 };
-
-const styles = StyleSheet.create({
-  headerRight: {
-    alignItems: 'center',
-    paddingRight: normalize(7)
-  },
-  icon: {
-    paddingHorizontal: normalize(10)
-  }
-});
 
 WebScreen.propTypes = {
   navigation: PropTypes.object,

--- a/src/types/SubQuery.ts
+++ b/src/types/SubQuery.ts
@@ -1,6 +1,7 @@
 export type SubQuery = {
   buttons?: [{ buttonTitle: string; routeName: string; webUrl: string }];
   buttonTitle: string;
+  isExternal?: boolean;
   params: { rootRouteName: string; routeName: string; title: string; webUrl: string };
   routeName: string;
   webUrl?: string;


### PR DESCRIPTION
- added the ability to automatically open the browser if the `WebScreen` in the app is redirected with the `isExternal` param
- updated `MultiButtonWithSubQuery` to add `isExternal` as param when redirecting via multi button screen

SVASD-15

changes in main-server:
- redirect to browser:

```
  {
    "title": "YT",
    "routeName": "Web",
    "params": {
      "webUrl": "https://www.youtube.com/",
      "isExternal": true
    }
  }
```

- redirect to WebScreen in the app:

```
  {
    "title": "YT",
    "routeName": "Web",
    "params": {
      "webUrl": "https://www.youtube.com/"
    }
  }
```