### PR TITLE
feat(sue): update config when report screen opens

### DIFF
--- a/src/screens/SUE/SueReportScreen.tsx
+++ b/src/screens/SUE/SueReportScreen.tsx
@@ -230,7 +230,11 @@ export const SueReportScreen = ({
   navigation,
   route
 }: { navigation: any } & StackScreenProps<any>) => {
-  const { sueConfig = {} } = useContext(ConfigurationsContext);
+  const {
+    isLoading: isConfigLoading,
+    refetch: configRefetch,
+    sueConfig = {}
+  } = useContext(ConfigurationsContext);
   const {
     geoMap = {},
     limitation = {},
@@ -599,6 +603,10 @@ export const SueReportScreen = ({
     ]
   );
 
+  useEffect(() => {
+    configRefetch();
+  }, []);
+
   useLayoutEffect(() => {
     if (storedValues) {
       navigation.setOptions({
@@ -632,7 +640,7 @@ export const SueReportScreen = ({
     }
   }, [storedValues, service, selectedPosition]);
 
-  if (areaServiceLoading) {
+  if (areaServiceLoading || isConfigLoading) {
     return (
       <LoadingContainer>
         <ActivityIndicator color={colors.refreshControl} />


### PR DESCRIPTION
added `refetch` and `isLoading` to `ConfigurationsProvider` to update the config when the report screen is opened

SUE-139