### PR TITLE
fix(bookmarks): multi events handling

### DIFF
--- a/src/components/DataListSection.tsx
+++ b/src/components/DataListSection.tsx
@@ -31,6 +31,7 @@ type Props = {
   navigation: StackNavigationProp<any>;
   placeholder?: React.ReactElement;
   query: string;
+  queryVariables?: Record<string, unknown>;
   sectionData?: unknown[];
   sectionTitle?: string;
   sectionTitleDetail?: string;
@@ -38,7 +39,7 @@ type Props = {
   showLink?: boolean;
 };
 
-// eslint-disable-next-line complexity
+/* eslint-disable complexity */
 export const DataListSection = ({
   additionalData,
   buttonTitle,
@@ -54,6 +55,7 @@ export const DataListSection = ({
   navigation,
   placeholder,
   query,
+  queryVariables,
   sectionData,
   sectionTitle = getTitleForQuery(query),
   sectionTitleDetail,
@@ -74,10 +76,11 @@ export const DataListSection = ({
 
   let listData = parseListItemsFromQuery(query, sectionData, sectionTitleDetail, {
     withDate:
-      query === QUERY_TYPES.EVENT_RECORDS ||
+      (query === QUERY_TYPES.EVENT_RECORDS && !queryVariables?.onlyUniqEvents) ||
       query === QUERY_TYPES.VOLUNTEER.CALENDAR_ALL ||
       query === QUERY_TYPES.VOLUNTEER.CALENDAR_ALL_MY ||
       query === QUERY_TYPES.VOLUNTEER.CONVERSATIONS,
+    withTime: query === QUERY_TYPES.EVENT_RECORDS && !queryVariables?.onlyUniqEvents,
     skipLastDivider: true,
     queryKey: query === QUERY_TYPES.VOUCHERS ? QUERY_TYPES.GENERIC_ITEMS : query
   });
@@ -131,3 +134,4 @@ export const DataListSection = ({
     </View>
   );
 };
+/* eslint-enable complexity */

--- a/src/components/bookmarks/BookmarkSection.tsx
+++ b/src/components/bookmarks/BookmarkSection.tsx
@@ -37,6 +37,10 @@ export const BookmarkSection = ({
   // slice the first 3 entries off of the bookmark ids, to get the 3 most recently bookmarked items
   const variables = query === QUERY_TYPES.VOUCHERS ? { ids } : { ids: ids.slice(0, 3) };
 
+  if (query === QUERY_TYPES.EVENT_RECORDS) {
+    variables.onlyUniqEvents = true;
+  }
+
   const refreshTime = useRefreshTime('bookmarks', REFRESH_INTERVALS.BOOKMARKS);
 
   const fetchPolicy = graphqlFetchPolicy({ isConnected, isMainserverUp, refreshTime });
@@ -51,6 +55,7 @@ export const BookmarkSection = ({
       navigation.navigate(ScreenName.BookmarkCategory, {
         suffix,
         query,
+        queryVariables: variables,
         title: sectionTitle,
         categoryTitleDetail
       }),
@@ -69,15 +74,16 @@ export const BookmarkSection = ({
   return (
     <DataListSection
       buttonTitle={texts.bookmarks.showAll}
+      limit={variables?.ids.length}
       loading={loading}
       navigate={onPressShowMore}
       navigation={navigation}
       query={query}
+      queryVariables={variables}
       sectionData={data}
       sectionTitle={sectionTitle}
       sectionTitleDetail={categoryTitleDetail}
       showButton={ids.length > 3}
-      limit={variables?.ids.length}
     />
   );
 };

--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -95,6 +95,7 @@ export const GET_EVENT_RECORDS = gql`
     $dateRange: [String]
     $dataProvider: String
     $dataProviderId: ID
+    $onlyUniqEvents: Boolean
   ) {
     eventRecords(
       ids: $ids
@@ -107,6 +108,7 @@ export const GET_EVENT_RECORDS = gql`
       dateRange: $dateRange
       dataProvider: $dataProvider
       dataProviderId: $dataProviderId
+      onlyUniqEvents: $onlyUniqEvents
     ) {
       ...defaultFields
       ...dateFields

--- a/src/screens/BookmarkCategoryScreen.js
+++ b/src/screens/BookmarkCategoryScreen.js
@@ -18,6 +18,7 @@ import { getQuery, QUERY_TYPES } from '../queries';
 
 const { MATOMO_TRACKING } = consts;
 
+/* eslint-disable complexity */
 export const BookmarkCategoryScreen = ({ navigation, route }) => {
   const query = route.params?.query ?? '';
   const queryKey = query === QUERY_TYPES.VOUCHERS ? QUERY_TYPES.GENERIC_ITEMS : query;
@@ -26,7 +27,7 @@ export const BookmarkCategoryScreen = ({ navigation, route }) => {
   const categoryTitleDetail = route.params?.categoryTitleDetail ?? '';
   const bookmarks = useBookmarks(query, suffix);
 
-  const variables = { ids: bookmarks, ...queryVariables };
+  const variables = { ...queryVariables, ids: bookmarks };
 
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
 
@@ -70,7 +71,12 @@ export const BookmarkCategoryScreen = ({ navigation, route }) => {
       </Wrapper>
     );
   }
-  const listItems = parseListItemsFromQuery(query, data, categoryTitleDetail, { queryKey });
+  const listItems = parseListItemsFromQuery(query, data, categoryTitleDetail, {
+    withDate: query === QUERY_TYPES.EVENT_RECORDS && !queryVariables?.onlyUniqEvents,
+    withTime: query === QUERY_TYPES.EVENT_RECORDS && !queryVariables?.onlyUniqEvents,
+    skipLastDivider: true,
+    queryKey
+  });
 
   return (
     <SafeAreaViewFlex>
@@ -78,6 +84,7 @@ export const BookmarkCategoryScreen = ({ navigation, route }) => {
     </SafeAreaViewFlex>
   );
 };
+/* eslint-enable complexity */
 
 BookmarkCategoryScreen.propTypes = {
   navigation: PropTypes.object.isRequired,


### PR DESCRIPTION
Request a single event with the event records query for bookmarks instead of multiple events for all dates of an event.

⚠️ **this does not work with int-development**

SVA-1509