### PR TITLE
feat(tab): configureable tab navigation

### DIFF
--- a/src/components/OrientationAwareIcon.tsx
+++ b/src/components/OrientationAwareIcon.tsx
@@ -1,11 +1,12 @@
 import React, { useContext } from 'react';
 import { StyleProp, StyleSheet, ViewStyle } from 'react-native';
 
-import { consts, device, IconProps, normalize } from '../config';
+import { consts, device, Icon as IconComponent, IconProps, normalize } from '../config';
 import { OrientationContext } from '../OrientationProvider';
 
 type Props = IconProps & {
   Icon: (props: IconProps) => JSX.Element;
+  iconName: keyof typeof IconComponent;
   landscapeIconStyle?: StyleProp<ViewStyle>;
   landscapeStyle?: StyleProp<ViewStyle>;
   size?: number;
@@ -17,6 +18,7 @@ export const OrientationAwareIcon = (props: Props) => {
   const { orientation, dimensions } = useContext(OrientationContext);
   const {
     Icon,
+    iconName,
     iconStyle,
     landscapeIconStyle,
     landscapeStyle,
@@ -24,19 +26,37 @@ export const OrientationAwareIcon = (props: Props) => {
     style
   } = props;
 
+  const SelectedIcon = Icon || IconComponent.NamedIcon;
+
   const needLandscapeStyle =
     orientation === 'landscape' || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH;
 
   // we need adjustments only on iOS, so otherwise just return the item with the usual props
   // TODO: is this still needed with Expo 48?
   if (!needLandscapeStyle || !(device.platform === 'ios')) {
-    return <Icon {...props} />;
+    if (SelectedIcon === IconComponent.NamedIcon) {
+      return <SelectedIcon {...props} name={iconName} />;
+    }
+
+    return <SelectedIcon {...props} />;
   }
 
   const adjustedSize = size * LANDSCAPE_ADJUSTMENT_FACTOR;
 
+  if (SelectedIcon === IconComponent.NamedIcon) {
+    return (
+      <SelectedIcon
+        {...props}
+        name={iconName}
+        iconStyle={[iconStyle, styles.marginIcon, { width: adjustedSize }, landscapeIconStyle]}
+        size={adjustedSize}
+        style={[style, landscapeStyle]}
+      />
+    );
+  }
+
   return (
-    <Icon
+    <SelectedIcon
       {...props}
       iconStyle={[iconStyle, styles.marginIcon, { width: adjustedSize }, landscapeIconStyle]}
       size={adjustedSize}

--- a/src/components/OrientationAwareIcon.tsx
+++ b/src/components/OrientationAwareIcon.tsx
@@ -27,42 +27,32 @@ export const OrientationAwareIcon = (props: Props) => {
   } = props;
 
   const SelectedIcon = Icon || IconComponent.NamedIcon;
+  const isNamedIcon = SelectedIcon === IconComponent.NamedIcon;
 
   const needLandscapeStyle =
     orientation === 'landscape' || dimensions.width > consts.DIMENSIONS.FULL_SCREEN_MAX_WIDTH;
 
-  // we need adjustments only on iOS, so otherwise just return the item with the usual props
-  // TODO: is this still needed with Expo 48?
-  if (!needLandscapeStyle || !(device.platform === 'ios')) {
-    if (SelectedIcon === IconComponent.NamedIcon) {
-      return <SelectedIcon {...props} name={iconName} />;
+  const getIconProps = () => {
+    const baseProps = {
+      ...props,
+      ...(isNamedIcon ? { name: iconName } : {})
+    };
+
+    if (device.platform === 'android' || !needLandscapeStyle) {
+      return baseProps;
     }
 
-    return <SelectedIcon {...props} />;
-  }
+    const adjustedSize = size * LANDSCAPE_ADJUSTMENT_FACTOR;
 
-  const adjustedSize = size * LANDSCAPE_ADJUSTMENT_FACTOR;
+    return {
+      ...baseProps,
+      iconStyle: [iconStyle, styles.marginIcon, { width: adjustedSize }, landscapeIconStyle],
+      size: adjustedSize,
+      style: [style, landscapeStyle]
+    };
+  };
 
-  if (SelectedIcon === IconComponent.NamedIcon) {
-    return (
-      <SelectedIcon
-        {...props}
-        name={iconName}
-        iconStyle={[iconStyle, styles.marginIcon, { width: adjustedSize }, landscapeIconStyle]}
-        size={adjustedSize}
-        style={[style, landscapeStyle]}
-      />
-    );
-  }
-
-  return (
-    <SelectedIcon
-      {...props}
-      iconStyle={[iconStyle, styles.marginIcon, { width: adjustedSize }, landscapeIconStyle]}
-      size={adjustedSize}
-      style={[style, landscapeStyle]}
-    />
-  );
+  return <SelectedIcon {...getIconProps()} />;
 };
 
 const styles = StyleSheet.create({

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -89,89 +89,108 @@ const { MATOMO_TRACKING } = consts;
 
 export const defaultStackConfig = ({
   initialRouteName,
+  initialParams,
   isDrawer
 }: {
   initialRouteName: ScreenName;
+  initialParams?: Record<string, any>;
   isDrawer: boolean;
 }): StackConfig => ({
   initialRouteName,
   screenOptions: getScreenOptions({ withDrawer: isDrawer }),
   screenConfigs: [
     {
+      initialParams,
       routeName: ScreenName.About,
       screenComponent: AboutScreen,
       screenOptions: { title: texts.screenTitles.about }
     },
     {
+      initialParams,
       routeName: ScreenName.ARInfo,
       screenComponent: ARInfoScreen,
       screenOptions: { title: texts.augmentedReality.arInfoScreen.header }
     },
     {
+      initialParams,
       routeName: ScreenName.ARShow,
       screenComponent: ARShowScreen,
       screenOptions: { headerShown: false }
     },
     {
+      initialParams,
       routeName: ScreenName.ArtworkDetail,
       screenComponent: ArtworkDetailScreen,
       screenOptions: { title: texts.augmentedReality.artworkDetailScreen.header }
     },
     {
+      initialParams,
       routeName: ScreenName.BBBUSIndex,
       screenComponent: BBBUSIndexScreen
     },
     {
+      initialParams,
       routeName: ScreenName.BBBUSDetail,
       screenComponent: BBBUSDetailScreen,
       screenOptions: getScreenOptions({ withDrawer: isDrawer, withShare: true })
     },
     {
+      initialParams,
       routeName: ScreenName.BookmarkCategory,
       screenComponent: BookmarkCategoryScreen
     },
     {
+      initialParams,
       routeName: ScreenName.Bookmarks,
       screenComponent: BookmarkScreen,
       screenOptions: getScreenOptions({ withDrawer: isDrawer })
     },
     {
+      initialParams,
       routeName: ScreenName.Category,
       screenComponent: IndexScreen
     },
     {
+      initialParams,
       routeName: ScreenName.ConsulHomeScreen,
       screenComponent: ConsulHomeScreen,
       screenOptions: { title: texts.screenTitles.consul.home }
     },
     {
+      initialParams,
       routeName: ScreenName.ConsulRegisterScreen,
       screenComponent: ConsulRegisterScreen,
       screenOptions: { title: texts.screenTitles.consul.register }
     },
     {
+      initialParams,
       routeName: ScreenName.ConsulRegisteredScreen,
       screenComponent: ConsulRegisteredScreen,
       screenOptions: { title: texts.screenTitles.consul.register }
     },
     {
+      initialParams,
       routeName: ScreenName.ConsulLoginScreen,
       screenComponent: ConsulLoginScreen,
       screenOptions: { title: texts.screenTitles.consul.login }
     },
     {
+      initialParams,
       routeName: ScreenName.ConsulIndexScreen,
       screenComponent: ConsulIndexScreen
     },
     {
+      initialParams,
       routeName: ScreenName.ConsulDetailScreen,
       screenComponent: ConsulDetailScreen
     },
     {
+      initialParams,
       routeName: ScreenName.ConsulStartNewScreen,
       screenComponent: ConsulStartNewScreen
     },
     {
+      initialParams,
       routeName: ScreenName.Company,
       screenComponent: getTilesScreen({
         matomoString: MATOMO_TRACKING.SCREEN_VIEW.COMPANY,
@@ -183,52 +202,63 @@ export const defaultStackConfig = ({
       screenOptions: { title: texts.screenTitles.company }
     },
     {
+      initialParams,
       routeName: ScreenName.ConstructionSiteDetail,
       screenComponent: ConstructionSiteDetailScreen,
       screenOptions: { title: texts.screenTitles.constructionSite }
     },
     {
+      initialParams,
       routeName: ScreenName.ConstructionSiteOverview,
       screenComponent: ConstructionSiteOverviewScreen
     },
     {
+      initialParams,
       routeName: ScreenName.DataProvider,
       screenComponent: DataProviderScreen
     },
     {
+      initialParams,
       routeName: ScreenName.DefectReportForm,
       screenComponent: DefectReportFormScreen
     },
     {
+      initialParams,
       routeName: ScreenName.Detail,
       screenComponent: DetailScreen,
       screenOptions: getScreenOptions({ withDrawer: isDrawer, withBookmark: true, withShare: true })
     },
     {
+      initialParams,
       routeName: ScreenName.DocIcons,
       screenComponent: DocIconsScreen
     },
     {
+      initialParams,
       routeName: ScreenName.EncounterData,
       screenComponent: EncounterDataScreen,
       screenOptions: { title: texts.screenTitles.encounterHome }
     },
     {
+      initialParams,
       routeName: ScreenName.EncounterHome,
       screenComponent: EncounterHomeScreen,
       screenOptions: { title: texts.screenTitles.encounterHome }
     },
     {
+      initialParams,
       routeName: ScreenName.EncounterRegistration,
       screenComponent: EncounterRegistrationScreen,
       screenOptions: { title: texts.screenTitles.encounterHome }
     },
     {
+      initialParams,
       routeName: ScreenName.EncounterScanner,
       screenComponent: EncounterScannerScreen,
       screenOptions: { title: texts.screenTitles.encounterHome }
     },
     {
+      initialParams,
       routeName: ScreenName.EncounterUserDetail,
       screenComponent: EncounterUserDetailScreen,
       screenOptions: ({ navigation, route }) => ({
@@ -248,106 +278,124 @@ export const defaultStackConfig = ({
       })
     },
     {
-      routeName: ScreenName.Events,
-      screenComponent: IndexScreen,
       initialParams: {
         title: texts.screenTitles.events,
         query: QUERY_TYPES.EVENT_RECORDS,
         queryVariables: { limit: 15, order: 'listDate_ASC' }
-      }
+      },
+      routeName: ScreenName.Events,
+      screenComponent: IndexScreen
     },
     {
+      initialParams,
       routeName: ScreenName.EventSuggestion,
       screenComponent: EventSuggestionScreen,
       screenOptions: { title: texts.screenTitles.eventSuggestion }
     },
     {
+      initialParams,
       routeName: ScreenName.Form,
       screenComponent: FeedbackScreen,
       screenOptions: { title: texts.screenTitles.feedback }
     },
     {
+      initialParams,
       routeName: ScreenName.Feedback,
       screenComponent: FeedbackScreen,
       screenOptions: { title: texts.screenTitles.feedback }
     },
     {
-      routeName: ScreenName.Home,
-      screenComponent: HomeScreen,
-      screenOptions: getScreenOptions({ withDrawer: isDrawer, withFavorites: true }),
       initialParams: {
         isDrawer,
         title: texts.screenTitles.home
-      }
+      },
+      routeName: ScreenName.Home,
+      screenComponent: HomeScreen,
+      screenOptions: getScreenOptions({ withDrawer: isDrawer, withFavorites: true })
     },
     {
+      initialParams,
       routeName: ScreenName.Html,
       screenComponent: HtmlScreen
     },
     {
-      routeName: ScreenName.Index,
-      screenComponent: IndexScreen,
       // NOTE: is used as initial screen for the points of interest tab
       initialParams: {
         title: texts.screenTitles.pointsOfInterest,
         query: QUERY_TYPES.CATEGORIES,
         usedAsInitialScreen: true
-      }
+      },
+      routeName: ScreenName.Index,
+      screenComponent: IndexScreen
     },
     {
+      initialParams,
       routeName: ScreenName.Lunch,
       screenComponent: LunchScreen
     },
     {
+      initialParams,
       routeName: ScreenName.MapView,
       screenComponent: MapViewScreen,
       screenOptions: { title: texts.screenTitles.mapView }
     },
     {
+      initialParams,
       routeName: ScreenName.MultiButton,
       screenComponent: MultiButtonScreen
     },
     {
+      initialParams,
       routeName: ScreenName.NestedInfo,
       screenComponent: NestedInfoScreen
     },
     {
+      initialParams,
       routeName: ScreenName.NoticeboardForm,
       screenComponent: NoticeboardFormScreen
     },
     {
+      initialParams,
       routeName: ScreenName.Noticeboard,
       screenComponent: NoticeboardIndexScreen
     },
     {
+      initialParams,
       routeName: ScreenName.OParlCalendar,
       screenComponent: OParlCalendarScreen
     },
     {
+      initialParams,
       routeName: ScreenName.OParlDetail,
       screenComponent: OParlDetailScreen
     },
     {
+      initialParams,
       routeName: ScreenName.OParlOrganizations,
       screenComponent: OParlOrganizationsScreen
     },
     {
+      initialParams,
       routeName: ScreenName.OParlOverview,
       screenComponent: OParlOverviewScreen
     },
     {
+      initialParams,
       routeName: ScreenName.OParlPersons,
       screenComponent: OParlPersonsScreen
     },
     {
+      initialParams,
       routeName: ScreenName.OParlSearch,
       screenComponent: OParlSearchScreen
     },
     {
+      initialParams,
       routeName: ScreenName.Pdf,
       screenComponent: PdfScreen
     },
     {
+      initialParams,
       routeName: ScreenName.Service,
       screenComponent: getTilesScreen({
         matomoString: MATOMO_TRACKING.SCREEN_VIEW.SERVICE,
@@ -359,83 +407,92 @@ export const defaultStackConfig = ({
       screenOptions: { title: texts.screenTitles.service }
     },
     {
+      initialParams: { title: texts.screenTitles.settings },
       routeName: ScreenName.Settings,
       screenComponent: SettingsScreen,
-      screenOptions: getScreenOptions({ withDrawer: isDrawer }),
-      initialParams: { title: texts.screenTitles.settings }
+      screenOptions: getScreenOptions({ withDrawer: isDrawer })
     },
     {
-      routeName: ScreenName.SueList,
-      screenComponent: SueListScreen,
       initialParams: {
         title: texts.screenTitles.sue.listView,
         query: QUERY_TYPES.SUE.REQUESTS,
         usedAsInitialScreen: true
-      }
+      },
+      routeName: ScreenName.SueList,
+      screenComponent: SueListScreen
     },
     {
-      routeName: ScreenName.SueMap,
-      screenComponent: SueMapScreen,
       initialParams: {
         title: texts.screenTitles.sue.mapView,
         query: QUERY_TYPES.SUE.REQUESTS,
         usedAsInitialScreen: true
-      }
+      },
+      routeName: ScreenName.SueMap,
+      screenComponent: SueMapScreen
     },
     {
-      routeName: ScreenName.SueReport,
-      screenComponent: SueReportScreen,
       initialParams: {
         title: texts.screenTitles.sue.reportView,
         query: QUERY_TYPES.SUE.REQUESTS,
         usedAsInitialScreen: true
-      }
+      },
+      routeName: ScreenName.SueReport,
+      screenComponent: SueReportScreen
     },
     {
+      initialParams,
       routeName: ScreenName.SueReportMapView,
       screenComponent: SueMapViewScreen,
       screenOptions: { title: texts.screenTitles.mapView }
     },
     {
+      initialParams,
       routeName: ScreenName.SurveyDetail,
       screenComponent: SurveyDetailScreen,
       screenOptions: { title: texts.screenTitles.survey }
     },
     {
+      initialParams,
       routeName: ScreenName.SurveyOverview,
       screenComponent: SurveyOverviewScreen,
       screenOptions: { title: texts.screenTitles.surveys }
     },
     {
+      initialParams,
       routeName: ScreenName.TilesScreen,
       screenComponent: TilesScreen
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerDetail,
       screenComponent: VolunteerDetailScreen,
       screenOptions: getScreenOptions({ withDrawer: isDrawer, withShare: true })
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerForm,
       screenComponent: VolunteerFormScreen
     },
     {
-      routeName: ScreenName.VolunteerHome,
-      screenComponent: VolunteerHomeScreen,
       initialParams: {
         title: texts.screenTitles.volunteer.home
-      }
+      },
+      routeName: ScreenName.VolunteerHome,
+      screenComponent: VolunteerHomeScreen
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerIndex,
       screenComponent: VolunteerIndexScreen
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerLogin,
       screenComponent: VolunteerLoginScreen,
       screenOptions: { title: texts.screenTitles.volunteer.home }
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerLogout,
       screenComponent: VolunteerLogoutScreen,
       screenOptions: getScreenOptions({
@@ -444,68 +501,82 @@ export const defaultStackConfig = ({
       })
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerMe,
       screenComponent: VolunteerMeScreen
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerPersonal,
       screenComponent: VolunteerPersonalScreen,
       screenOptions: { title: texts.screenTitles.volunteer.personal }
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerRegistered,
       screenComponent: VolunteerRegisteredScreen,
       screenOptions: { title: texts.screenTitles.volunteer.home }
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerRegistration,
       screenComponent: VolunteerRegistrationScreen,
       screenOptions: { title: texts.screenTitles.volunteer.home }
     },
     {
+      initialParams,
       routeName: ScreenName.VolunteerSignup,
       screenComponent: VolunteerSignupScreen,
       screenOptions: { title: texts.screenTitles.volunteer.home }
     },
     {
+      initialParams,
       routeName: ScreenName.VoucherDetail,
       screenComponent: VoucherDetailScreen,
       screenOptions: getScreenOptions({ withBookmark: false })
     },
     {
+      initialParams,
       routeName: ScreenName.VoucherHome,
       screenComponent: VoucherHomeScreen,
       screenOptions: { title: texts.screenTitles.voucher.home }
     },
     {
+      initialParams,
       routeName: ScreenName.VoucherIndex,
       screenComponent: VoucherIndexScreen
     },
     {
+      initialParams,
       routeName: ScreenName.VoucherLogin,
       screenComponent: VoucherLoginScreen,
       screenOptions: { title: texts.screenTitles.voucher.home }
     },
     {
+      initialParams,
       routeName: ScreenName.VoucherScanner,
       screenComponent: VoucherScannerScreen,
       screenOptions: { title: texts.screenTitles.voucher.qr }
     },
     {
+      initialParams,
       routeName: ScreenName.WasteCollection,
       screenComponent: WasteCollectionScreen,
       screenOptions: { title: texts.screenTitles.wasteCollection }
     },
     {
+      initialParams,
       routeName: ScreenName.WasteReminder,
       screenComponent: WasteReminderScreen,
       screenOptions: { title: texts.screenTitles.wasteCollection }
     },
     {
+      initialParams,
       routeName: ScreenName.Weather,
       screenComponent: WeatherScreen
     },
     {
+      initialParams,
       routeName: ScreenName.Web,
       screenComponent: WebScreen,
       screenOptions: getScreenOptions({ withDrawer: isDrawer, withShare: true })

--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -109,13 +109,15 @@ export const tabNavigatorConfig: TabNavigatorConfig = {
 
 export const createDynamicTabConfig = (
   accessibilityLabel: string,
-  iconName: string,
-  iconSize: number,
+  iconName: keyof typeof Icon,
+  iconSize: number = 24,
   index: number,
   label: string,
-  length: number,
+  totalCount: number,
   screen: ScreenName,
-  initialParams?: Record<string, any>
+  initialParams?: Record<string, any>,
+  iconLandscapeStyle?: ViewStyle,
+  iconStyle?: ViewStyle
 ): TabConfig => ({
   stackConfig: defaultStackConfig({
     initialParams,
@@ -123,13 +125,16 @@ export const createDynamicTabConfig = (
     isDrawer: false
   }),
   tabOptions: {
-    tabBarAccessibilityLabel: `${accessibilityLabel || label} (Tab ${index + 1} von ${length})`,
+    tabBarAccessibilityLabel: `${accessibilityLabel || label} (Tab ${index + 1} von ${totalCount})`,
     tabBarLabel: label,
     tabBarIcon: ({ color }: TabBarIconProps) => (
       <OrientationAwareIcon
         color={color}
-        Icon={Icon[upperFirst(iconName)]}
+        iconName={iconName}
+        Icon={Icon[iconName as keyof typeof Icon]}
+        landscapeStyle={iconLandscapeStyle}
         size={normalize(iconSize)}
+        style={iconStyle}
       />
     )
   }

--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-native/no-inline-styles */
-import { upperFirst } from 'lodash';
 import React from 'react';
+import { ViewStyle } from 'react-native';
 
 import { OrientationAwareIcon } from '../../components';
 import { ScreenName, TabConfig, TabNavigatorConfig } from '../../types';

--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-native/no-inline-styles */
+import { upperFirst } from 'lodash';
 import React from 'react';
 
 import { OrientationAwareIcon } from '../../components';
@@ -36,6 +37,7 @@ const serviceTabConfig: TabConfig = {
     isDrawer: false
   }),
   tabOptions: {
+    tabBarAccessibilityLabel: `${texts.tabBarLabel.service} (Tab 2 von 5)`,
     tabBarLabel: texts.tabBarLabel.service,
     tabBarIcon: ({ color }: TabBarIconProps) => (
       <OrientationAwareIcon color={color} Icon={Icon.Service} />
@@ -49,6 +51,7 @@ const pointOfInterestTabConfig: TabConfig = {
     isDrawer: false
   }),
   tabOptions: {
+    tabBarAccessibilityLabel: `${texts.tabBarLabel.pointsOfInterest} (Tab 3 von 5)`,
     tabBarLabel: texts.tabBarLabel.pointsOfInterest,
     tabBarIcon: ({ color }: TabBarIconProps) => (
       <OrientationAwareIcon color={color} Icon={Icon.Location} size={normalize(30)} />
@@ -62,6 +65,7 @@ const eventsTabConfig: TabConfig = {
     isDrawer: false
   }),
   tabOptions: {
+    tabBarAccessibilityLabel: `${texts.tabBarLabel.events} (Tab 4 von 5)`,
     tabBarLabel: texts.tabBarLabel.events,
     tabBarIcon: ({ color }: TabBarIconProps) => (
       <OrientationAwareIcon color={color} Icon={Icon.Calendar} size={normalize(24)} />
@@ -102,3 +106,31 @@ export const tabNavigatorConfig: TabNavigatorConfig = {
     aboutTabConfig
   ]
 };
+
+export const createDynamicTabConfig = (
+  accessibilityLabel: string,
+  iconName: string,
+  iconSize: number,
+  index: number,
+  label: string,
+  length: number,
+  screen: ScreenName,
+  initialParams?: Record<string, any>
+): TabConfig => ({
+  stackConfig: defaultStackConfig({
+    initialParams,
+    initialRouteName: screen,
+    isDrawer: false
+  }),
+  tabOptions: {
+    tabBarAccessibilityLabel: `${accessibilityLabel || label} (Tab ${index + 1} von ${length})`,
+    tabBarLabel: label,
+    tabBarIcon: ({ color }: TabBarIconProps) => (
+      <OrientationAwareIcon
+        color={color}
+        Icon={Icon[upperFirst(iconName)]}
+        size={normalize(iconSize)}
+      />
+    )
+  }
+});

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -1,37 +1,154 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { colors, device, normalize } from '../config';
-import { TabNavigatorConfig } from '../types';
+import { LoadingSpinner } from '../components';
+import { colors, normalize } from '../config';
+import {
+  createDynamicTabConfig,
+  tabNavigatorConfig as defaultTabNavigatorConfig
+} from '../config/navigation/tabConfig';
+import { useStaticContent } from '../hooks';
+import { ScreenName, TabConfig, TabNavigatorConfig } from '../types';
 
 import { getStackNavigator } from './AppStackNavigator';
+
+const defaultTabRoutes: TabRoutes = {
+  tabConfig: {
+    activeBackgroundColor: colors.surface,
+    activeTintColor: colors.accent,
+    inactiveBackgroundColor: colors.surface,
+    inactiveTintColor: colors.primary,
+    tabs: ['Home', 'Service', 'Events', 'Index', 'About']
+  }
+};
+
+type Tab = {
+  accessibilityLabel: string;
+  iconName: string;
+  iconSize: number;
+  label: string;
+  screen: ScreenName;
+  params?: Record<string, any>;
+};
+
+type TabRoutes = {
+  tabConfig: {
+    activeTintColor: string;
+    inactiveTintColor: string;
+    activeBackgroundColor: string;
+    inactiveBackgroundColor: string;
+    tabs: (Tab | string)[];
+  };
+};
+
+const useTabRoutes = () => {
+  const { data, error, loading } = useStaticContent<TabRoutes>({
+    name: 'tabNavigation',
+    type: 'json'
+  });
+
+  const [tabRoutes, setTabRoutes] = useState<TabRoutes>(defaultTabRoutes);
+
+  useEffect(() => {
+    const tabs: (Tab | string)[] = data?.tabConfig.tabs || defaultTabRoutes.tabConfig.tabs;
+    const { activeBackgroundColor, activeTintColor, inactiveBackgroundColor, inactiveTintColor } =
+      data?.tabConfig || defaultTabRoutes.tabConfig;
+
+    setTabRoutes((prev) => {
+      const filteredTabs = defaultTabNavigatorConfig.tabConfigs.filter((tabConfig) => {
+        const screen = tabConfig.stackConfig.initialRouteName;
+
+        return tabs.some((tab) =>
+          typeof tab === 'string' ? tab === screen : tab.screen === screen
+        );
+      });
+
+      const dynamicTabs = tabs
+        .map((tab, index) => {
+          if (typeof tab === 'string') {
+            const screen = tab;
+            return filteredTabs.find(
+              (tabConfig) => tabConfig.stackConfig.initialRouteName === screen
+            );
+          } else {
+            return createDynamicTabConfig(
+              tab.accessibilityLabel,
+              tab.iconName,
+              tab.iconSize,
+              index,
+              tab.label,
+              tabs.length,
+              tab.screen,
+              tab.params
+            );
+          }
+        })
+        .filter(Boolean) as TabConfig[];
+
+      return {
+        ...prev,
+        tabConfig: {
+          ...prev.tabConfig,
+          activeBackgroundColor,
+          activeTintColor,
+          inactiveBackgroundColor,
+          inactiveTintColor,
+          tabs: dynamicTabs
+        }
+      };
+    });
+  }, [data, error]);
+
+  return { loading, tabRoutes };
+};
 
 const Tab = createBottomTabNavigator();
 
 export const MainTabNavigator = ({
-  tabNavigatorConfig
+  tabNavigatorConfig = defaultTabNavigatorConfig
 }: {
-  tabNavigatorConfig: TabNavigatorConfig;
-}) => (
-  <Tab.Navigator
-    screenOptions={{
-      headerShown: false,
-      tabBarActiveBackgroundColor: tabNavigatorConfig.activeBackgroundColor,
-      tabBarActiveTintColor: tabNavigatorConfig.activeTintColor,
-      tabBarHideOnKeyboard: true,
-      tabBarInactiveBackgroundColor: tabNavigatorConfig.inactiveBackgroundColor,
-      tabBarInactiveTintColor: tabNavigatorConfig.inactiveTintColor,
-      tabBarItemStyle: { marginTop: normalize(0) },
-      tabBarStyle: { backgroundColor: colors.surface }
-    }}
-  >
-    {tabNavigatorConfig.tabConfigs.map((tabConfig, index) => (
-      <Tab.Screen
-        key={`Stack${index}`}
-        name={`Stack${index}`}
-        component={getStackNavigator(tabConfig.stackConfig)}
-        options={tabConfig.tabOptions}
-      />
-    ))}
-  </Tab.Navigator>
-);
+  tabNavigatorConfig?: TabNavigatorConfig;
+}) => {
+  const { loading, tabRoutes } = useTabRoutes();
+
+  const [tabConfigs, setTabConfigs] = useState<TabConfig[]>(defaultTabNavigatorConfig.tabConfigs);
+
+  useEffect(() => {
+    if (!loading) {
+      setTabConfigs(tabRoutes.tabConfig.tabs);
+    }
+  }, [tabRoutes, loading]);
+
+  if (loading) return <LoadingSpinner loading />;
+
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveBackgroundColor:
+          tabRoutes.tabConfig?.activeBackgroundColor || tabNavigatorConfig.activeBackgroundColor,
+        tabBarActiveTintColor:
+          tabRoutes.tabConfig?.activeTintColor || tabNavigatorConfig.activeTintColor,
+        tabBarHideOnKeyboard: true,
+        tabBarInactiveBackgroundColor:
+          tabRoutes.tabConfig?.inactiveBackgroundColor ||
+          tabNavigatorConfig.inactiveBackgroundColor,
+        tabBarInactiveTintColor:
+          tabRoutes.tabConfig?.inactiveTintColor || tabNavigatorConfig.inactiveTintColor,
+        tabBarItemStyle: { marginTop: normalize(0) },
+        tabBarStyle: { backgroundColor: colors.surface }
+      }}
+    >
+      {tabConfigs.map((tabConfig, index) => {
+        return (
+          <Tab.Screen
+            key={`Stack${index}`}
+            name={`Stack${index}`}
+            component={getStackNavigator(tabConfig.stackConfig)}
+            options={tabConfig.tabOptions}
+          />
+        );
+      })}
+    </Tab.Navigator>
+  );
+};

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -3,119 +3,84 @@ import React, { useEffect, useState } from 'react';
 
 import { LoadingSpinner } from '../components';
 import { colors, normalize } from '../config';
-import {
-  createDynamicTabConfig,
-  tabNavigatorConfig as defaultTabNavigatorConfig
-} from '../config/navigation/tabConfig';
+import { createDynamicTabConfig, tabNavigatorConfig } from '../config/navigation/tabConfig';
 import { useStaticContent } from '../hooks';
-import { ScreenName, TabConfig, TabNavigatorConfig } from '../types';
+import { TabConfig, TabNavigatorConfig } from '../types';
 
 import { getStackNavigator } from './AppStackNavigator';
 
-const defaultTabRoutes: TabRoutes = {
-  tabConfig: {
-    activeBackgroundColor: colors.surface,
-    activeTintColor: colors.accent,
-    inactiveBackgroundColor: colors.surface,
-    inactiveTintColor: colors.primary,
-    tabs: ['Home', 'Service', 'Events', 'Index', 'About']
-  }
-};
-
-type Tab = {
-  accessibilityLabel: string;
-  iconName: string;
-  iconSize: number;
-  label: string;
-  screen: ScreenName;
-  params?: Record<string, any>;
-};
-
-type TabRoutes = {
-  tabConfig: {
-    activeTintColor: string;
-    inactiveTintColor: string;
-    activeBackgroundColor: string;
-    inactiveBackgroundColor: string;
-    tabs: (Tab | string)[];
-  };
-};
-
 const useTabRoutes = () => {
-  const { data, error, loading } = useStaticContent<TabRoutes>({
+  const {
+    data: tabRoutesData,
+    error,
+    loading
+  } = useStaticContent<TabNavigatorConfig>({
     name: 'tabNavigation',
     type: 'json'
   });
 
-  const [tabRoutes, setTabRoutes] = useState<TabRoutes>(defaultTabRoutes);
+  const [tabRoutes, setTabRoutes] = useState<TabNavigatorConfig>(tabNavigatorConfig);
 
   useEffect(() => {
-    const tabs: (Tab | string)[] = data?.tabConfig.tabs || defaultTabRoutes.tabConfig.tabs;
-    const { activeBackgroundColor, activeTintColor, inactiveBackgroundColor, inactiveTintColor } =
-      data?.tabConfig || defaultTabRoutes.tabConfig;
+    const {
+      activeBackgroundColor,
+      activeTintColor,
+      inactiveBackgroundColor,
+      inactiveTintColor,
+      tabConfigs
+    } = tabRoutesData || tabNavigatorConfig;
 
     setTabRoutes((prev) => {
-      const filteredTabs = defaultTabNavigatorConfig.tabConfigs.filter((tabConfig) => {
-        const screen = tabConfig.stackConfig.initialRouteName;
-
-        return tabs.some((tab) =>
-          typeof tab === 'string' ? tab === screen : tab.screen === screen
-        );
+      const dynamicTabs = tabConfigs?.map((tab, index) => {
+        if (typeof tab === 'string') {
+          // here we are comparing defaultTabs with the array on main-server.
+          // if the string in the main-server array matches the `initialRouteName` in the
+          // `tabNavigatorConfig` (default), that tab is automatically selected.
+          return tabNavigatorConfig.tabConfigs.find(
+            (tabConfig) => tabConfig.stackConfig.initialRouteName === tab
+          );
+        } else if ('stackConfig' in tab) {
+          return tab;
+        } else {
+          return createDynamicTabConfig(
+            tab.accessibilityLabel,
+            tab.iconName,
+            tab.iconSize,
+            index,
+            tab.label,
+            tabConfigs.length,
+            tab.screen,
+            tab.params,
+            tab.iconLandscapeStyle,
+            tab.iconStyle
+          );
+        }
       });
-
-      const dynamicTabs = tabs
-        .map((tab, index) => {
-          if (typeof tab === 'string') {
-            const screen = tab;
-            return filteredTabs.find(
-              (tabConfig) => tabConfig.stackConfig.initialRouteName === screen
-            );
-          } else {
-            return createDynamicTabConfig(
-              tab.accessibilityLabel,
-              tab.iconName,
-              tab.iconSize,
-              index,
-              tab.label,
-              tabs.length,
-              tab.screen,
-              tab.params
-            );
-          }
-        })
-        .filter(Boolean) as TabConfig[];
 
       return {
         ...prev,
-        tabConfig: {
-          ...prev.tabConfig,
-          activeBackgroundColor,
-          activeTintColor,
-          inactiveBackgroundColor,
-          inactiveTintColor,
-          tabs: dynamicTabs
-        }
+        activeBackgroundColor,
+        activeTintColor,
+        inactiveBackgroundColor,
+        inactiveTintColor,
+        tabConfigs: dynamicTabs
       };
     });
-  }, [data, error]);
+  }, [tabRoutesData, error]);
 
   return { loading, tabRoutes };
 };
 
 const Tab = createBottomTabNavigator();
 
-export const MainTabNavigator = ({
-  tabNavigatorConfig = defaultTabNavigatorConfig
-}: {
-  tabNavigatorConfig?: TabNavigatorConfig;
-}) => {
+export const MainTabNavigator = () => {
   const { loading, tabRoutes } = useTabRoutes();
 
-  const [tabConfigs, setTabConfigs] = useState<TabConfig[]>(defaultTabNavigatorConfig.tabConfigs);
+  const [tabConfigs, setTabConfigs] = useState<TabConfig[]>(tabNavigatorConfig.tabConfigs);
 
   useEffect(() => {
     if (!loading) {
-      setTabConfigs(tabRoutes.tabConfig.tabs);
+      setTabConfigs(tabRoutes.tabConfigs);
     }
   }, [tabRoutes, loading]);
 
@@ -126,20 +91,18 @@ export const MainTabNavigator = ({
       screenOptions={{
         headerShown: false,
         tabBarActiveBackgroundColor:
-          tabRoutes.tabConfig?.activeBackgroundColor || tabNavigatorConfig.activeBackgroundColor,
-        tabBarActiveTintColor:
-          tabRoutes.tabConfig?.activeTintColor || tabNavigatorConfig.activeTintColor,
+          tabRoutes?.activeBackgroundColor || tabNavigatorConfig.activeBackgroundColor,
+        tabBarActiveTintColor: tabRoutes?.activeTintColor || tabNavigatorConfig.activeTintColor,
         tabBarHideOnKeyboard: true,
         tabBarInactiveBackgroundColor:
-          tabRoutes.tabConfig?.inactiveBackgroundColor ||
-          tabNavigatorConfig.inactiveBackgroundColor,
+          tabRoutes?.inactiveBackgroundColor || tabNavigatorConfig.inactiveBackgroundColor,
         tabBarInactiveTintColor:
-          tabRoutes.tabConfig?.inactiveTintColor || tabNavigatorConfig.inactiveTintColor,
+          tabRoutes?.inactiveTintColor || tabNavigatorConfig.inactiveTintColor,
         tabBarItemStyle: { marginTop: normalize(0) },
         tabBarStyle: { backgroundColor: colors.surface }
       }}
     >
-      {tabConfigs.map((tabConfig, index) => {
+      {tabConfigs?.map((tabConfig, index) => {
         return (
           <Tab.Screen
             key={`Stack${index}`}

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -1,6 +1,9 @@
 import { BottomTabNavigationOptions } from '@react-navigation/bottom-tabs';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationOptions } from '@react-navigation/stack';
+import { ViewStyle } from 'react-native';
+
+import { Icon } from '../config';
 
 export enum ScreenName {
   About = 'About',
@@ -115,6 +118,17 @@ export type StackConfig = {
   screenConfigs: ScreenConfig[];
 };
 
+export type CustomTab = {
+  accessibilityLabel: string;
+  iconLandscapeStyle?: ViewStyle;
+  iconName: keyof typeof Icon;
+  iconSize?: number;
+  iconStyle?: ViewStyle;
+  label: string;
+  params?: Record<string, any>;
+  screen: ScreenName;
+};
+
 export type TabConfig = {
   stackConfig: StackConfig;
   tabOptions: TabOptions;
@@ -125,7 +139,7 @@ export type TabNavigatorConfig = {
   inactiveTintColor: string;
   activeBackgroundColor: string;
   inactiveBackgroundColor: string;
-  tabConfigs: TabConfig[];
+  tabConfigs: (CustomTab | string | TabConfig)[];
 };
 
 export type NavigatorConfig = { type: 'drawer' } | { type: 'tab'; config: TabNavigatorConfig };


### PR DESCRIPTION
tab navigation feature that can be configured via main-server has been added

To test this feature:

- Create a JSON type content named `tabNavigation` on main-server:
- Update the JSON content as follows or add the desired navigation structure.
```
{
  "activeTintColor": "#0f4618",
  "activeBackgroundColor": "#fff",
  "inactiveTintColor": "#107821",
  "inactiveBackgroundColor": "#fff",
  "tabConfigs": [
    "Home",
    "Service",
    "Events",
    "Index",
    "About",
    {
      "label": "Custom",
      "screen": "VolunteerHome",
      "iconName": "Volunteer",
      "iconSize": 30,
      "accessibilityLabel": "Volunteer",
      "iconStyle": {
        "marginTop": 20
      },
      "iconLandscapeStyle": {
        "marginTop": 20
      }
    }
  ]
}
```
- Delete the app's cache and reload it

## Screenshots
|before|after|
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-07 at 12 22 36](https://github.com/user-attachments/assets/f8029522-6579-4b4d-9c2e-8df3381e8e3f)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-07 at 12 21 44](https://github.com/user-attachments/assets/7cfac80c-c077-43f3-b411-17fcfb8b2198)

SVA-1531