### PR TITLE
feat(sue) increased contrast pin colors

### DIFF
--- a/src/components/SUE/report/SueReportLocation.tsx
+++ b/src/components/SUE/report/SueReportLocation.tsx
@@ -79,7 +79,6 @@ export const SueReportLocation = ({
   areaServiceData,
   control,
   errorMessage,
-  getValues,
   requiredInputs,
   selectedPosition,
   setSelectedPosition,
@@ -108,7 +107,13 @@ export const SueReportLocation = ({
   const systemPermission = useSystemPermission();
   const { appDesignSystem = {} } = useContext(ConfigurationsContext);
   const { sueStatus = {} } = appDesignSystem;
-  const { statusBorderColors = {}, statusTextColors = {}, statusViewColors = {} } = sueStatus;
+  const { mapPinColors = {} } = sueStatus;
+  const {
+    activeBackgroundColors = {},
+    activeIconColors = {},
+    backgroundColors = {},
+    iconColors = {}
+  } = mapPinColors;
   const [address, setAddress] = useState(
     {} as { street: string; houseNumber: string; postalCode: string; city: string }
   );
@@ -149,9 +154,10 @@ export const SueReportLocation = ({
         parseListItemsFromQuery(QUERY_TYPES.SUE.REQUESTS_WITH_SERVICE_REQUEST_ID, data, undefined, {
           appDesignSystem
         }),
-        statusBorderColors,
-        statusTextColors,
-        statusViewColors
+        activeBackgroundColors,
+        activeIconColors,
+        backgroundColors,
+        iconColors
       ) || [],
     [data]
   );

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -262,7 +262,9 @@ export const Map = ({
                     iconColor={
                       marker.iconBackgroundColor
                         ? isActiveMarker
-                          ? marker.iconColor
+                          ? marker.activeBackgroundColor
+                            ? marker.activeBackgroundColor
+                            : marker.iconColor
                           : marker.iconBackgroundColor
                         : isActiveMarker
                         ? colors.darkerPrimary
@@ -270,7 +272,13 @@ export const Map = ({
                     }
                     iconName={isActiveMarker ? 'locationActive' : undefined}
                     iconSize={MARKER_ICON_SIZE * (isActiveMarker ? 1.4 : 1.1)}
-                    iconStrokeColor={isActiveMarker ? colors.surface : marker.iconBorderColor}
+                    iconStrokeColor={
+                      isActiveMarker
+                        ? marker.activeIconColor
+                          ? marker.activeIconColor
+                          : colors.surface
+                        : marker.iconBorderColor
+                    }
                   />
                   <View
                     style={[
@@ -278,7 +286,9 @@ export const Map = ({
                       isActiveMarker ? styles.mapIconOnLocationMarkerContainerActive : undefined,
                       !!marker.iconBackgroundColor && {
                         backgroundColor: isActiveMarker
-                          ? marker.iconColor
+                          ? marker.activeBackgroundColor
+                            ? marker.activeBackgroundColor
+                            : marker.iconColor
                           : marker.iconBackgroundColor
                       }
                     ]}
@@ -286,7 +296,9 @@ export const Map = ({
                     <MapIcon
                       iconColor={
                         isActiveMarker
-                          ? colors.surface
+                          ? marker.activeIconColor
+                            ? marker.activeIconColor
+                            : colors.surface
                           : marker.iconColor
                           ? marker.iconColor
                           : colors.primary

--- a/src/config/appDesignSystem/default.ts
+++ b/src/config/appDesignSystem/default.ts
@@ -24,6 +24,28 @@ export const defaultAppDesignSystemConfig = {
   },
   sueStatus: {
     containerStyle: {},
+    mapPinColors: {
+      activeBackgroundColors: {
+        'Wird geprüft': '',
+        'In Bearbeitung': '',
+        Abgeschlossen: ''
+      },
+      activeIconColors: {
+        'Wird geprüft': '',
+        'In Bearbeitung': '',
+        Abgeschlossen: ''
+      },
+      backgroundColors: {
+        'Wird geprüft': '',
+        'In Bearbeitung': '',
+        Abgeschlossen: ''
+      },
+      iconColors: {
+        'Wird geprüft': '',
+        'In Bearbeitung': '',
+        Abgeschlossen: ''
+      }
+    },
     statusTextColors: {
       Abgeschlossen: '',
       'In Bearbeitung': '',

--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -54,17 +54,20 @@ type ItemProps = {
 
 export const mapToMapMarkers = (
   items: ItemProps[],
-  statusBorderColors: Record<string, string | undefined>,
-  statusTextColors: Record<string, string | undefined>,
-  statusViewColors: Record<string, string | undefined>
+  activeBackgroundColors: Record<string, string | undefined>,
+  activeIconColors: Record<string, string | undefined>,
+  backgroundColors: Record<string, string | undefined>,
+  iconColors: Record<string, string | undefined>
 ): MapMarker[] | undefined =>
   items
     ?.filter((item) => item.lat && item.long)
     ?.map((item: ItemProps) => ({
       ...item,
-      iconBackgroundColor: statusViewColors?.[item.status],
-      iconBorderColor: statusBorderColors?.[item.status],
-      iconColor: statusTextColors?.[item.status],
+      activeBackgroundColor: activeBackgroundColors?.[item.status],
+      iconBackgroundColor: backgroundColors?.[item.status],
+      activeIconColor: activeIconColors?.[item.status],
+      iconColor: iconColors?.[item.status],
+      iconBorderColor: colors.transparent,
       iconName: `Sue${_upperFirst(item.iconName)}`,
       id: item.serviceRequestId,
       position: {
@@ -88,6 +91,7 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
   const { navigation: navigationType, settings = {} } = globalSettings;
   const { locationService } = settings;
   const { sueStatus = {} } = appDesignSystem;
+  const { mapPinColors = {} } = sueStatus;
   const { geoMap = {} } = sueConfig;
   const systemPermission = useSystemPermission();
   const { position } = usePosition(systemPermission?.status !== Location.PermissionStatus.GRANTED);
@@ -95,7 +99,13 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
     systemPermission?.status !== Location.PermissionStatus.GRANTED
   );
 
-  const { statusBorderColors = {}, statusTextColors = {}, statusViewColors = {} } = sueStatus;
+  const {
+    activeBackgroundColors = {},
+    activeIconColors = {},
+    backgroundColors = {},
+    iconColors = {}
+  } = mapPinColors;
+
   const queryVariables = route.params?.queryVariables ?? {
     start_date: '1900-01-01T00:00:00+01:00'
   };
@@ -116,9 +126,10 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
         parseListItemsFromQuery(QUERY_TYPES.SUE.REQUESTS_WITH_SERVICE_REQUEST_ID, data, undefined, {
           appDesignSystem
         }),
-        statusBorderColors,
-        statusTextColors,
-        statusViewColors
+        activeBackgroundColors,
+        activeIconColors,
+        backgroundColors,
+        iconColors
       ),
     [data]
   );

--- a/src/types/Map.ts
+++ b/src/types/Map.ts
@@ -2,6 +2,8 @@ import { Point } from 'react-native-maps';
 
 export type MapMarker = {
   iconAnchor?: Point;
+  activeBackgroundColor?: string;
+  activeIconColor?: string;
   iconBackgroundColor?: string;
   iconBorderColor?: string;
   iconColor?: string;


### PR DESCRIPTION
added active and inactive icon color tones to increase the contrast difference with the map

SUE-142

|before|before with active pin|after|after with active pin|
|--|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-27 at 09 06 31](https://github.com/user-attachments/assets/8a7cc5bc-37cb-4b71-b8f3-177b6b7a5c2e)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-27 at 09 06 36](https://github.com/user-attachments/assets/02ce12a8-38a7-4eee-b9a8-4453441ac90a)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-27 at 09 06 00](https://github.com/user-attachments/assets/1e92befa-b2c4-43e0-b07a-e96f09b36d9c)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-27 at 09 07 08](https://github.com/user-attachments/assets/c9bf24d9-b1d7-4dfa-a7b9-10590d9a1db4)
