### PR TITLE
feat(sue): hide alternate location selection button

### DIFF
--- a/src/components/settings/LocationSettings.js
+++ b/src/components/settings/LocationSettings.js
@@ -41,7 +41,8 @@ export const LocationSettings = () => {
   const {
     locationService = systemPermission.status !== Location.PermissionStatus.DENIED,
     alternativePosition,
-    defaultAlternativePosition
+    defaultAlternativePosition,
+    showAlternativeLocationButton = true
   } = locationSettings || {};
 
   const locationServiceSwitchData = {
@@ -107,52 +108,59 @@ export const LocationSettings = () => {
       <WrapperHorizontal>
         <SettingsToggle item={locationServiceSwitchData} />
       </WrapperHorizontal>
-      <Wrapper>
-        <RegularText>{texts.settingsContents.locationService.alternativePositionHint}</RegularText>
-      </Wrapper>
-      <Collapsible collapsed={!showMap}>
-        <Map
-          locations={locations}
-          onMapPress={({ nativeEvent }) => {
-            setSelectedPosition({
-              ...nativeEvent.coordinate
-            });
-          }}
-        />
-        <Wrapper>
-          <Button
-            title={texts.settingsContents.locationService.save}
-            onPress={() => {
-              selectedPosition &&
-                setAndSyncLocationSettings({
-                  alternativePosition: geoLocationToLocationObject(selectedPosition)
-                });
-              setSelectedPosition(undefined);
-              setShowMap(false);
-            }}
-          />
-
-          <Touchable
-            onPress={() => {
-              setSelectedPosition(undefined);
-              setShowMap(false);
-            }}
-            style={styles.containerStyle}
-          >
-            <RegularText primary center>
-              {texts.settingsContents.locationService.abort}
+      {!!showAlternativeLocationButton && (
+        <>
+          <Wrapper>
+            <RegularText>
+              {texts.settingsContents.locationService.alternativePositionHint}
             </RegularText>
-          </Touchable>
-        </Wrapper>
-      </Collapsible>
-      <Collapsible collapsed={showMap}>
-        <Wrapper>
-          <Button
-            title={texts.settingsContents.locationService.chooseAlternateLocationButton}
-            onPress={() => setShowMap(true)}
-          />
-        </Wrapper>
-      </Collapsible>
+          </Wrapper>
+
+          <Collapsible collapsed={!showMap}>
+            <Map
+              locations={locations}
+              onMapPress={({ nativeEvent }) => {
+                setSelectedPosition({
+                  ...nativeEvent.coordinate
+                });
+              }}
+            />
+            <Wrapper>
+              <Button
+                title={texts.settingsContents.locationService.save}
+                onPress={() => {
+                  selectedPosition &&
+                    setAndSyncLocationSettings({
+                      alternativePosition: geoLocationToLocationObject(selectedPosition)
+                    });
+                  setSelectedPosition(undefined);
+                  setShowMap(false);
+                }}
+              />
+
+              <Touchable
+                onPress={() => {
+                  setSelectedPosition(undefined);
+                  setShowMap(false);
+                }}
+                style={styles.containerStyle}
+              >
+                <RegularText primary center>
+                  {texts.settingsContents.locationService.abort}
+                </RegularText>
+              </Touchable>
+            </Wrapper>
+          </Collapsible>
+          <Collapsible collapsed={showMap}>
+            <Wrapper>
+              <Button
+                title={texts.settingsContents.locationService.chooseAlternateLocationButton}
+                onPress={() => setShowMap(true)}
+              />
+            </Wrapper>
+          </Collapsible>
+        </>
+      )}
     </ScrollView>
   );
 };


### PR DESCRIPTION
- added `showAlternativeLocationButton` to add the option to hide the alternative location button

SUE-138

for testing, update the `settings.locationService` object in `globalSettings` as follows

```
    "locationService": {
      ...
      "showAlternativeLocationButton": false // true
    },
```
|before|after|
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-27 at 12 24 27](https://github.com/user-attachments/assets/aa30a7cc-949b-4730-8350-07d60f843d24)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-27 at 12 24 09](https://github.com/user-attachments/assets/1075ea74-a12a-4c66-932e-35c859c1bf53)
