### PR TITLE
feat(tab): add customizable service tile screen

### DIFF
--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -104,13 +104,15 @@ import { texts } from '../texts';
 const { MATOMO_TRACKING } = consts;
 
 export const defaultStackConfig = ({
-  initialRouteName,
   initialParams,
-  isDrawer
+  initialRouteName,
+  isDrawer,
+  tilesScreenParams
 }: {
-  initialRouteName: ScreenName;
   initialParams?: Record<string, any>;
+  initialRouteName: ScreenName;
   isDrawer: boolean;
+  tilesScreenParams?: Record<string, any>;
 }): StackConfig => ({
   initialRouteName,
   screenOptions: getScreenOptions({ withDrawer: isDrawer }),
@@ -494,13 +496,15 @@ export const defaultStackConfig = ({
     {
       initialParams,
       routeName: ScreenName.Service,
-      screenComponent: getTilesScreen({
-        matomoString: MATOMO_TRACKING.SCREEN_VIEW.SERVICE,
-        staticJsonName: 'homeService',
-        titleFallback: texts.homeTitles.service,
-        titleKey: 'headlineService',
-        imageKey: 'headlineServiceImage'
-      }),
+      screenComponent: getTilesScreen(
+        tilesScreenParams || {
+          matomoString: MATOMO_TRACKING.SCREEN_VIEW.SERVICE,
+          staticJsonName: 'homeService',
+          titleFallback: texts.homeTitles.service,
+          titleKey: 'headlineService',
+          imageKey: 'headlineServiceImage'
+        }
+      ),
       screenOptions: { title: texts.screenTitles.service }
     },
     {

--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -124,14 +124,16 @@ export const createDynamicTabConfig = (
   label: string,
   totalCount: number,
   screen: ScreenName,
-  initialParams?: Record<string, any>,
   iconLandscapeStyle?: ViewStyle,
-  iconStyle?: ViewStyle
+  iconStyle?: ViewStyle,
+  initialParams?: Record<string, any>,
+  tilesScreenParams?: Record<string, any>
 ): TabConfig => ({
   stackConfig: defaultStackConfig({
     initialParams,
     initialRouteName: screen,
-    isDrawer: false
+    isDrawer: false,
+    tilesScreenParams
   }),
   tabOptions: {
     tabBarAccessibilityLabel: `${accessibilityLabel || label} (Tab ${index + 1} von ${totalCount})`,

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -53,9 +53,10 @@ const useTabRoutes = () => {
             tab.label,
             tabConfigs.length,
             tab.screen,
-            tab.params,
             tab.iconLandscapeStyle,
-            tab.iconStyle
+            tab.iconStyle,
+            tab.params,
+            tab.tilesScreenParams
           );
         }
       });

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -143,6 +143,7 @@ export type CustomTab = {
   label: string;
   params?: Record<string, any>;
   screen: ScreenName;
+  tilesScreenParams?: Record<string, any>;
 };
 
 export type TabConfig = {


### PR DESCRIPTION
- added `tilesScreenParams` option to `getTilesScreen` in `defaultStackConfig` to add the ability to create custom service tiles on main-server without any code modification

SVA-1531

It will be enough to add the desired values to the `tilesScreenParams` section to create a custom service tile page by updating the `tabNavigation` staticContent on the main-server without any code modification.

Note: It is important to remember to create a staticContent named staticJsonName.

```
{
  screen: 'Service',
  tilesScreenParams: {
    staticJsonName: 'homeCompanies',
    titleKey: 'headlineCompanies', // optional
    imageKey: 'headlineCompaniesImage', // optional
    matomoString: 'string', // optional
    titleFallback: 'string' // optional
  }
  ...
}
```