### PR TITLE
fix(codeclimate): disable files that are unnecessary to scan

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,6 +23,8 @@ ratings:
     - '**.js'
     - '**.jsx'
     - '**.md'
+    - '**.ts'
+    - '**.tsx'
 exclude_paths:
   - .expo/
   - .github/
@@ -32,13 +34,23 @@ exclude_paths:
   - node_modules/
   - scripts/
   - src/config/
+  - __tests__/**/__snapshots__
+  - __maestro__/
+  - patches/
   - .codeclimate.yml
+  - publiccode.yml
   - .eslintrc
   - .gitignore
   - .nvmrc
   - .yvmrc
   - babel.config.js
   - '*.png'
+  - '*.jpg'
+  - '*.tmpl'
+  - '*.json'
+  - '*.txt'
+  - '*.ttf'
+  - '*.gif'
   - jest-setup.js
   - yarn.lock
 checks:


### PR DESCRIPTION
- added file types we don't want codeclimate to scan to `exclude_paths`
- added .ts and .tsx file types that we want to be rated by codeclimate to the `ratings` section

SVA-1557
