### PR TITLE
fix(sue): unable to overwrite configuration error

### DIFF
--- a/src/ConfigurationsProvider.tsx
+++ b/src/ConfigurationsProvider.tsx
@@ -34,19 +34,17 @@ const FILTER_QUERY_TYPES = {
   Tour: QUERY_TYPES.TOURS
 };
 
-const mergeDefaultConfiguration = (target: any, source: any) => {
-  for (const key in source) {
-    if (source[key] instanceof Object && !Array.isArray(source[key])) {
-      if (!target[key]) {
-        target[key] = {};
-      }
-      mergeDefaultConfiguration(target[key], source[key]);
-    } else {
-      target[key] = source[key];
-    }
-  }
-  return target;
-};
+const mergeDefaultConfiguration = (target, source) =>
+  Object.entries(source).reduce(
+    (acc, [key, value]) => {
+      acc[key] =
+        value instanceof Object && !Array.isArray(value)
+          ? mergeDefaultConfiguration(acc[key] || {}, value)
+          : value;
+      return acc;
+    },
+    { ...target }
+  );
 
 const defaultConfiguration = {
   appDesignSystem: defaultAppDesignSystemConfig,


### PR DESCRIPTION
- copied the target value and overwritten the result variable in the `mergeDefaultConfiguration` function in `ConfigurationsProvider` to fix the problem of `staticContentList` not being able to overwrite style data that can be updated from main-server

SUE-97

![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-03 at 14 19 15](https://github.com/user-attachments/assets/02d44f90-792c-48d1-b980-aad429e6b6a3)


update `globalSettings.sections` as follows to be able to test it

```
  "sections": {
    ...
    "staticContentList": {
      "horizontal": true,
      "showStaticContentList": true,
      "staticContentListTitle": "staticContentListTitle",
      "staticContentListDescription": "staticContentListDescription",
      "staticContentName": "homeList"
    }
  },
```