### PR TITLE
feat(waste): add export functionality for waste calendar

### DIFF
--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -1513,6 +1513,7 @@ export const texts = {
     exportAlertBody:
       'Ein Download wird in einem externen Browser gestartet.\nNachdem der Download abgeschlossen ist, können Sie die Termine durch Öffnen der Datei in Ihren Kalender importieren.',
     exportAlertTitle: 'Abfallkalender',
+    exportButton: 'Kalender exportieren',
     exportCalendar: 'Kalender exportieren',
     hintCityAndStreet: 'Bitte geben Sie Ihre Ortschaft und anschließend Ihre Straße an.',
     hintStreet: 'Bitte geben Sie Ihre Straße an.',

--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -10,7 +10,7 @@ import React, {
   useMemo,
   useState
 } from 'react';
-import { ActivityIndicator, Alert, StyleSheet, TouchableOpacity } from 'react-native';
+import { ActivityIndicator, StyleSheet, TouchableOpacity } from 'react-native';
 import { Calendar as RNCalendar } from 'react-native-calendars';
 import { Overlay } from 'react-native-elements';
 
@@ -35,15 +35,11 @@ import { FeedbackFooter } from '../components/FeedbackFooter';
 import {
   colors,
   consts,
-  device,
   Icon,
-  namespace,
   normalize,
-  secrets,
-  staticRestSuffix,
   texts
 } from '../config';
-import { momentFormat, openLink, parseListItemsFromQuery } from '../helpers';
+import { momentFormat, parseListItemsFromQuery } from '../helpers';
 import { setupLocales } from '../helpers/calendarHelper';
 import {
   useRenderSuggestions,
@@ -144,45 +140,6 @@ export const WasteCollectionScreen = ({ navigation }) => {
       return item.listDate >= today && hasMatchesForItem;
     });
   }, [markedDates, selectedTypes]);
-
-  const triggerExport = useCallback(() => {
-    const { street, zip, city } = getLocationData(streetData);
-
-    const baseUrl = secrets[namespace].serverUrl + staticRestSuffix.wasteCalendarExport;
-
-    let params = `street=${encodeURIComponent(street)}`;
-
-    if (zip) {
-      params += `&zip=${encodeURIComponent(zip)}`;
-    }
-
-    if (city) {
-      params += `&city=${encodeURIComponent(city)}`;
-    }
-
-    const combinedUrl = baseUrl + params;
-
-    if (device.platform === 'android') {
-      Alert.alert(
-        wasteTexts.exportAlertTitle,
-        wasteTexts.exportAlertBody,
-        [
-          {
-            onPress: () => {
-              openLink(combinedUrl);
-            }
-          }
-        ],
-        {
-          onDismiss: () => {
-            openLink(combinedUrl);
-          }
-        }
-      );
-    } else {
-      openLink(combinedUrl);
-    }
-  }, [streetData]);
 
   // Monitors changes to `addressesData` and `inputValueCity` when the two-step
   // address selection (`hasWasteAddressesTwoStep`) is enabled. If only one city matches the input,


### PR DESCRIPTION
- moved export button in WasteCollectionSettings with possibility to hide per global settings

|with notifications|without notifications|export overview|
|---|---|---|
|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-04 at 22 31 08](https://github.com/user-attachments/assets/0c24a3af-b22c-40c0-91bb-27f34ead4b13)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-04 at 22 31 10](https://github.com/user-attachments/assets/e398e280-0a73-4d9d-a5a9-35fe7bc97b0a)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-04 at 22 31 33](https://github.com/user-attachments/assets/1a2d735c-8a93-4af1-876b-8ddcc1043719)|

GOS-118