### PR TITLE
fix(map): the pin problem on the map for android

### DIFF
--- a/patches/react-native-maps+1.18.0.patch
+++ b/patches/react-native-maps+1.18.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/react-native-maps/android/src/main/java/com/rnmaps/maps/MapMarker.java b/node_modules/react-native-maps/android/src/main/java/com/rnmaps/maps/MapMarker.java
+index b755f9b..dd560f2 100644
+--- a/node_modules/react-native-maps/android/src/main/java/com/rnmaps/maps/MapMarker.java
++++ b/node_modules/react-native-maps/android/src/main/java/com/rnmaps/maps/MapMarker.java
+@@ -622,4 +622,11 @@ public class MapMarker extends MapFeature {
+     return BitmapDescriptorFactory.fromResource(getDrawableResourceByName(name));
+   }
+ 
++  @Override
++  protected void onLayout(boolean changed, int l, int t, int r, int b) {
++    super.onLayout(changed, l, t, r, b);
++    this.height = b-t;
++    this.width = r-l;
++  }
++
+ }


### PR DESCRIPTION
- patch added to fix the problem of half of the pins on the map being visible on android platform
  - https://github.com/react-native-maps/react-native-maps/issues/5247#issuecomment-2521958144

SVA-1569

|before|after|
|--|--|
<img width="88" alt="image" src="https://github.com/user-attachments/assets/3b81b28b-01a5-4ed5-87c7-eae49a263155" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/576208fb-655b-4319-ba0a-f5cb9caa639e" />
