### PR TITLE
feat: update permissions according to google policies

### DIFF
--- a/app.json
+++ b/app.json
@@ -58,6 +58,8 @@
         "READ_EXTERNAL_STORAGE",
         "WRITE_EXTERNAL_STORAGE"
       ],
+      // `READ_MEDIA_IMAGES` permission must be removed from the array when using the ability to save photos from the camera
+      "blockedPermissions": ["READ_MEDIA_IMAGES", "READ_MEDIA_VIDEO"],
       "config": {
         "googleMaps": {
           "apiKey": "abcdef"


### PR DESCRIPTION
- updated `blockedPermissions` to exclude `READ_MEDIA_IMAGES` when saving photos from the camera

SVASD-67
