### PR TITLE
fix: the back button issue on the `IndexScreen? placed in tab

### DIFF
--- a/src/components/screens/Overviews.js
+++ b/src/components/screens/Overviews.js
@@ -312,7 +312,7 @@ export const Overviews = ({ navigation, route }) => {
           />
         )
       });
-    } else {
+    } else if (query === QUERY_TYPES.POINTS_OF_INTEREST && !showMap) {
       navigation.setOptions({
         headerLeft: () => <HeaderLeft onPress={() => navigation.goBack()} />
       });


### PR DESCRIPTION
- extended the control in `useLayoutEffect` to fix the problem of the return button appearing even though `IndexScreen` is in tab

SVA-1570

|before|after|with initial filter LIST (POI)|map view (POI)|with initial filter MAP (POI)|
|--|--|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-13 at 10 17 08](https://github.com/user-attachments/assets/0898c85b-fca5-4bb7-b00f-b144f8ec63fa)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-13 at 10 16 55](https://github.com/user-attachments/assets/dd0a76e2-ac49-4773-9532-e5ec3aa2edc6)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-13 at 10 19 02](https://github.com/user-attachments/assets/a666c0ac-58cf-4ddb-864f-c55585e774eb)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-13 at 10 19 05](https://github.com/user-attachments/assets/fa4555e3-3b95-4f8c-a0f6-542839f09712)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-13 at 10 19 33](https://github.com/user-attachments/assets/3d2708ed-5c52-4e48-a78c-f308f2bca8c7)
