### PR TITLE
refactor: update event record query structure

### DIFF
--- a/src/queries/eventRecords.js
+++ b/src/queries/eventRecords.js
@@ -14,6 +14,11 @@ const defaultFragment = `
       url
     }
   }
+  webUrls: urls {
+    id
+    url
+    description
+  }
   addresses {
     id
     city
@@ -188,11 +193,6 @@ export const GET_EVENT_RECORD = gql`
           url
           description
         }
-      }
-      webUrls: urls {
-        id
-        url
-        description
       }
       priceInformations {
         id


### PR DESCRIPTION
- added `webUrls` to `defaultFragment` to fix the problem of links not being added to the share section when sharing events
- removed from `eventRecord` query because `webUrls` was added to `defaultFragment`

SVASD-105

|before|after|
|--|--|
<img width="419" alt="image" src="https://github.com/user-attachments/assets/304fe592-a443-446b-a8ea-952d22f4ea8c" />|<img width="410" alt="image" src="https://github.com/user-attachments/assets/5dcdd00a-844e-406e-a07a-f4ccc3673848" />
