### PR TITLE
fix the design bug of the oparl list

### DIFF
--- a/src/components/oParl/previews/MeetingPreview.tsx
+++ b/src/components/oParl/previews/MeetingPreview.tsx
@@ -1,10 +1,11 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 
-import { texts } from '../../../config';
+import { normalize, texts } from '../../../config';
 import { momentFormat } from '../../../helpers';
 import { MeetingPreviewData } from '../../../types';
 import { TextListItem } from '../../TextListItem';
+import { StyleSheet } from 'react-native';
 
 type Props = {
   data: MeetingPreviewData;
@@ -23,5 +24,11 @@ export const MeetingPreview = ({ data, navigation }: Props) => {
     title: name ?? texts.oparl.meeting.meeting
   };
 
-  return <TextListItem navigation={navigation} item={item} />;
+  return <TextListItem containerStyle={styles.container} navigation={navigation} item={item} />;
 };
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: normalize(16)
+  }
+});

--- a/src/components/oParl/previews/OParlItemPreview.tsx
+++ b/src/components/oParl/previews/OParlItemPreview.tsx
@@ -7,7 +7,6 @@ import { OParlObjectPreviewData } from '../../../types';
 import { SectionHeader } from '../../SectionHeader';
 
 import { OParlPreviewComponent } from './OParlPreviewComponent';
-import { WrapperHorizontal } from '../../Wrapper';
 
 type Props = {
   data?: OParlObjectPreviewData;
@@ -31,14 +30,12 @@ export const OParlItemPreview = ({
   return (
     <View style={styles.marginTop}>
       {!!header?.length && <SectionHeader title={header} />}
-      <WrapperHorizontal>
-        <OParlPreviewComponent
-          data={data}
-          navigation={navigation}
-          withAgendaItem={withAgendaItem}
-          withPerson={withPerson}
-        />
-      </WrapperHorizontal>
+      <OParlPreviewComponent
+        data={data}
+        navigation={navigation}
+        withAgendaItem={withAgendaItem}
+        withPerson={withPerson}
+      />
     </View>
   );
 };

--- a/src/components/oParl/previews/OParlPreviewEntry.tsx
+++ b/src/components/oParl/previews/OParlPreviewEntry.tsx
@@ -48,6 +48,7 @@ export const OParlPreviewEntry = ({
 const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.transparent,
+    marginHorizontal: normalize(16),
     padding: 0,
     paddingVertical: normalize(12)
   }

--- a/src/components/oParl/previews/PersonPreview.tsx
+++ b/src/components/oParl/previews/PersonPreview.tsx
@@ -1,7 +1,8 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
-import { texts } from '../../../config';
+import { normalize, texts } from '../../../config';
 import { getFullName } from '../../../helpers';
 import { PersonPreviewData } from '../../../types';
 import { TextListItem } from '../../TextListItem';
@@ -30,5 +31,11 @@ export const PersonPreview = ({ data, navigation }: Props) => {
     topDivider: false
   };
 
-  return <TextListItem navigation={navigation} item={item} />;
+  return <TextListItem containerStyle={styles.container} navigation={navigation} item={item} />;
 };
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: normalize(16)
+  }
+});

--- a/src/components/oParl/sections/OParlPreviewSection.tsx
+++ b/src/components/oParl/sections/OParlPreviewSection.tsx
@@ -6,10 +6,9 @@ import { Divider } from 'react-native-elements';
 
 import { normalize } from '../../../config';
 import { OParlObjectPreviewData } from '../../../types';
-import { OParlPreviewComponent } from '../previews/OParlPreviewComponent';
-import { OParlItemPreview } from '../previews/OParlItemPreview';
 import { SectionHeader } from '../../SectionHeader';
-import { WrapperHorizontal } from '../../Wrapper';
+import { OParlItemPreview } from '../previews/OParlItemPreview';
+import { OParlPreviewComponent } from '../previews/OParlPreviewComponent';
 
 type Props = {
   data?: OParlObjectPreviewData[] | OParlObjectPreviewData;
@@ -47,7 +46,7 @@ export const OParlPreviewSection = ({
     return (
       <View style={styles.marginTop}>
         {header?.length ? <SectionHeader title={header} /> : <Divider />}
-        <WrapperHorizontal>{data.map((item) => renderPreview(item))}</WrapperHorizontal>
+        {data.map((item) => renderPreview(item))}
       </View>
     );
   } else {


### PR DESCRIPTION
- added `WrapperHorizontal` to `OParlOrganizationsScreen` and `OParlPersonsScreen` for improved layout
- adjusted imports in `OParlPreviewSection` for better organization

SVA-1384

|before|after|before|after|
|--|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-14 at 10 10 57](https://github.com/user-attachments/assets/e66c1b25-dd04-499b-9c6d-60aa357fc3d0)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-14 at 10 10 47](https://github.com/user-attachments/assets/45fe635b-1001-4a7d-b9f0-1c8928762bd5)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-14 at 10 11 01](https://github.com/user-attachments/assets/33a230ae-b3f8-4e49-bfa5-15c7a1fe8f70)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-14 at 10 10 50](https://github.com/user-attachments/assets/9057b2d5-07f3-47ad-9a9d-661d8791c29b)|

