### PR TITLE
fix(waste): date time picker not centered

### DIFF
--- a/src/components/waste/WasteCollectionSettings.tsx
+++ b/src/components/waste/WasteCollectionSettings.tsx
@@ -607,8 +607,9 @@ export const WasteCollectionSettings = ({
                           display="spinner"
                           mode="time"
                           onChange={onDatePickerChange}
-                          value={reminderTime}
+                          style={styles.dateTimePickerIOS}
                           textColor={colors.darkText}
+                          value={reminderTime}
                         />
                       </SafeAreaView>
                     </View>
@@ -720,6 +721,9 @@ const styles = StyleSheet.create({
   },
   dateTimePickerContainerIOS: {
     backgroundColor: colors.surface
+  },
+  dateTimePickerIOS: {
+    alignSelf: 'center'
   },
   modalContainer: {
     backgroundColor: colors.overlayRgba,


### PR DESCRIPTION
- added `alignSelf` style to fix the problem of date time picker not being centered

SVA-1384

|before|after|
|--|--|
![IMG_0070](https://github.com/user-attachments/assets/75f9ccce-b477-48e6-b851-4940c5705fd9)|![IMG_0069](https://github.com/user-attachments/assets/b7e0ca33-223e-4dcb-ba54-0f3f310359eb)
