### PR TITLE
fix(waste): adjust date time picker layout for Android

### DIFF
--- a/src/components/waste/WasteCollectionSettings.tsx
+++ b/src/components/waste/WasteCollectionSettings.tsx
@@ -15,6 +15,7 @@ import {
   Alert,
   FlatList,
   Modal,
+  Platform,
   RefreshControl,
   SafeAreaView,
   ScrollView,
@@ -617,7 +618,9 @@ export const WasteCollectionSettings = ({
                 </Modal>
               )}
               {device.platform === 'android' && showDatePicker && (
-                <DateTimePicker mode="time" onChange={onDatePickerChange} value={reminderTime} />
+                <View style={styles.dateTimePickerContainerAndroid}>
+                  <DateTimePicker mode="time" onChange={onDatePickerChange} value={reminderTime} />
+                </View>
               )}
             </ListItem>
             <Divider style={styles.divider} />
@@ -719,6 +722,9 @@ const styles = StyleSheet.create({
   paddingTop: {
     paddingTop: normalize(14)
   },
+  dateTimePickerContainerAndroid: {
+    marginLeft: normalize(-14)
+  },
   dateTimePickerContainerIOS: {
     backgroundColor: colors.surface
   },
@@ -734,7 +740,14 @@ const styles = StyleSheet.create({
     backgroundColor: colors.shadowRgba,
     paddingVertical: normalize(6),
     paddingHorizontal: normalize(10),
-    marginRight: normalize(-14)
+    ...Platform.select({
+      ios: {
+        marginRight: normalize(-14)
+      },
+      android: {
+        marginRight: 0
+      }
+    })
   },
   resultsList: {
     padding: normalize(14)


### PR DESCRIPTION
- wrap `DateTimePicker` in a container for better alignment on Android
- add specific styles for Android and iOS platforms

SVA-1384

|before without picker|after without picker|before with picker|after with picker|
|--|--|--|--|
![Screenshot_20250217-161852](https://github.com/user-attachments/assets/673867ef-5600-473a-b7bf-897fbbf1458a)|![Screenshot_20250217-161828](https://github.com/user-attachments/assets/40bea61b-5003-4293-9d35-5b04de7dce6f)|![Screenshot_20250217-161856](https://github.com/user-attachments/assets/dd5c02f3-380f-4c9b-aa57-35dbd788b2e7)|![Screenshot_20250217-161832](https://github.com/user-attachments/assets/2ac25ae8-0d7a-4627-a710-f960ae34234f)
