### PR TITLE
refactor(navigation): streamline navigator configuration and imports

### DIFF
--- a/src/config/navigation/config.ts
+++ b/src/config/navigation/config.ts
@@ -4,13 +4,11 @@ import * as Linking from 'expo-linking';
 import { NavigatorConfig, ScreenName } from '../../types';
 import { consts } from '../consts';
 
-import { tabNavigatorConfig } from './tabConfig';
-
 const { HOST_NAMES } = consts;
 
 export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
   let navigatorConfig: NavigatorConfig;
-  const linkingConfig: LinkingOptions = {
+  const linkingConfig: LinkingOptions<{}> = {
     prefixes: [Linking.createURL('/')]
   };
   const screens = {
@@ -24,8 +22,7 @@ export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
     const index = 0;
 
     navigatorConfig = {
-      type: 'tab',
-      config: tabNavigatorConfig
+      type: 'tab'
     };
 
     linkingConfig.config = {
@@ -34,7 +31,7 @@ export const navigationConfig = (navigationType: 'drawer' | 'tab') => {
         [`Stack${index}`]: {
           // The initialRouteName has to be the initial route of the chosen stack:
           // whatever is specified in the tab config for tab navigation
-          initialRouteName: navigatorConfig.config.tabConfigs[index].stackConfig.initialRouteName,
+          initialRouteName: ScreenName.Home,
           screens
         }
       }

--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -127,7 +127,8 @@ export const createDynamicTabConfig = (
   iconLandscapeStyle?: ViewStyle,
   iconStyle?: ViewStyle,
   initialParams?: Record<string, any>,
-  tilesScreenParams?: Record<string, any>
+  tilesScreenParams?: Record<string, any>,
+  unmountOnBlur?: boolean
 ): TabConfig => ({
   stackConfig: defaultStackConfig({
     initialParams,
@@ -147,6 +148,7 @@ export const createDynamicTabConfig = (
         size={normalize(iconSize)}
         style={iconStyle}
       />
-    )
+    ),
+    unmountOnBlur
   }
 });

--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -7,8 +7,8 @@ import { LoadingSpinner } from '../components/LoadingSpinner';
 import { device, texts } from '../config';
 import { defaultStackConfig } from '../config/navigation';
 import { useStaticContent } from '../hooks';
-import { ScreenName } from '../types';
 import { OrientationContext } from '../OrientationProvider';
+import { ScreenName } from '../types';
 
 import { getStackNavigator } from './AppStackNavigator';
 import { CustomDrawerContentComponent } from './CustomDrawerContentComponent';

--- a/src/navigation/Navigator.tsx
+++ b/src/navigation/Navigator.tsx
@@ -9,7 +9,7 @@ import { DrawerNavigator } from './DrawerNavigator';
 import { MainTabNavigator } from './MainTabNavigator';
 
 export const Navigator = ({ navigationType }: { navigationType: 'drawer' | 'tab' }) => {
-  const { navigatorConfig, linkingConfig } = navigationConfig(navigationType);
+  const { linkingConfig } = navigationConfig(navigationType);
 
   return (
     <NavigationContainer
@@ -20,11 +20,7 @@ export const Navigator = ({ navigationType }: { navigationType: 'drawer' | 'tab'
       linking={linkingConfig}
     >
       <StatusBar style="light" translucent backgroundColor="transparent" />
-      {navigatorConfig.type === 'drawer' ? (
-        <DrawerNavigator />
-      ) : (
-        <MainTabNavigator tabNavigatorConfig={navigatorConfig.config} />
-      )}
+      {navigationType === 'drawer' ? <DrawerNavigator /> : <MainTabNavigator />}
     </NavigationContainer>
   );
 };

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -145,6 +145,7 @@ export type CustomTab = {
   params?: Record<string, any>;
   screen: ScreenName;
   tilesScreenParams?: Record<string, any>;
+  unmountOnBlur?: boolean;
 };
 
 export type TabConfig = {
@@ -160,4 +161,4 @@ export type TabNavigatorConfig = {
   tabConfigs: (CustomTab | string | TabConfig)[];
 };
 
-export type NavigatorConfig = { type: 'drawer' } | { type: 'tab'; config: TabNavigatorConfig };
+export type NavigatorConfig = { type: 'drawer' } | { type: 'tab' };


### PR DESCRIPTION
- adjusted setting the tab routes to not have the fallback routes set before dynamic routes are loaded, to be able to have a different initial route than home
  - currently initialRouteName in linkingConfig.config is still hardcoded

SVA-1531