### PR TITLE
fix: remove unused back button in header for android

### DIFF
--- a/src/components/HeaderLeft.tsx
+++ b/src/components/HeaderLeft.tsx
@@ -13,7 +13,7 @@ export const HeaderLeft = ({
   text
 }: HeaderBackButtonProps & { text?: string }) => {
   if (!onPress && !backImage) {
-    return device.platform == 'android' ? <Icon.ArrowLeft color={colors.surface} /> : null;
+    return null;
   }
 
   if (!onPress && backImage) {


### PR DESCRIPTION
- remove unnecessary rendering of `ArrowLeft` icon when no `onPress` or `backImage` is provided

SVA-1384

|before|after|
|--|--|
<img width="421" alt="image" src="https://github.com/user-attachments/assets/39313375-474b-4131-ae34-108a9ec6b351" />|<img width="422" alt="image" src="https://github.com/user-attachments/assets/cbc92bbc-49a8-44a7-855e-aa7ad47a8530" />
