### PR TITLE
fix: the problem of not showing daily events

### DIFF
--- a/src/components/filter/DateFilter.tsx
+++ b/src/components/filter/DateFilter.tsx
@@ -45,7 +45,7 @@ const CalendarView = ({
     dates[date] = {
       ...(dates[date] ?? {}),
       selected: true,
-      selectedColor: colors.lighterSecondary
+      selectedColor: colors.lighterPrimary
     };
 
     return dates;

--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -36,6 +36,16 @@ const deleteInitialStartDateFromQueryVariables = (queryVariables: FilterProps): 
     return newQueryVariables;
   }
 
+  if (queryVariables.dateRange?.length) {
+    const newQueryVariables = { ...queryVariables };
+
+    return {
+      ...newQueryVariables,
+      start_date: queryVariables.dateRange[0],
+      end_date: queryVariables.dateRange[1]
+    };
+  }
+
   return queryVariables;
 };
 
@@ -100,7 +110,7 @@ export const Filter = ({
 
   useEffect(() => {
     if (!!isOverlay && !_isEqual(filters, queryVariables) && isCollapsed) {
-      setFilters(queryVariables);
+      setFilters(updatedQueryVariables);
     }
   }, [isCollapsed]);
 

--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -53,7 +53,7 @@ export const EventWidget = ({ text, additionalProps }: WidgetProps) => {
       title: text ?? texts.homeTitles.events,
       query: QUERY_TYPES.EVENT_RECORDS,
       queryVariables: {
-        order: 'listDate_ASC',
+        ...queryVariables,
         limit: additionalProps?.limit || 15
       },
       rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS,

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -262,7 +262,6 @@ export const defaultStackConfig = ({
         headerLeft: () => (
           <HeaderLeft
             onPress={() => {
-              // @ts-expect-error we are lacking proper param types here
               if (route.params?.qrId || route.params?.fromPoll) {
                 navigation.goBack();
               } else {
@@ -312,15 +311,13 @@ export const defaultStackConfig = ({
       screenComponent: HtmlScreen
     },
     {
-      routeName: ScreenName.Index,
-      screenComponent: IndexScreen,
-      screenOptions: getScreenOptions({ withInfo: true }),
-      // NOTE: is used as initial screen for the points of interest tab
       initialParams: initialParams || {
         title: texts.screenTitles.pointsOfInterest,
-        query: QUERY_TYPES.CATEGORIES,
-        usedAsInitialScreen: true
-      }
+        query: QUERY_TYPES.CATEGORIES
+      },
+      routeName: ScreenName.Index,
+      screenComponent: IndexScreen,
+      screenOptions: getScreenOptions({ withInfo: true })
     },
     {
       initialParams,
@@ -390,9 +387,6 @@ export const defaultStackConfig = ({
       screenComponent: PdfScreen
     },
     {
-      routeName: ScreenName.Profile,
-      screenComponent: ProfileHomeScreen,
-      screenOptions: getScreenOptions({ withInfo: true }),
       initialParams: initialParams || {
         title: texts.screenTitles.profile.home,
         query: QUERY_TYPES.PUBLIC_JSON_FILE,
@@ -400,7 +394,10 @@ export const defaultStackConfig = ({
           name: 'profile'
         },
         rootRouteName: ScreenName.Profile
-      }
+      },
+      routeName: ScreenName.Profile,
+      screenComponent: ProfileHomeScreen,
+      screenOptions: getScreenOptions({ withInfo: true })
     },
     {
       initialParams,
@@ -495,8 +492,7 @@ export const defaultStackConfig = ({
     {
       initialParams: initialParams || {
         title: texts.screenTitles.sue.listView,
-        query: QUERY_TYPES.SUE.REQUESTS,
-        usedAsInitialScreen: true
+        query: QUERY_TYPES.SUE.REQUESTS
       },
       routeName: ScreenName.SueList,
       screenComponent: SueListScreen
@@ -504,8 +500,7 @@ export const defaultStackConfig = ({
     {
       initialParams: initialParams || {
         title: texts.screenTitles.sue.mapView,
-        query: QUERY_TYPES.SUE.REQUESTS,
-        usedAsInitialScreen: true
+        query: QUERY_TYPES.SUE.REQUESTS
       },
       routeName: ScreenName.SueMap,
       screenComponent: SueMapScreen
@@ -513,8 +508,7 @@ export const defaultStackConfig = ({
     {
       initialParams: initialParams || {
         title: texts.screenTitles.sue.reportView,
-        query: QUERY_TYPES.SUE.REQUESTS,
-        usedAsInitialScreen: true
+        query: QUERY_TYPES.SUE.REQUESTS
       },
       routeName: ScreenName.SueReport,
       screenComponent: SueReportScreen

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -223,7 +223,6 @@ const parseCategories = (data, skipLastDivider, routeName, queryVariables, query
           category: `${category.name}`,
           location: queryVariables?.location
         },
-        usedAsInitialScreen: false,
         rootRouteName: ROOT_ROUTE_NAMES.POINTS_OF_INTEREST_AND_TOURS
       },
       bottomDivider: !skipLastDivider || index !== data.length - 1


### PR DESCRIPTION
With this PR, the problem that the daily event screen redirected via widget still shows all events has been fix and `dateRange` dates are shown in the filter component

SVA-1384

|before|after|before|after|before|after|
|--|--|--|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-20 at 10 57 04](https://github.com/user-attachments/assets/2ab8edae-25d3-4b9c-8409-8ef9df183f6c)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-20 at 10 56 43](https://github.com/user-attachments/assets/6adb3b67-e0f7-42c8-a84d-dde0ffdb67a4)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-20 at 10 57 12](https://github.com/user-attachments/assets/9361a048-a765-438b-a960-2145cb935c3b)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-20 at 10 56 45](https://github.com/user-attachments/assets/cf57bb6a-6a96-4316-91bb-80b83c8fcad8)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-20 at 10 57 18](https://github.com/user-attachments/assets/db5e699e-78bc-4d1b-bd39-8a727aa7c427)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-20 at 10 56 48](https://github.com/user-attachments/assets/0e8eeae4-b58e-4e32-a832-9a99d7888c88)
