### PR TITLE
fix(survey): enhance header styling in `SurveyOverviewScreen`

### DIFF
--- a/src/screens/SurveyOverviewScreen.tsx
+++ b/src/screens/SurveyOverviewScreen.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/core';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useCallback } from 'react';
 import { useQuery } from 'react-apollo';
-import { SectionList, View } from 'react-native';
+import { SectionList, StyleSheet } from 'react-native';
 
 import { SafeAreaViewFlex, SectionHeader, TextListItem, WrapperHorizontal } from '../components';
 import { LoadingSpinner } from '../components/LoadingSpinner';
@@ -65,17 +65,21 @@ const parseSurveyToItem = (survey: Survey & { archived?: true }, languages: stri
 };
 
 const renderSectionHeader = ({
-  section: { title, data }
+  data,
+  hasOngoingSurveys,
+  title
 }: {
-  section: { title?: string; data: Survey[] };
+  data: Survey[];
+  hasOngoingSurveys: boolean;
+  title?: string;
 }) => {
   if (!data.length || !title) return null;
 
   return (
-    <>
-      <View style={{ height: normalize(20) }} />
-      <SectionHeader title={title} />
-    </>
+    <SectionHeader
+      title={title}
+      containerStyle={hasOngoingSurveys && styles.headerTitleContainer}
+    />
   );
 };
 
@@ -110,6 +114,8 @@ export const SurveyOverviewScreen = ({ route }: Props) => {
     return <LoadingSpinner loading />;
   }
 
+  const hasOngoingSurveys = surveySections.some((section) => section.key === 'ongoing');
+
   return (
     <SafeAreaViewFlex>
       <SectionList
@@ -125,9 +131,21 @@ export const SurveyOverviewScreen = ({ route }: Props) => {
         }
         refreshControl={RefreshControl}
         renderItem={renderSurvey}
-        renderSectionHeader={renderSectionHeader}
+        renderSectionHeader={({ section: { data, title } }) =>
+          renderSectionHeader({
+            data,
+            hasOngoingSurveys,
+            title
+          })
+        }
         sections={surveySections}
       />
     </SafeAreaViewFlex>
   );
 };
+
+const styles = StyleSheet.create({
+  headerTitleContainer: {
+    paddingTop: normalize(20)
+  }
+});


### PR DESCRIPTION
- added `isOngoingSurveysEnmpty` control to avoid too much space above `sectionHeader` in case there is no ongoing survey

SVA-1384

|with ongoing surveys|without ongoing surveys|
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-27 at 10 27 27](https://github.com/user-attachments/assets/ebdbc687-4f2f-4914-8e12-90434579ebe1)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-27 at 10 27 24](https://github.com/user-attachments/assets/0a17763e-18aa-4731-8651-d42364ba71e7)

