### PR TITLE
fix(navigation): update screen options and navigation method

### DIFF
--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -317,7 +317,7 @@ export const defaultStackConfig = ({
       },
       routeName: ScreenName.Index,
       screenComponent: IndexScreen,
-      screenOptions: getScreenOptions({ withInfo: true })
+      screenOptions: getScreenOptions({ withDrawer: isDrawer, withInfo: true })
     },
     {
       initialParams,

--- a/src/config/navigation/defaultStackConfig.tsx
+++ b/src/config/navigation/defaultStackConfig.tsx
@@ -338,13 +338,13 @@ export const defaultStackConfig = ({
       initialParams,
       routeName: ScreenName.NestedInfo,
       screenComponent: NestedInfoScreen,
-      screenOptions: getScreenOptions({ withInfo: true })
+      screenOptions: getScreenOptions({ withDrawer: isDrawer, withInfo: true })
     },
     {
       initialParams,
       routeName: ScreenName.Noticeboard,
       screenComponent: NoticeboardIndexScreen,
-      screenOptions: getScreenOptions({ withInfo: true })
+      screenOptions: getScreenOptions({ withDrawer: isDrawer, withInfo: true })
     },
     {
       initialParams,
@@ -397,7 +397,7 @@ export const defaultStackConfig = ({
       },
       routeName: ScreenName.Profile,
       screenComponent: ProfileHomeScreen,
-      screenOptions: getScreenOptions({ withInfo: true })
+      screenOptions: getScreenOptions({ withDrawer: isDrawer, withInfo: true })
     },
     {
       initialParams,
@@ -433,7 +433,7 @@ export const defaultStackConfig = ({
       initialParams,
       routeName: ScreenName.ProfileNoticeboard,
       screenComponent: ProfileNoticeboardIndexScreen,
-      screenOptions: getScreenOptions({ withInfo: true })
+      screenOptions: getScreenOptions({ withDrawer: isDrawer, withInfo: true })
     },
     {
       initialParams,
@@ -532,7 +532,7 @@ export const defaultStackConfig = ({
       initialParams,
       routeName: ScreenName.TilesScreen,
       screenComponent: TilesScreen,
-      screenOptions: getScreenOptions({ withInfo: true })
+      screenOptions: getScreenOptions({ withDrawer: isDrawer, withInfo: true })
     },
     {
       initialParams,
@@ -598,7 +598,7 @@ export const defaultStackConfig = ({
       initialParams,
       routeName: ScreenName.VoucherDetail,
       screenComponent: VoucherDetailScreen,
-      screenOptions: getScreenOptions({ withBookmark: false })
+      screenOptions: getScreenOptions({ withDrawer: isDrawer, withBookmark: false })
     },
     {
       initialParams: initialParams || { title: texts.screenTitles.voucher.home },

--- a/src/navigation/DrawerNavigatorItem.js
+++ b/src/navigation/DrawerNavigatorItem.js
@@ -13,7 +13,7 @@ export const DrawerNavigatorItem = ({ activeRoute, itemInfo, navigation, topDivi
   const accessibilityLabel = itemInfo.params.title;
 
   const handleItemPress = () => {
-    navigation.navigate(itemInfo.screen, {
+    navigation.navigateDeprecated(itemInfo.screen, {
       ...itemInfo.params,
       subQuery: itemInfo.params.subQuery ?? undefined
     });

--- a/src/screens/WasteCollectionScreen.js
+++ b/src/screens/WasteCollectionScreen.js
@@ -18,6 +18,7 @@ import {
   BoldText,
   Button,
   DefaultKeyboardAvoidingView,
+  DrawerHeader,
   HeaderLeft,
   LoadingSpinner,
   RegularText,
@@ -77,7 +78,7 @@ export const getLocationData = (streetData) => {
 export const WasteCollectionScreen = ({ navigation }) => {
   const { dimensions } = useContext(OrientationContext);
   const { globalSettings } = useContext(SettingsContext);
-  const { settings = {}, waste = {} } = globalSettings;
+  const { navigation: navigationType, settings = {}, waste = {} } = globalSettings;
   const { wasteAddresses = {} } = settings;
   const {
     twoStep: hasWasteAddressesTwoStep = false,
@@ -226,7 +227,7 @@ export const WasteCollectionScreen = ({ navigation }) => {
     navigation.setOptions({
       headerRight: () =>
         !!streetData && !!usedTypes ? (
-          <WrapperRow>
+          <WrapperRow itemsCenter>
             <HeaderLeft
               onPress={goToReminder}
               backImage={({ tintColor }) => (
@@ -249,8 +250,14 @@ export const WasteCollectionScreen = ({ navigation }) => {
                 }
               />
             )}
+
+            {navigationType === 'drawer' && (
+              <DrawerHeader navigation={navigation} style={styles.icon} />
+            )}
           </WrapperRow>
-        ) : undefined
+        ) : navigationType === 'drawer' ? (
+          <DrawerHeader navigation={navigation} style={styles.icon} />
+        ) : null
     });
 
     if (isReset) {

--- a/src/screens/WasteCollectionSettingsScreen.tsx
+++ b/src/screens/WasteCollectionSettingsScreen.tsx
@@ -29,6 +29,7 @@ import {
   BoldText,
   Button,
   Dot,
+  DrawerHeader,
   HeaderLeft,
   LoadingSpinner,
   RegularText,
@@ -89,7 +90,7 @@ export const WasteCollectionSettingsScreen = () => {
   const navigation = useNavigation();
   const routeParams = useRoute().params;
   const { globalSettings, setGlobalSettings } = useContext(SettingsContext);
-  const { settings = {}, waste = {} } = globalSettings;
+  const { navigation: navigationType, settings = {}, waste = {} } = globalSettings;
   const { wasteAddresses = {} } = settings;
   const { texts: wasteAddressesTexts = {}, hasExport = true } = wasteAddresses;
   const wasteTexts = { ...texts.wasteCalendar, ...wasteAddressesTexts };
@@ -306,10 +307,16 @@ export const WasteCollectionSettingsScreen = () => {
       headerLeft: () => <HeaderLeft onPress={() => navigation.goBack()} />,
       headerRight: () =>
         selectedStreetId ? (
-          <HeaderLeft
-            onPress={isSavingSettings ? undefined : saveSettings}
-            text={wasteTexts.save}
-          />
+          <WrapperRow itemsCenter>
+            <HeaderLeft
+              onPress={isSavingSettings ? undefined : saveSettings}
+              text={wasteTexts.save}
+            />
+
+            {navigationType === 'drawer' && (
+              <DrawerHeader navigation={navigation} style={styles.icon} />
+            )}
+          </WrapperRow>
         ) : null
     });
   }, [selectedStreetId, isSavingSettings, saveSettings]);
@@ -689,6 +696,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.placeholder,
     marginVertical: normalize(4),
     width: normalize(140)
+  },
+  icon: {
+    paddingRight: normalize(10)
   },
   listItemContainer: {
     backgroundColor: colors.surface,


### PR DESCRIPTION
- modified `IndexScreen` options to include `withDrawer` parameter
- updated the `navigate` property in `DrawerNavigatorItem` with `navigateDeprecated` to fix the problem of not being able to navigate with drawer
  - https://reactnavigation.org/docs/upgrading-from-6.x/#changes-to-the-navigate-action

SVA-1384

Note that `navigateDeprecated` will be removed in the next version. This can only be used as a temporary solution.

The hamburger icon for drawer navigation is not shown on the Waste calendar page. This is because the `WasteCollectionScreen` has a `useLayoutEffect` where we add different buttons for the `headerRight`.

To test, update the `navigation` value in `globalSettings` to `drawer`