### PR TITLE
fix: categories not showing up on noticeboard

### DIFF
--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -228,6 +228,10 @@ const parseCategories = (data, skipLastDivider, routeName, queryVariables, query
       bottomDivider: !skipLastDivider || index !== data.length - 1
     };
 
+    if (!query) {
+      categories.push(item);
+    }
+
     if (query !== QUERY_TYPES.TOURS && category.pointsOfInterestTreeCount) {
       categories.push({
         ...item,


### PR DESCRIPTION
- added a `query` control to the `parseCategories` parser to show categories in the noticeboard creation form because until now the query was only set to POI or TOUR to create a category tree

SVA-1384

|before|after|
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-27 at 16 08 40](https://github.com/user-attachments/assets/c518ca68-6377-47d2-a8e0-3dde4953682e)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-27 at 16 08 22](https://github.com/user-attachments/assets/f73829eb-e493-4882-91fb-d3fac0d20963)
