### PR TITLE
fix: center align `DateTimePicker` component

### DIFF
--- a/src/components/form/DateTimeInput.tsx
+++ b/src/components/form/DateTimeInput.tsx
@@ -93,6 +93,7 @@ const DateTimePicker = ({
                   minimumDate={minimumDate}
                   mode={mode}
                   onChange={onDatePickerChange}
+                  style={styles.DateTimePicker}
                   textColor={colors.darkText}
                   value={value}
                 />
@@ -179,6 +180,9 @@ export const DateTimeInput = ({
 };
 
 const styles = StyleSheet.create({
+  DateTimePicker: {
+    alignSelf: 'center'
+  },
   modalContainer: {
     backgroundColor: colors.overlayRgba,
     flex: 1,


### PR DESCRIPTION
- added style to center align the `DateTimePicker`

SVA-1384

|before|after|
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-27 at 16 16 20](https://github.com/user-attachments/assets/770fd25a-b4dc-4c9e-84ca-8567b3fc242f)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-27 at 16 16 12](https://github.com/user-attachments/assets/3e3d13bc-c673-4602-a747-37b7c1fb0dd5)
