### PR TITLE
fix: conditionally render count in `DefaultWidget` component

### DIFF
--- a/src/components/widgets/DefaultWidget.tsx
+++ b/src/components/widgets/DefaultWidget.tsx
@@ -34,9 +34,11 @@ export const DefaultWidget = ({ Icon, count, onPress, text, image }: Props) => {
           ) : (
             <Icon style={[!!count?.toString() && styles.iconWithCount]} />
           )}
-          <BoldText primary big>
-            {count ?? ''}
-          </BoldText>
+          {!!count && (
+            <BoldText primary big>
+              {count}
+            </BoldText>
+          )}
         </WrapperRow>
         <RegularText primary small>
           {text}


### PR DESCRIPTION
- update rendering logic to display `count` only when it exists

SVA-1384

|with count|without count (before)|without count (after)|
|--|--|--|
![Simulator Screenshot - iPhone 16 Pro - 2025-03-05 at 16 00 36](https://github.com/user-attachments/assets/06d37880-8c03-4c97-ad0c-b4d6904c19fe)|![Simulator Screenshot - iPhone 16 Pro - 2025-03-05 at 16 00 55](https://github.com/user-attachments/assets/eb38b17b-553c-46ac-aae2-40a58c0973fd)|![Simulator Screenshot - iPhone 16 Pro - 2025-03-05 at 16 00 59](https://github.com/user-attachments/assets/b8a19022-7721-48f9-977e-65b5ca697919)


