### PR TITLE
refactor: introduce RootView

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,15 +1,12 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from '@sentry/react-native';
-import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
-import React, { useCallback, useEffect, useRef } from 'react';
-import { AppState, StyleSheet } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import { MainApp } from './src';
 import { auth } from './src/auth';
-import { fontConfig, namespace, secrets } from './src/config';
-import { SUE_REPORT_VALUES } from './src/screens';
+import { namespace, secrets } from './src/config';
 
 const sentryApi = secrets[namespace]?.sentryApi;
 
@@ -26,7 +23,6 @@ SplashScreen.preventAutoHideAsync();
 
 const App = () => {
   const appState = useRef(AppState.currentState);
-  const [isFontLoaded] = useFonts(fontConfig);
 
   useEffect(() => {
     // runs auth() if app returns from background or inactive to foreground
@@ -43,33 +39,11 @@ const App = () => {
     };
   }, []);
 
-  const onLayoutRootView = useCallback(async () => {
-    if (isFontLoaded) {
-      // when the application is closed and reopened, the saved data in the sue report form is deleted
-      await AsyncStorage.removeItem(SUE_REPORT_VALUES);
-
-      // This tells the splash screen to hide immediately! If we call this after
-      // `isFontLoaded`, then we may see a blank screen while the app is
-      // loading its initial state and rendering its first pixels. So instead,
-      // we hide the splash screen once we know the root view has already
-      // performed layout.
-      await SplashScreen.hideAsync();
-    }
-  }, [isFontLoaded]);
-
-  if (!isFontLoaded) return null;
-
   return (
-    <GestureHandlerRootView style={styles.flex} onLayout={onLayoutRootView}>
+    <GestureHandlerRootView>
       <MainApp />
     </GestureHandlerRootView>
   );
 };
 
 export default Sentry.wrap(App);
-
-const styles = StyleSheet.create({
-  flex: {
-    flex: 1
-  }
-});

--- a/src/RootView.tsx
+++ b/src/RootView.tsx
@@ -1,0 +1,42 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useFonts } from 'expo-font';
+import * as SplashScreen from 'expo-splash-screen';
+import React, { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { fontConfig } from './config';
+import { SUE_REPORT_VALUES } from './screens';
+
+const RootView = ({ children }: { children: React.ReactNode }) => {
+  const [isFontLoaded] = useFonts(fontConfig);
+
+  const onLayoutRootView = useCallback(async () => {
+    if (isFontLoaded) {
+      // when the application is closed and reopened, the saved data in the sue report form is deleted
+      await AsyncStorage.removeItem(SUE_REPORT_VALUES);
+
+      // This tells the splash screen to hide immediately! If we call this after
+      // `isFontLoaded`, then we may see a blank screen while the app is
+      // loading its initial state and rendering its first pixels. So instead,
+      // we hide the splash screen once we know the root view has already
+      // performed layout.
+      await SplashScreen.hideAsync();
+    }
+  }, [isFontLoaded]);
+
+  if (!isFontLoaded) return null;
+
+  return (
+    <View style={styles.flex} onLayout={onLayoutRootView}>
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1
+  }
+});
+
+export default RootView;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,6 @@ import * as SecureStore from 'expo-secure-store';
 import _isEmpty from 'lodash/isEmpty';
 import React, { useContext, useEffect, useState } from 'react';
 import { ApolloProvider } from 'react-apollo';
-import { ActivityIndicator } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import appJson from '../app.json';
@@ -17,8 +16,7 @@ import appJson from '../app.json';
 import { AccessibilityProvider } from './AccessibilityProvider';
 import { auth } from './auth';
 import { BookmarkProvider } from './BookmarkProvider';
-import { LoadingContainer } from './components';
-import { colors, consts, namespace, secrets } from './config';
+import { consts, namespace, secrets } from './config';
 import { ConfigurationsProvider } from './ConfigurationsProvider';
 import {
   geoLocationToLocationObject,
@@ -35,6 +33,7 @@ import { PermanentFilterProvider } from './PermanentFilterProvider';
 import { ProfileProvider } from './ProfileProvider';
 import { getQuery, QUERY_TYPES } from './queries';
 import { ReactQueryProvider } from './ReactQueryProvider';
+import RootView from './RootView';
 import { initialContext, SettingsProvider } from './SettingsProvider';
 import { UnreadMessagesProvider } from './UnreadMessagesProvider';
 
@@ -201,13 +200,7 @@ const MainAppWithApolloProvider = () => {
     !!isMainserverUp && prepare();
   }, [isMainserverUp]);
 
-  if (loading || !client) {
-    return (
-      <LoadingContainer>
-        <ActivityIndicator color={colors.refreshControl} />
-      </LoadingContainer>
-    );
-  }
+  if (loading || !client) return null;
 
   if (initialGlobalSettings.imageAspectRatio) {
     consts.IMAGE_ASPECT_RATIO = parsedImageAspectRatio(initialGlobalSettings.imageAspectRatio);
@@ -227,7 +220,9 @@ const MainAppWithApolloProvider = () => {
           <OnboardingManager>
             <ProfileProvider>
               <UnreadMessagesProvider>
-                <Navigator navigationType={initialGlobalSettings.navigation} />
+                <RootView>
+                  <Navigator navigationType={initialGlobalSettings.navigation} />
+                </RootView>
               </UnreadMessagesProvider>
             </ProfileProvider>
           </OnboardingManager>


### PR DESCRIPTION
- removed props from GestureHandlerRootView as it is not intended to be handled as root view for renderings
- created a new RootView component to handle the initial font loading and splash screen hiding
- integrated RootView into the main application structure after provider and contexts before first rendering, to be in place where first needed
  - this way it could be a positive side effect, that the splash screen is visible for a longer time, as things will be setup first now