### PR TITLE
fix(opening times): check more explicitly to catch edge cases

### DIFF
--- a/src/components/screens/OpeningTimesCard.js
+++ b/src/components/screens/OpeningTimesCard.js
@@ -66,7 +66,7 @@ export const OpeningTimesCard = ({
 
               {(!!timeFrom || !!timeTo || !!dateFrom || !!dateTo) && (
                 <WrapperRow>
-                  {(open === undefined || open === true) && (!!timeFrom || !!timeTo) && (
+                  {open !== false && (!!timeFrom || !!timeTo) && (
                     <TimeBox>
                       {!!timeFrom && <RegularText>{timeFrom}</RegularText>}
                       {!!timeFrom && !!timeTo && timeFrom !== timeTo && (


### PR DESCRIPTION
- there were `open: null`s we did not catch for opening hours so we simplified the logic to check for "not open" instead of listing different cases that can mean "not open"