### PR TITLE
fix(weather): adjust temperature display logic and styles

### DIFF
--- a/src/components/weather/DailyWeather.tsx
+++ b/src/components/weather/DailyWeather.tsx
@@ -42,18 +42,18 @@ export const DailyWeather = ({ date, description, icon, temperatures, index }: P
           resizeMode="contain"
         />
         <WrapperRow>
-          <WrapperRow>
+          <WrapperRow style={styles.temperatureContainer} itemsCenter>
             <Icon.MinTemperature color={colors.darkText} />
             <RegularText>
-              {min < 10 ? ' ' : ''}
+              {min < 9.5 ? ' ' : ''}
               {min.toFixed(0)}°
             </RegularText>
           </WrapperRow>
           <View style={styles.marginHorizontal} />
-          <WrapperRow>
+          <WrapperRow style={styles.temperatureContainer} itemsCenter>
             <Icon.MaxTemperature color={colors.darkText} />
             <RegularText>
-              {max < 10 ? ' ' : ''}
+              {max < 9.5 ? ' ' : ''}
               {max.toFixed(0)}°
             </RegularText>
           </WrapperRow>
@@ -70,6 +70,9 @@ const styles = StyleSheet.create({
   icon: {
     aspectRatio: 1,
     width: normalize(44)
+  },
+  temperatureContainer: {
+    width: normalize(50)
   },
   textWrapper: {
     width: normalize(70)


### PR DESCRIPTION
- updated control to less than 9.5 to remove the unnecessary gap caused by values above 9.50 being completed to 10
- added standard width to fix the problem of items not being sorted properly on the daily weather section
- added `itemsCenter` prop to center items horizontally in `WrapperRow`

The background color of the weather section has been set to red to better show the difference

|before|after|
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-19 at 10 38 03](https://github.com/user-attachments/assets/9ee91a4d-0474-4c0f-afce-4ad01554a46d)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-19 at 10 38 16](https://github.com/user-attachments/assets/4e3ee29d-fc2e-4c83-9c88-5d866d82ab48)
