### PR TITLE
feat(onboarding): add 'skip' option to app intro

### DIFF
--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -8,9 +8,40 @@ import { useOpenWebScreen } from '../hooks';
 import { OrientationContext } from '../OrientationProvider';
 
 import { BoldText, RegularText } from './Text';
-import { WrapperHorizontal, WrapperRow } from './Wrapper';
+import { WrapperHorizontal } from './Wrapper';
 
 const { a11yLabel } = consts;
+
+const renderTitleContent = ({
+  boldTitle,
+  lightest,
+  link,
+  linkDescription,
+  navigate,
+  openWebScreen,
+  title
+}) => {
+  const TextComponent = boldTitle ? BoldText : RegularText;
+
+  return (
+    <WrapperHorizontal>
+      <TextComponent small lightest={lightest}>
+        {title}
+        {(!!link || !!navigate) && !!linkDescription && (
+          <RegularText
+            small
+            primary
+            underline
+            onPress={link ? openWebScreen : navigate}
+            style={{ flexShrink: 1 }}
+          >
+            {linkDescription}
+          </RegularText>
+        )}
+      </TextComponent>
+    </WrapperHorizontal>
+  );
+};
 
 // eslint-disable-next-line complexity
 export const Checkbox = ({
@@ -50,26 +81,15 @@ export const Checkbox = ({
       }
       size={normalize(21)}
       center={center}
-      title={
-        <WrapperHorizontal>
-          <WrapperRow>
-            {boldTitle ? (
-              <BoldText small lightest={lightest}>
-                {title}
-              </BoldText>
-            ) : (
-              <RegularText small lightest={lightest}>
-                {title}
-              </RegularText>
-            )}
-            {(!!link || !!navigate) && !!linkDescription && (
-              <RegularText small primary underline onPress={link ? openWebScreen : navigate}>
-                {linkDescription}
-              </RegularText>
-            )}
-          </WrapperRow>
-        </WrapperHorizontal>
-      }
+      title={renderTitleContent({
+        boldTitle,
+        lightest,
+        link,
+        linkDescription,
+        navigate,
+        openWebScreen,
+        title
+      })}
       onPress={onPress}
       checkedIcon={checkedIcon}
       checked={checked}

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -28,7 +28,8 @@ export const texts = {
     }
   },
   appIntro: {
-    continue: 'Weiter'
+    continue: 'Weiter',
+    skip: 'Überspringen'
   },
   augmentedReality: {
     arInfoScreen: {


### PR DESCRIPTION
- added `backgroundColor` prop to update the background color of onboarding
- updated the `renderSlider` function to show the incoming order of content
- added `handleSkip` to redirect to that slide if there is `termsAndConditions` checkbox when skip button is pressed
- added `handleSlideChange` to show alert with next button if there is `termsAndConditions` checkbox
- added `bottomButton` prop to style and `AppIntroSlider` component to show next and skip buttons above the dots
- updated text file to show on skip button

SVA-1577


|before|after|before|after|before|after|
|--|--|--|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-21 at 13 02 42](https://github.com/user-attachments/assets/ec68a8d7-90dc-4748-94ec-844415f0a997)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-21 at 13 01 33](https://github.com/user-attachments/assets/ea75b237-7dc9-4f11-96b9-0b351ab07c4f)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-21 at 13 02 44](https://github.com/user-attachments/assets/08d2c6e0-9e85-4d08-b06b-21e0681d2cfc)|![image](https://github.com/user-attachments/assets/200ee969-24a0-400f-99ee-de4434964d77)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-21 at 13 02 47](https://github.com/user-attachments/assets/de994eac-081d-41be-aef5-6c491d8a1e35)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-21 at 13 02 16](https://github.com/user-attachments/assets/3fa07635-9a46-437c-a18c-dd5aecdc7c4e)
