### PR TITLE
fix(TextListItem): update `borderRadius` and enhance `renderItem` functionality

### DIFF
--- a/src/components/TextListItem.tsx
+++ b/src/components/TextListItem.tsx
@@ -153,7 +153,7 @@ export const TextListItem: NamedExoticComponent<Props> & {
                 imageStyle,
                 withCard && styles.withBigCardStyle
               ]}
-              borderRadius={withCard ? normalize(8) : undefined}
+              borderRadius={normalize(8)}
               containerStyle={[styles.smallImageContainer, imageContainerStyle]}
             />
           ) : undefined)}

--- a/src/hooks/listHooks.js
+++ b/src/hooks/listHooks.js
@@ -108,9 +108,13 @@ export const useRenderItem = (query, navigation, options = {}) => {
 
   switch (listType) {
     case LIST_TYPES.CARD_LIST: {
-      renderItem = ({ item, index }) => {
+      renderItem = ({ item, index, section, target }) => {
         if (query === QUERY_TYPES.EVENT_RECORDS && typeof item === 'string') {
-          return <EventSectionHeader {...{ item, navigation, options, query }} />;
+          return (
+            <View style={target == 'StickyHeader' ? styles.eventStickyHeader : styles.eventHeader}>
+              <EventSectionHeader {...{ item, navigation, options, query }} />
+            </View>
+          );
         }
 
         return (
@@ -126,9 +130,13 @@ export const useRenderItem = (query, navigation, options = {}) => {
       break;
     }
     case LIST_TYPES.CARD_TEXT_LIST: {
-      renderItem = ({ item, index, section }) => {
+      renderItem = ({ item, index, section, target }) => {
         if (query === QUERY_TYPES.EVENT_RECORDS && typeof item === 'string') {
-          return <EventSectionHeader {...{ item, navigation, options, query }} />;
+          return (
+            <View style={target == 'StickyHeader' ? styles.eventStickyHeader : styles.eventHeader}>
+              <EventSectionHeader {...{ item, navigation, options, query }} />
+            </View>
+          );
         }
 
         // in special lists such as `EventList`, since the data starts from the 1st index,
@@ -196,9 +204,13 @@ export const useRenderItem = (query, navigation, options = {}) => {
       break;
     }
     case LIST_TYPES.IMAGE_TEXT_LIST: {
-      renderItem = ({ item, index, section }) => {
+      renderItem = ({ item, index, section, target }) => {
         if (query === QUERY_TYPES.EVENT_RECORDS && typeof item === 'string') {
-          return <EventSectionHeader {...{ item, navigation, options, query }} />;
+          return (
+            <View style={target == 'StickyHeader' ? styles.eventStickyHeader : styles.eventHeader}>
+              <EventSectionHeader {...{ item, navigation, options, query }} />
+            </View>
+          );
         }
 
         return (
@@ -273,7 +285,7 @@ export const useRenderItem = (query, navigation, options = {}) => {
         // `SectionHeader` list item for `EventList`
         if (query === QUERY_TYPES.EVENT_RECORDS && typeof item === 'string') {
           return (
-            <View style={target == 'StickyHeader' ? styes.eventStickyHeader : styes.eventHeader}>
+            <View style={target == 'StickyHeader' ? styles.eventStickyHeader : styles.eventHeader}>
               <EventSectionHeader {...{ item, navigation, options, query }} />
             </View>
           );
@@ -378,7 +390,7 @@ export const useGroupedData = (query, data, groupKey) => {
   }
 };
 
-const styes = StyleSheet.create({
+const styles = StyleSheet.create({
   eventHeader: {
     marginLeft: -normalize(16),
     marginRight: -normalize(16)


### PR DESCRIPTION
This PR solves the problem of padding the date header from the left in different list types and adds a `borderRadius` to the image in the `IMAGE_TEXT_LIST` list type

SVASD-162


|before|after|
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-27 at 08 59 58](https://github.com/user-attachments/assets/832174dc-315a-4e05-8177-3e8ea02e9c0f)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-27 at 08 59 32](https://github.com/user-attachments/assets/382b9703-efbc-4532-841b-449f023b3ffc)
