### PR TITLE
feat(tabbar): add the ability to use different icons when tabbar is active

### DIFF
--- a/src/config/navigation/tabConfig.tsx
+++ b/src/config/navigation/tabConfig.tsx
@@ -124,6 +124,7 @@ export const createDynamicTabConfig = (
   label: string,
   totalCount: number,
   screen: ScreenName,
+  activeIconName?: keyof typeof Icon,
   iconLandscapeStyle?: ViewStyle,
   iconStyle?: ViewStyle,
   initialParams?: Record<string, any>,
@@ -142,11 +143,15 @@ export const createDynamicTabConfig = (
     tabBarAccessibilityLabel: `${accessibilityLabel || label} (Tab ${index + 1} von ${totalCount})`,
     tabBarLabel: label,
     tabBarLabelStyle,
-    tabBarIcon: ({ color }: TabBarIconProps) => (
+    tabBarIcon: ({ color, focused }: TabBarIconProps) => (
       <OrientationAwareIcon
         color={color}
-        Icon={Icon[iconName as keyof typeof Icon]}
-        iconName={iconName}
+        Icon={
+          !!activeIconName && focused
+            ? Icon[activeIconName as keyof typeof Icon]
+            : Icon[iconName as keyof typeof Icon]
+        }
+        iconName={!!activeIconName && focused ? activeIconName : iconName}
         landscapeStyle={iconLandscapeStyle}
         size={normalize(iconSize)}
         strokeColor={strokeColor}

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -49,6 +49,7 @@ export const useTabRoutes = () => {
                 tabConfig.label,
                 tabConfigs.length,
                 tabConfig.screen,
+                tabConfig.activeIconName,
                 tabConfig.iconLandscapeStyle,
                 tabConfig.iconStyle,
                 tabConfig.params,

--- a/src/types/Navigation.ts
+++ b/src/types/Navigation.ts
@@ -137,6 +137,7 @@ export type StackConfig = {
 
 export type CustomTab = {
   accessibilityLabel: string;
+  activeIconName?: keyof typeof Icon;
   iconLandscapeStyle?: ViewStyle;
   iconName: keyof typeof Icon;
   iconSize?: number;


### PR DESCRIPTION
- added `activeIconName` to add the option to use a different icon when the tabbar is active

SVA-1555

In the screenshots, the active and deactive icon of the 3rd icon from the right is activated. It can be seen that the icon changes when Tab is selected.

|||
|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-28 at 10 58 22](https://github.com/user-attachments/assets/9ecfafb2-ab73-43e6-b09d-d994157c727f)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-28 at 11 00 11](https://github.com/user-attachments/assets/d9399de6-ef04-4699-8680-ea7e889fbe01)

