### PR TITLE
feat(waste): add note for waste

### DIFF
--- a/src/components/waste/WasteCollectionListItem.tsx
+++ b/src/components/waste/WasteCollectionListItem.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Divider } from 'react-native-elements';
+import { Divider, Tooltip } from 'react-native-elements';
 
-import { colors, normalize } from '../../config';
+import { colors, device, Icon, normalize } from '../../config';
 import { momentFormat } from '../../helpers';
 import { HeadlineText, RegularText } from '../Text';
 import { Wrapper, WrapperHorizontal, WrapperRow } from '../Wrapper';
@@ -37,7 +37,19 @@ export const WasteCollectionListItem = ({ item: groupedItem, options }) => {
                           {usedTypes[typeKey].color !== usedTypes[typeKey].selected_color && (
                             <Dot color={usedTypes[typeKey].selected_color} />
                           )}
-                          <RegularText> {usedTypes[typeKey].label}</RegularText>
+                          <RegularText> {usedTypes[typeKey].label} </RegularText>
+                          {item.note && (
+                            <Tooltip
+                              backgroundColor={colors.darkText}
+                              containerStyle={{ height: 'auto' }}
+                              overlayColor={colors.shadowRgba}
+                              popover={<RegularText lightest>{item.note}</RegularText>}
+                              withOverlay={device.platform === 'android'}
+                              withPointer
+                            >
+                              <Icon.Info size={normalize(15)} />
+                            </Tooltip>
+                          )}
                         </WrapperRow>
                       </View>
                     )

--- a/src/helpers/parser/listItemParser.js
+++ b/src/helpers/parser/listItemParser.js
@@ -283,6 +283,7 @@ const parseWasteData = (data) => {
   return Object.entries(data).map(([listDate, value]) => ({
     listDate,
     dots: value.dots || [],
+    note: value.note || '',
     title: listDate
   }));
 };

--- a/src/hooks/waste.tsx
+++ b/src/hooks/waste.tsx
@@ -100,10 +100,11 @@ export const useWasteMarkedDates = ({ streetData, selectedTypes }) =>
         }
 
         const { color, selected_color: selectedColor } = selectedTypes[wasteLocationType.wasteType];
-        wasteLocationType?.listPickUpDates?.forEach((date) => {
-          dates[date] = {
+        wasteLocationType?.pickUpTimes?.forEach((date) => {
+          dates[date.pickupDate] = {
             marked: true,
-            dots: [...(dates[date]?.dots ?? []), { color, selectedColor }]
+            note: date.note,
+            dots: [...(dates[date.pickupDate]?.dots ?? []), { color, selectedColor }]
           };
         });
       });

--- a/src/queries/waste.js
+++ b/src/queries/waste.js
@@ -22,6 +22,11 @@ export const WASTE_STREET = gql`
         wasteType
         id
         listPickUpDates
+        pickUpTimes {
+          id
+          note
+          pickupDate
+        }
       }
     }
   }


### PR DESCRIPTION
- updated query to add note feature for waste calendar
- used `pickUpTimes` instead of `listPickUpDates` for the data in the `useWasteMarkedDates` hook to show the notes in the list
- added `Tooltip` component to show if there is a note for a date

SVA-1510

|before|after|after|
|--|--|--|
![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-03 at 11 26 46](https://github.com/user-attachments/assets/5a244255-02aa-4d7d-91b0-0efe2fb8589a)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-03 at 11 26 29](https://github.com/user-attachments/assets/a3b7f8b3-514a-43c2-9276-3fcb0784735c)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-03 at 11 26 31](https://github.com/user-attachments/assets/61b683c7-cc21-4573-9f7a-73dc4228a557)

