### PR TITLE
fix(OParlPersonsScreen): correct loading condition for spinner

### DIFF
--- a/src/screens/OParl/OParlPersonsScreen.tsx
+++ b/src/screens/OParl/OParlPersonsScreen.tsx
@@ -153,7 +153,7 @@ export const OParlPersonsScreen = ({ navigation }: Props) => {
     setFetchingMore(false);
   };
 
-  if (orgaListLoading) {
+  if (orgaListLoading || personLoading) {
     return <LoadingSpinner loading />;
   }
 


### PR DESCRIPTION
- updated loading condition to include `personLoading`
- ensures spinner displays correctly during data fetching

SVA-1613
