### PR TITLE
fix(helpers): replace `uuid` import with `expo-crypto`'s `randomUUID`

### DIFF
--- a/src/components/vouchers/VoucherRedeem.tsx
+++ b/src/components/vouchers/VoucherRedeem.tsx
@@ -1,4 +1,4 @@
-import * as Crypto from 'expo-crypto';
+import { randomUUID as uuid } from 'expo-crypto';
 import React, { useEffect, useState } from 'react';
 import { useMutation } from 'react-apollo';
 import { Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
@@ -84,7 +84,7 @@ export const VoucherRedeem = ({ quota, voucherId }: { quota: TQuota; voucherId: 
     let deviceToken = await readFromStore(VOUCHER_DEVICE_TOKEN);
 
     if (!deviceToken) {
-      deviceToken = Crypto.randomUUID();
+      deviceToken = uuid();
       addToStore(VOUCHER_DEVICE_TOKEN, deviceToken);
     }
 

--- a/src/helpers/matomoHelper.js
+++ b/src/helpers/matomoHelper.js
@@ -1,5 +1,5 @@
+import { randomUUID as uuid } from 'expo-crypto';
 import { Alert } from 'react-native';
-import { v4 as uuid } from 'uuid';
 
 import { texts } from '../config';
 import { storageHelper } from '../helpers/storageHelper';


### PR DESCRIPTION
- updated `uuid` import in `VoucherRedeem` and `matomoHelper` to use `expo-crypto`'s `randomUUID` for consistency
- improves code clarity and reduces dependency on external uuid library

SVASD-129
