### PR TITLE
fix: the problem of the effect of saving the image twice for android

### DIFF
--- a/src/hooks/imagePicker.ts
+++ b/src/hooks/imagePicker.ts
@@ -16,7 +16,7 @@ import { useCallback, useState } from 'react';
 import { Alert } from 'react-native';
 
 import appJson from '../../app.json';
-import { texts } from '../config';
+import { device, texts } from '../config';
 
 type TMediaTypeOptions = 'images' | 'videos' | Array<'images' | 'videos'>;
 
@@ -36,6 +36,9 @@ const saveImageToGallery = async (uri: string) => {
 
   try {
     const asset = await createAssetAsync(uri);
+
+    if (device.platform === 'android') return;
+
     const album = await getAlbumAsync(appName);
 
     if (!album) {


### PR DESCRIPTION
- added android control for android platform to fix the problem of the effect of saving the same image to the gallery twice when saved to both the camera album and the album created with the app name by referencing the same image

SUE-163