### PR TITLE
feat(oparl): add special agenda items sorting

### DIFF
--- a/src/components/oParl/Meeting.tsx
+++ b/src/components/oParl/Meeting.tsx
@@ -1,5 +1,4 @@
 import { StackNavigationProp } from '@react-navigation/stack';
-import { isNumber } from 'lodash';
 import React from 'react';
 
 import { texts } from '../../config';
@@ -7,6 +6,7 @@ import { MeetingData } from '../../types';
 import { BoldText } from '../Text';
 import { Wrapper, WrapperHorizontal, WrapperRow } from '../Wrapper';
 
+import { getSortedAgendaItems } from './oParlHelpers';
 import { FormattedLocation } from './previews';
 import { Row, SimpleRow } from './Row';
 import {
@@ -47,13 +47,7 @@ export const Meeting = ({ data, navigation }: Props) => {
     web
   } = data;
 
-  const sortedAgendaItems = agendaItem
-    ? [...agendaItem].sort((a, b) => {
-        if (isNumber(a.order) && isNumber(b.order)) return a.order - b.order;
-        return 0;
-      })
-    : undefined;
-
+  const sortedAgendaItems = getSortedAgendaItems(agendaItem);
   const formattedLocation = location && <FormattedLocation location={location} />;
 
   return (

--- a/src/components/oParl/oParlHelpers.ts
+++ b/src/components/oParl/oParlHelpers.ts
@@ -1,5 +1,5 @@
 import { texts } from '../../config';
-import { OrganizationPreviewData } from '../../types';
+import { AgendaItemPreviewData, OrganizationPreviewData } from '../../types';
 
 export const getOrganizationNameString = (organization?: OrganizationPreviewData) => {
   if (!organization) return texts.oparl.organization.organization;
@@ -7,4 +7,85 @@ export const getOrganizationNameString = (organization?: OrganizationPreviewData
   const { classification, name, shortName } = organization;
 
   return name || shortName || classification || texts.oparl.organization.organization;
+};
+
+export const getSortedAgendaItems = (agendaItems?: AgendaItemPreviewData[]) => {
+  if (!agendaItems) return;
+
+  const romanToInt = (romanNumber: string): number | null => {
+    const romanNumbers: Record<string, number> = {
+      I: 1,
+      V: 5,
+      X: 10,
+      L: 50,
+      C: 100,
+      D: 500,
+      M: 1000
+    };
+    let result = 0;
+    let previous = 0;
+
+    for (let i = romanNumber.length - 1; i >= 0; i--) {
+      const current = romanNumbers[romanNumber[i]];
+
+      if (!current) return null;
+
+      if (current < previous) {
+        result -= current;
+      } else {
+        result += current;
+      }
+
+      previous = current;
+    }
+
+    return result;
+  };
+
+  const isRoman = (value: string) =>
+    /^[IVXLCDM]+$/i.test(value) && romanToInt(value.toUpperCase()) !== null;
+
+  const parseParts = (number?: string | number): (number | null)[] => {
+    return String(number ?? '')
+      .split('.')
+      .map((n) => {
+        const parsed = parseInt(n, 10);
+
+        if (!isNaN(parsed)) return parsed;
+
+        const lower = n.toLowerCase();
+
+        if (/^[a-z]$/.test(lower)) {
+          return lower.charCodeAt(0) - 'a'.charCodeAt(0) + 1; // a → 1, b → 2, ...
+        }
+
+        return romanToInt(n.toUpperCase()) ?? null;
+      });
+  };
+
+  const [romanItems, otherItems] = (agendaItems ?? []).reduce(
+    ([romans, others], item) => {
+      const firstPart = String(item.number ?? '').split('.')[0];
+      return isRoman(firstPart) ? [[...romans, item], others] : [romans, [...others, item]];
+    },
+    [[], []] as [AgendaItemPreviewData[], AgendaItemPreviewData[]]
+  );
+
+  const sortFn = (a: AgendaItemPreviewData, b: AgendaItemPreviewData) => {
+    const aParts = parseParts(a.number);
+    const bParts = parseParts(b.number);
+
+    for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+      const aValue = aParts[i] ?? 0;
+      const bValue = bParts[i] ?? 0;
+
+      if (aValue !== bValue) {
+        return (aValue ?? 0) - (bValue ?? 0);
+      }
+    }
+
+    return 0;
+  };
+
+  return [...romanItems.sort(sortFn), ...otherItems.sort(sortFn)];
 };


### PR DESCRIPTION
- replaced failing inline sorting logic with a dedicated helper function for better readability and maintainability
- sort not just numbers, but roman numbers and things like "1.a, 1.b" as well
  - entries with roman numbers should always be listed first

|before|after|
|---|---|
|![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-17 at 10 44 41](https://github.com/user-attachments/assets/677f6fc6-f998-40fc-a541-90254fa52ef9)|![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-17 at 10 44 58](https://github.com/user-attachments/assets/5c33a292-40b8-423a-b685-c45e6c83befd)|

SVASD-151