### PR TITLE
feat(map): add pin to map

### DIFF
--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -174,6 +174,19 @@ export const MapLibre = ({
 
   const [centerCoordinate] = useState([initialRegion.longitude, initialRegion.latitude]);
 
+  const handleMapPressToSetNewPin = (event: any) => {
+    const { geometry } = event;
+    if (!geometry) return;
+
+    if (geometry.coordinates) {
+      const newPin = point(geometry.coordinates, {
+        iconName: MAP.DEFAULT_PIN, // TODO: find a proper default icon for setting a pin
+        id: `new-pin-${Date.now()}`
+      });
+      setNewPins([newPin]);
+    }
+  };
+
   const handleOnPress = async (event: any) => {
     const feature = event.features[0];
     if (!feature) return;
@@ -196,18 +209,6 @@ export const MapLibre = ({
     }
   };
 
-  const handleMapPress = (event: any) => {
-    const { geometry } = event;
-    if (geometry?.coordinates) {
-      const newPin = point(geometry.coordinates, {
-        iconName: MAP.DEFAULT_PIN,
-        id: `${Date.now()}`
-      });
-      setNewPins([newPin]);
-    }
-    onMapPress?.(event);
-  };
-
   if (loading) {
     return <LoadingSpinner loading />;
   }
@@ -222,7 +223,7 @@ export const MapLibre = ({
         rotateEnabled={false}
         style={[styles.map, mapStyle]}
         zoomEnabled
-        onPress={!!onMapPress && handleMapPress}
+        onPress={handleMapPressToSetNewPin}
         onDidFinishLoadingMap={() => setMapReady(true)}
       >
         <Camera
@@ -244,7 +245,7 @@ export const MapLibre = ({
         <Images images={markerImages} />
 
         <ShapeSource
-          id="benches"
+          id="pois"
           ref={shapeSourceRef}
           shape={featureCollection(
             locations?.map((location) =>
@@ -300,7 +301,7 @@ export const MapLibre = ({
 
         <ShapeSource id="new-pins" shape={featureCollection(newPins)}>
           <SymbolLayer
-            id="new-pin-icon"
+            id="pin-single-icon"
             style={{
               ...layerStyles.singleIcon,
               iconImage: ['get', 'iconName'],

--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -25,7 +25,7 @@ import { MapMarker } from '../../types';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { BoldText, RegularText } from '../Text';
 
-const { a11yLabel } = consts;
+const { a11yLabel, MAP } = consts;
 
 const CustomCallout = ({ feature }: { feature: GeoJSON.Feature }) => {
   const { properties = {} } = feature;
@@ -115,6 +115,7 @@ export const MapLibre = ({
   const [followsUserLocation, setFollowsUserLocation] = useState(false);
   const [selectedFeature, setSelectedFeature] = useState(null);
   const [mapReady, setMapReady] = useState(false);
+  const [newPins, setNewPins] = useState<GeoJSON.Feature[]>([]);
   const mapRef = useRef(null);
   const cameraRef = useRef(null);
   const shapeSourceRef = useRef<ShapeSourceRef>(null);
@@ -195,6 +196,18 @@ export const MapLibre = ({
     }
   };
 
+  const handleMapPress = (event: any) => {
+    const { geometry } = event;
+    if (geometry?.coordinates) {
+      const newPin = point(geometry.coordinates, {
+        iconName: MAP.DEFAULT_PIN,
+        id: `${Date.now()}`
+      });
+      setNewPins([newPin]);
+    }
+    onMapPress?.(event);
+  };
+
   if (loading) {
     return <LoadingSpinner loading />;
   }
@@ -209,6 +222,7 @@ export const MapLibre = ({
         rotateEnabled={false}
         style={[styles.map, mapStyle]}
         zoomEnabled
+        onPress={!!onMapPress && handleMapPress}
         onDidFinishLoadingMap={() => setMapReady(true)}
       >
         <Camera
@@ -280,6 +294,17 @@ export const MapLibre = ({
               ...layerStyles.clusterCount,
               textField: ['format', ['concat', ['get', 'point_count']]],
               textPitchAlignment: 'map'
+            }}
+          />
+        </ShapeSource>
+
+        <ShapeSource id="new-pins" shape={featureCollection(newPins)}>
+          <SymbolLayer
+            id="new-pin-icon"
+            style={{
+              ...layerStyles.singleIcon,
+              iconImage: ['get', 'iconName'],
+              iconSize: layerStyles.singleIcon.iconSize
             }}
           />
         </ShapeSource>


### PR DESCRIPTION
This PR adds the ability to add new pins to the map view in the Maplibre component

|without new pin|with new pin|with new pin without cluster|
|--|--|--|
![Simulator Screenshot - iPhone 16 Plus - 2025-04-23 at 15 12 16](https://github.com/user-attachments/assets/506a5526-b97d-4f5a-87b6-75bef8e871eb)|![Simulator Screenshot - iPhone 16 Plus - 2025-04-23 at 15 12 22](https://github.com/user-attachments/assets/0a234b5f-2bb5-41cd-84e6-a8f83103bbf2)|![Simulator Screenshot - iPhone 16 Plus - 2025-04-23 at 15 12 31](https://github.com/user-attachments/assets/91a8a7a2-cb5e-478b-a95e-cef2b35a3332)

SVA-1365