### PR TITLE
feat(map): add polyline attribute

### DIFF
--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -2,6 +2,7 @@ import {
   Camera,
   CircleLayer,
   Images,
+  LineLayer,
   MapView,
   MarkerView,
   ShapeSource,
@@ -297,6 +298,28 @@ export const MapLibre = ({
             }}
           />
         </ShapeSource>
+
+        {!!geometryTourData?.length && (
+          <ShapeSource
+            id="polyline"
+            shape={{
+              type: 'Feature',
+              geometry: {
+                type: 'LineString',
+                coordinates: geometryTourData.map((point) => [point.longitude, point.latitude])
+              }
+            }}
+          >
+            <LineLayer
+              id="polyline-layer"
+              style={{
+                lineColor: colors.primary,
+                lineWidth: 4,
+                lineOpacity: 0.8
+              }}
+            />
+          </ShapeSource>
+        )}
 
         <ShapeSource id="new-pins" shape={featureCollection(newPins)}>
           <SymbolLayer


### PR DESCRIPTION
This PR adds the polyline property to the maplibre component

to test: 

- Download the json data and add it to the `src/screens` folder
[geometryTourData.json](https://github.com/user-attachments/files/19871094/geometryTourData.json)
- Import this data into `MapScreen.tsx` and add it as a prop to the `MapLibre` component


![Simulator Screenshot - iPhone 16 Plus - 2025-04-23 at 16 38 45](https://github.com/user-attachments/assets/5c51d155-1738-4830-accc-ef76180d2fba)

SVA-1365
