### PR TITLE
feat(map): add the ability to show a different icon when selected

### DIFF
--- a/src/components/map/MapLibre.tsx
+++ b/src/components/map/MapLibre.tsx
@@ -269,7 +269,12 @@ export const MapLibre = ({
             filter={['!', ['has', 'point_count']]}
             style={{
               ...layerStyles.singleIcon,
-              iconImage: ['get', 'iconName'],
+              iconImage: [
+                'case',
+                ['==', ['get', 'id'], selectedMarker],
+                ['coalesce', ['get', 'activeIconName'], ['get', 'iconName']],
+                ['get', 'iconName']
+              ],
               iconSize: [
                 'case',
                 ['==', ['get', 'id'], selectedMarker],

--- a/src/screens/SUE/SueMapScreen.tsx
+++ b/src/screens/SUE/SueMapScreen.tsx
@@ -13,7 +13,7 @@ import {
   BoldText,
   Image,
   LoadingContainer,
-  Map,
+  MapLibre,
   RegularText,
   SafeAreaViewFlex,
   SueImageFallback,
@@ -52,23 +52,13 @@ type ItemProps = {
   title: string;
 };
 
-export const mapToMapMarkers = (
-  items: ItemProps[],
-  activeBackgroundColors: Record<string, string | undefined>,
-  activeIconColors: Record<string, string | undefined>,
-  backgroundColors: Record<string, string | undefined>,
-  iconColors: Record<string, string | undefined>
-): MapMarker[] | undefined =>
+export const mapToMapMarkers = (items: ItemProps[]): MapMarker[] | undefined =>
   items
     ?.filter((item) => item.lat && item.long)
     ?.map((item: ItemProps) => ({
       ...item,
-      activeBackgroundColor: activeBackgroundColors?.[item.status],
-      iconBackgroundColor: backgroundColors?.[item.status],
-      activeIconColor: activeIconColors?.[item.status],
-      iconColor: iconColors?.[item.status],
-      iconBorderColor: iconColors?.[item.status],
       iconName: `Sue${_upperFirst(item.iconName)}`,
+      activeIconName: `Sue${_upperFirst(item.iconName)}Active`,
       id: item.serviceRequestId,
       position: {
         latitude: item.lat,
@@ -90,8 +80,6 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
   const { globalSettings } = useContext(SettingsContext);
   const { navigation: navigationType, settings = {} } = globalSettings;
   const { locationService } = settings;
-  const { sueStatus = {} } = appDesignSystem;
-  const { mapPinColors = {} } = sueStatus;
   const { geoMap = {} } = sueConfig;
   const systemPermission = useSystemPermission();
   const { position } = usePosition(systemPermission?.status !== Location.PermissionStatus.GRANTED);
@@ -99,22 +87,10 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
     systemPermission?.status !== Location.PermissionStatus.GRANTED
   );
 
-  const {
-    activeBackgroundColors = {},
-    activeIconColors = {},
-    backgroundColors = {},
-    iconColors = {}
-  } = mapPinColors;
-
   const queryVariables = route.params?.queryVariables ?? {
     start_date: '1900-01-01T00:00:00+01:00'
   };
   const [selectedRequestId, setSelectedRequestId] = useState<string>();
-
-  const [currentPosition, setCurrentPosition] = useState<
-    Location.LocationObjectCoords | undefined
-  >();
-  const [updateRegion, setUpdatedRegion] = useState<boolean>(false);
 
   const { data, isLoading } = useQuery([QUERY_TYPES.SUE.LOCATION, queryVariables], () =>
     getQuery(QUERY_TYPES.SUE.LOCATION)(queryVariables)
@@ -125,11 +101,7 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
       mapToMapMarkers(
         parseListItemsFromQuery(QUERY_TYPES.SUE.REQUESTS_WITH_SERVICE_REQUEST_ID, data, undefined, {
           appDesignSystem
-        }),
-        activeBackgroundColors,
-        activeIconColors,
-        backgroundColors,
-        iconColors
+        })
       ),
     [data]
   );
@@ -169,21 +141,13 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
 
   return (
     <SafeAreaViewFlex>
-      <Map
+      <MapLibre
         clusterDistance={geoMap?.clusterDistance}
-        clusteringEnabled
         isMultipleMarkersMap
         isMyLocationButtonVisible={!!locationService}
         locations={mapMarkers}
         mapStyle={styles.map}
-        onMarkerPress={(id) => {
-          // reset selected request id to undefined to avoid rendering bug with images in overlay
-          setSelectedRequestId(undefined);
-
-          setTimeout(() => {
-            setSelectedRequestId(id);
-          }, 100);
-        }}
+        onMarkerPress={setSelectedRequestId}
         onMyLocationButtonPress={() => {
           const location = position || lastKnownPosition;
 
@@ -192,24 +156,8 @@ export const SueMapScreen = ({ navigation, route }: Props) => {
             locationServiceEnabled,
             navigation
           });
-
-          setUpdatedRegion(true);
-          setCurrentPosition(location?.coords);
-
-          setTimeout(() => {
-            setUpdatedRegion(false);
-          }, 100);
         }}
         selectedMarker={selectedRequestId}
-        updatedRegion={
-          !!currentPosition && updateRegion
-            ? {
-                ...currentPosition,
-                latitudeDelta: 0.01,
-                longitudeDelta: 0.01
-              }
-            : undefined
-        }
       />
       {!detailsLoading && !!selectedRequestId && !!item && (
         <View style={[styles.listItemContainer, stylesWithProps({ navigationType }).position]}>


### PR DESCRIPTION
This PR adds the ability to show active and inactive icons to the MapLibre component

|inactive pin|active pin|
|--|--|
![Simulator Screenshot - iPhone 16 Plus - 2025-04-23 at 18 58 40](https://github.com/user-attachments/assets/d684b71d-ce3e-406f-9e9b-ccf0d67f5f30)|![Simulator Screenshot - iPhone 16 Plus - 2025-04-23 at 18 58 37](https://github.com/user-attachments/assets/8f1b0420-2f45-4e07-9951-1b97894c0988)


SVA-1365