### PR TITLE
feat(live ticker): add live ticker feature to `HomeScreen`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     ]
   },
   "dependencies": {
+    "@animatereactnative/marquee": "^0.5.2",
     "@apollo/react-hooks": "~3.1.5",
     "@config-plugins/react-native-blob-util": "^9.0.0",
     "@config-plugins/react-native-pdf": "^9.0.0",

--- a/src/components/LiveTicker.tsx
+++ b/src/components/LiveTicker.tsx
@@ -2,6 +2,7 @@ import { Marquee } from '@animatereactnative/marquee';
 import React from 'react';
 import { StyleSheet, ViewStyle } from 'react-native';
 
+import { device } from '../config';
 import { useHomeRefresh, useStaticContent } from '../hooks';
 
 import { HtmlView } from './HtmlView';
@@ -10,18 +11,17 @@ type Props = {
   publicJsonFile: string;
 };
 
-interface DataItem {
+type DataItem = {
   liveTickerSettings: {
     direction?: 'horizontal' | 'vertical';
     reverse?: boolean;
     spacing?: number;
     speed?: number;
-    style?: ViewStyle;
+    style?: ViewStyle | ViewStyle[];
   };
   text: string;
-}
+};
 
-// eslint-disable-next-line complexity
 export const LiveTicker = ({ publicJsonFile }: Props) => {
   const { data, refetch } = useStaticContent<DataItem>({
     refreshTimeKey: `publicJsonFile-${publicJsonFile}`,
@@ -31,16 +31,10 @@ export const LiveTicker = ({ publicJsonFile }: Props) => {
 
   useHomeRefresh(refetch);
 
-  if (!data) return null;
+  if (!data?.text?.length) return null;
 
   const {
-    liveTickerSettings: {
-      direction = 'horizontal',
-      reverse = false,
-      spacing = 20,
-      speed = 1,
-      style
-    },
+    liveTickerSettings: { direction = '', reverse = false, spacing = 20, speed = 1, style },
     text
   } = data;
 
@@ -52,7 +46,7 @@ export const LiveTicker = ({ publicJsonFile }: Props) => {
       speed={speed}
       style={[styles.container, style]}
     >
-      <HtmlView html={text} />
+      <HtmlView html={`<div style="padding-left: ${device.width / 2}px">${text}</div>`} />
     </Marquee>
   );
 };

--- a/src/components/LiveTicker.tsx
+++ b/src/components/LiveTicker.tsx
@@ -1,0 +1,64 @@
+import { Marquee } from '@animatereactnative/marquee';
+import React from 'react';
+import { StyleSheet, ViewStyle } from 'react-native';
+
+import { useHomeRefresh, useStaticContent } from '../hooks';
+
+import { HtmlView } from './HtmlView';
+
+type Props = {
+  publicJsonFile: string;
+};
+
+interface DataItem {
+  liveTickerSettings: {
+    direction?: 'horizontal' | 'vertical';
+    reverse?: boolean;
+    spacing?: number;
+    speed?: number;
+    style?: ViewStyle;
+  };
+  text: string;
+}
+
+// eslint-disable-next-line complexity
+export const LiveTicker = ({ publicJsonFile }: Props) => {
+  const { data, refetch } = useStaticContent<DataItem>({
+    refreshTimeKey: `publicJsonFile-${publicJsonFile}`,
+    name: publicJsonFile,
+    type: 'json'
+  });
+
+  useHomeRefresh(refetch);
+
+  if (!data) return null;
+
+  const {
+    liveTickerSettings: {
+      direction = 'horizontal',
+      reverse = false,
+      spacing = 20,
+      speed = 1,
+      style
+    },
+    text
+  } = data;
+
+  return (
+    <Marquee
+      direction={direction}
+      reverse={reverse}
+      spacing={spacing}
+      speed={speed}
+      style={[styles.container, style]}
+    >
+      <HtmlView html={text} />
+    </Marquee>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    overflow: 'hidden'
+  }
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -72,6 +72,7 @@ export * from './Link';
 export * from './ListComponent';
 export * from './ListSettingsItem';
 export * from './ListSwitchItem';
+export * from './LiveTicker';
 export * from './LoadingContainer';
 export * from './LoadingModal';
 export * from './LoadingSpinner';

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -300,6 +300,8 @@ export const HomeScreen = ({ navigation, route }) => {
         data={data}
         ListHeaderComponent={
           <>
+            <LiveTicker publicJsonFile="homeLiveTicker" />
+
             <ConnectedImagesCarousel
               navigation={navigation}
               publicJsonFile="homeCarousel"
@@ -307,8 +309,6 @@ export const HomeScreen = ({ navigation, route }) => {
             />
 
             <Widgets widgetConfigs={widgetConfigs} />
-
-            <LiveTicker publicJsonFile="homeLiveTicker" />
 
             <Disturber navigation={navigation} publicJsonFile="homeDisturber" />
           </>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -11,6 +11,7 @@ import {
   Disturber,
   HomeSection,
   HomeService,
+  LiveTicker,
   NewsSectionPlaceholder,
   SafeAreaViewFlex,
   Widgets
@@ -304,6 +305,8 @@ export const HomeScreen = ({ navigation, route }) => {
               publicJsonFile="homeCarousel"
               refreshTimeKey="publicJsonFile-homeCarousel"
             />
+
+            <LiveTicker publicJsonFile="homeLiveTicker" />
 
             <Widgets widgetConfigs={widgetConfigs} />
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -306,9 +306,9 @@ export const HomeScreen = ({ navigation, route }) => {
               refreshTimeKey="publicJsonFile-homeCarousel"
             />
 
-            <LiveTicker publicJsonFile="homeLiveTicker" />
-
             <Widgets widgetConfigs={widgetConfigs} />
+
+            <LiveTicker publicJsonFile="homeLiveTicker" />
 
             <Disturber navigation={navigation} publicJsonFile="homeDisturber" />
           </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,11 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@animatereactnative/marquee@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@animatereactnative/marquee/-/marquee-0.5.2.tgz#cf97fb474823db66112e0a3869e27e9a37264196"
+  integrity sha512-8VzfT1zc72aiwgL0NrvchgzVEIGVwVnjp93a/nSmw4vLRyhXh/8GSC/e23nJMGps7dxHeU7UrBMJoN2+Z5sYHg==
+
 "@apollo/react-common@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.4.tgz#ec13c985be23ea8e799c9ea18e696eccc97be345"


### PR DESCRIPTION
With this PR, a live ticker feature is added to the HomeScreen that can be updated via the main-server.

To activate this feature on the HomeScreen, create a json static content named `homeLiveTicker` on main-server
`homeLiveTicker` static content can be as follows

```
{
  "text": "Smart Village App ❤️",
  "liveTickerSettings": {
    "speed": 0.5,
    "style": {
      "backgroundColor": "#E5BFF7",
      "paddingVertical": 20
    }
  }
}
```

<img src="https://github.com/user-attachments/assets/ef401487-304c-455c-940f-167bb37b3801" width="300" />

SVAK-142