### PR TITLE
fix: app push switcher is always on

### DIFF
--- a/src/pushNotifications/PermissionHandling.ts
+++ b/src/pushNotifications/PermissionHandling.ts
@@ -81,7 +81,7 @@ export const handleSystemPermissions = async (
 
   const isGranted = finalStatus === PermissionStatus.GRANTED;
 
-  if (shouldSetInAppPermission) {
+  if (shouldSetInAppPermission && inAppPermission == null) {
     try {
       const successfullyHandledInAppPermission = await setInAppPermission(isGranted);
 


### PR DESCRIPTION
This PR fixes the issue where the push switcher appears on when you close and open the app after turning off the push settings in the app.

The problem was solved by adding inAppPermission control.

As viewed by the user:

- User opens the app and allows push notifications
- Then the user who doesn't want push notifications goes to settings and turns off push permissions
- After closing and reopening the app, the Async Storage value that we saved for push notifications will be updated with true again since there is no `inAppPermisson` control because we did not close the permission in the operating system, we only closed the push permission in the app.

SVA-1619