### PR TITLE
feat(service): add `isLastRow` prop to `ServiceTile` and update rendering logic

### DIFF
--- a/src/components/screens/Service.tsx
+++ b/src/components/screens/Service.tsx
@@ -80,12 +80,13 @@ export const Service = ({
     [isEditMode, hasDiagonalGradientBackground]
   );
   const renderItem = useCallback(
-    (item: TServiceTile, index: number) => (
+    (item: TServiceTile, index: number, isLastRow?: boolean) => (
       <ServiceTile
         draggableId={umlautSwitcher(item.title) || umlautSwitcher(item.accessibilityLabel)}
         draggableKey={`item${item.title || item.accessibilityLabel}-index${index}`}
         hasDiagonalGradientBackground={hasDiagonalGradientBackground}
         isEditMode={isEditMode}
+        isLastRow={isLastRow}
         item={item}
         key={`item${item.title || item.accessibilityLabel}-index${index}`}
         onToggleVisibility={onToggleVisibility}
@@ -132,14 +133,15 @@ export const Service = ({
         const isLastRow = rows[rows.length - 1] === row;
         const isIncompleteRow = row.length < itemsPerRow;
         const rowKey = row.map((tile) => tile.title || tile.accessibilityLabel);
+        const isLastAndIncompleteRow = isLastRow && isIncompleteRow;
 
         return (
           <WrapperWrap
             key={rowKey}
-            spaceAround={isLastRow && isIncompleteRow}
-            spaceBetween={!isLastRow || !isIncompleteRow}
+            center={isLastAndIncompleteRow}
+            spaceBetween={!isLastAndIncompleteRow}
           >
-            {row.map(renderItem)}
+            {row.map((item, index) => renderItem(item, index, isLastAndIncompleteRow))}
           </WrapperWrap>
         );
       })}

--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -58,14 +58,16 @@ export const ServiceTile = ({
   draggableId,
   hasDiagonalGradientBackground = false,
   isEditMode = false,
+  isLastRow = false,
   item,
   onToggleVisibility,
-  tileSizeFactor = 1,
-  serviceTiles
+  serviceTiles,
+  tileSizeFactor = 1
 }: {
   draggableId: string;
   hasDiagonalGradientBackground?: boolean;
   isEditMode?: boolean;
+  isLastRow?: boolean;
   item: TServiceTile;
   onToggleVisibility: (
     toggleableId: string,
@@ -114,7 +116,7 @@ export const ServiceTile = ({
       dimensions={dimensions}
       numberOfTiles={item?.numberOfTiles}
       orientation={orientation}
-      style={normalizedTileStyle}
+      style={[normalizedTileStyle, isLastRow && styles.marginLeft]}
     >
       <TouchableOpacity
         style={[hasTileStyle && styles.button]}
@@ -211,6 +213,9 @@ const styles = StyleSheet.create({
     height: '100%',
     justifyContent: 'center',
     width: '100%'
+  },
+  marginLeft: {
+    marginLeft: normalize(8)
   },
   serviceIcon: {
     alignSelf: 'center',


### PR DESCRIPTION
This PR ensures that the tiles in the last row are centered.

|before|after|
|--|--|
![Simulator Screenshot - iPhone 16 Plus - 2025-06-20 at 15 42 10](https://github.com/user-attachments/assets/e81b28d0-5abd-41ae-9a9e-5c17ee938599)|![Simulator Screenshot - iPhone 16 Plus - 2025-06-20 at 15 40 40](https://github.com/user-attachments/assets/1f040a39-d31f-4409-b487-8e62893e9bf7)

EP-71
