### PR TITLE
feat(settings): make list titles on the settings screen remotely upda…

### DIFF
--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -53,17 +53,19 @@ export const SETTINGS_SCREENS = {
   PERMANENT_FILTER: 'permanentFilterSettings'
 };
 
-const renderItem = ({ item, navigation, listsWithoutArrows }) => {
+/* eslint-disable complexity */
+const renderItem = ({ item, navigation, listsWithoutArrows, settingsScreenListItemTitles }) => {
   let component;
+  const title = settingsScreenListItemTitles[item];
 
   if (item === SETTINGS_SCREENS.LOCATION) {
     component = (
       <TextListItem
         item={{
           isHeadlineTitle: false,
-          params: { setting: item, title: texts.settingsContents.locationService.setting },
+          params: { setting: item, title: title || texts.settingsContents.locationService.setting },
           routeName: ScreenName.Settings,
-          title: texts.settingsContents.locationService.setting,
+          title: title || texts.settingsContents.locationService.setting,
           topDivider: true
         }}
         listsWithoutArrows={listsWithoutArrows}
@@ -75,9 +77,9 @@ const renderItem = ({ item, navigation, listsWithoutArrows }) => {
       <TextListItem
         item={{
           isHeadlineTitle: false,
-          params: { setting: item, title: texts.settingsContents.permanentFilter.setting },
+          params: { setting: item, title: title || texts.settingsContents.permanentFilter.setting },
           routeName: ScreenName.Settings,
-          title: texts.settingsContents.permanentFilter.setting
+          title: title || texts.settingsContents.permanentFilter.setting
         }}
         listsWithoutArrows={listsWithoutArrows}
         navigation={navigation}
@@ -88,9 +90,9 @@ const renderItem = ({ item, navigation, listsWithoutArrows }) => {
       <TextListItem
         item={{
           isHeadlineTitle: false,
-          params: { setting: item, title: texts.settingsContents.mowasRegion.setting },
+          params: { setting: item, title: title || texts.settingsContents.mowasRegion.setting },
           routeName: ScreenName.Settings,
-          title: texts.settingsContents.mowasRegion.setting
+          title: title || texts.settingsContents.mowasRegion.setting
         }}
         listsWithoutArrows={listsWithoutArrows}
         navigation={navigation}
@@ -101,9 +103,9 @@ const renderItem = ({ item, navigation, listsWithoutArrows }) => {
       <TextListItem
         item={{
           isHeadlineTitle: false,
-          params: { setting: item, title: texts.settingsContents.list.setting },
+          params: { setting: item, title: title || texts.settingsContents.list.setting },
           routeName: ScreenName.Settings,
-          title: texts.settingsContents.list.setting
+          title: title || texts.settingsContents.list.setting
         }}
         listsWithoutArrows={listsWithoutArrows}
         navigation={navigation}
@@ -114,9 +116,9 @@ const renderItem = ({ item, navigation, listsWithoutArrows }) => {
       <TextListItem
         item={{
           isHeadlineTitle: false,
-          params: { setting: item, title: texts.settingsContents.ar.setting },
+          params: { setting: item, title: title || texts.settingsContents.ar.setting },
           routeName: ScreenName.Settings,
-          title: texts.settingsContents.ar.setting
+          title: title || texts.settingsContents.ar.setting
         }}
         listsWithoutArrows={listsWithoutArrows}
         navigation={navigation}
@@ -128,6 +130,7 @@ const renderItem = ({ item, navigation, listsWithoutArrows }) => {
 
   return component;
 };
+/* eslint-enable complexity */
 
 renderItem.propTypes = {
   item: PropTypes.object.isRequired,
@@ -172,7 +175,7 @@ const onDeactivatePushNotifications = (revert) => {
 export const SettingsScreen = ({ navigation, route }) => {
   const { globalSettings } = useContext(SettingsContext);
   const { mowas, settings = {} } = globalSettings;
-  const { listsWithoutArrows = false } = settings;
+  const { listsWithoutArrows = false, settingsScreenListItemTitles = {} } = settings;
   const [data, setData] = useState([]);
   const { setting = '' } = route?.params || {};
 
@@ -190,7 +193,9 @@ export const SettingsScreen = ({ navigation, route }) => {
         settingsList.push({
           data: [
             {
-              title: texts.settingsTitles.pushNotifications,
+              title:
+                settingsScreenListItemTitles.pushNotifications ||
+                texts.settingsTitles.pushNotifications,
               topDivider: false,
               value: pushPermission,
               onActivate: onActivatePushNotifications,
@@ -207,7 +212,7 @@ export const SettingsScreen = ({ navigation, route }) => {
         settingsList.push({
           data: [
             {
-              title: texts.settingsTitles.analytics,
+              title: settingsScreenListItemTitles.matomo || texts.settingsTitles.analytics,
               topDivider: true,
               value: matomoValue,
               onActivate: (revert) =>
@@ -255,7 +260,7 @@ export const SettingsScreen = ({ navigation, route }) => {
         settingsList.push({
           data: [
             {
-              title: texts.settingsTitles.onboarding,
+              title: settingsScreenListItemTitles.onboarding || texts.settingsTitles.onboarding,
               topDivider: true,
               value: onboarding === 'incomplete',
               onActivate: () =>
@@ -296,7 +301,9 @@ export const SettingsScreen = ({ navigation, route }) => {
         settingsList.push({
           data: [
             {
-              title: texts.settingsTitles.termsAndConditions,
+              title:
+                settingsScreenListItemTitles.termsAndConditions ||
+                texts.settingsTitles.termsAndConditions,
               topDivider: true,
               value: termsAndConditionsAccepted === 'accepted',
               onActivate: () => null,
@@ -398,7 +405,9 @@ export const SettingsScreen = ({ navigation, route }) => {
           initialNumToRender={100}
           keyExtractor={keyExtractor}
           sections={data}
-          renderItem={({ item }) => renderItem({ item, navigation, listsWithoutArrows })}
+          renderItem={({ item }) =>
+            renderItem({ item, navigation, listsWithoutArrows, settingsScreenListItemTitles })
+          }
           ListHeaderComponent={
             !!texts.settingsScreen.intro && (
               <Wrapper>


### PR DESCRIPTION
This PR adds the ability to update the headers of the list elements in the settings page and the header with `globalSettings`.

How does it work?

This feature can be activated by adding the following object to the `settings` object in `globalSettings`. Keys are fixed.

```
  "settings": {
    "settingsScreenListItemTitles": {
      "augmentedRealitySettings": "AR-Einstellungen2",
      "listSettings": "App-Aussehen2",
      "locationSettings": "Standort2",
      "matomo": "Matomo Analytics2",
      "mowasRegionSettings": "MoWaS-Regionen2",
      "onboarding": "App-Einführung2",
      "permanentFilterSettings": "Datenquellen2",
      "pushNotifications": "Push-Benachrichtigungen2",
      "termsAndConditions": "Einwilligung zu Datenschutzhinweisen2"
    },
    ...
  },
```

|before|after|after with header title|
|--|--|--|
![image](https://github.com/user-attachments/assets/3c6fe802-a19a-4667-8567-d743a771320d)|![Simulator Screenshot - iPhone 16 Plus - 2025-07-01 at 09 00 09](https://github.com/user-attachments/assets/4bad083f-b99d-4e78-989b-d2aa43147cbf)|![Simulator Screenshot - iPhone 16 Plus - 2025-07-01 at 09 00 11](https://github.com/user-attachments/assets/aa555794-fc9c-485f-9ae4-6054da379800)

SVA-1626