### PR TITLE
Fix missing closing brace in Wrapper test

### DIFF
--- a/__tests__/components/Wrapper.test.js
+++ b/__tests__/components/Wrapper.test.js
@@ -56,4 +56,4 @@ describe('testing Wrapper style component', () => {
     const tree = renderer.create(<InfoBox />).toJSON();
     expect(tree).toMatchSnapshot();
   });
-
+});


### PR DESCRIPTION
## Summary
- fix missing closing bracket in `Wrapper.test.js`
- remove stray blank line near file end

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules and other errors)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864e8346c888333b339c3fb2642369e