### PR TITLE
Fix geolocation longitude fallback

### DIFF
--- a/src/helpers/geolocationRadiusFilterHelper.ts
+++ b/src/helpers/geolocationRadiusFilterHelper.ts
@@ -63,7 +63,7 @@ export const geoLocationFilteredListItem = ({
   const lng =
     currentPosition?.coords.longitude ||
     alternativePosition?.coords.longitude ||
-    defaultAlternativePosition?.coords.latitude;
+    defaultAlternativePosition?.coords.longitude;
 
   if (queryVariables.radiusSearch.currentPosition) {
     if (!locationServiceEnabled && !isLocationAlertShow) {


### PR DESCRIPTION
## Summary
- correct fallback property for longitude in `geoLocationFilteredListItem`

## Testing
- `npm test --silent` *(fails: `jest` not found)*
- `npm run lint` *(fails: `eslint` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866454c6f648320b70de7b3009b80f7