### PR TITLE
feat(android): upgrade target sdk version to 35

### DIFF
--- a/app.json
+++ b/app.json
@@ -110,6 +110,7 @@
         "expo-build-properties",
         {
           "android": {
+            "targetSdkVersion": 35,
             "usesCleartextTraffic": true
           }
         }


### PR DESCRIPTION
With this PR, it increases the targetSdkVersion to 35, which is mandatory after the new policy update in the Play Store.

SVA-1637