### PR TITLE
feat(volunteer): add exporting event

### DIFF
--- a/app.json
+++ b/app.json
@@ -95,6 +95,12 @@
         }
       ],
       [
+        "expo-calendar",
+        {
+          "calendarPermission": "Erlauben Sie $(PRODUCT_NAME) den Zugriff auf Ihren Kalender."
+        }
+      ],
+      [
         "expo-camera",
         {
           "recordAudioAndroid": false

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "expo-asset": "~11.0.5",
     "expo-blur": "~14.0.3",
     "expo-build-properties": "~0.13.3",
+    "expo-calendar": "~14.0.6",
     "expo-camera": "~16.0.18",
     "expo-clipboard": "~7.0.1",
     "expo-constants": "~17.0.8",

--- a/patches/expo-calendar+14.0.6.patch
+++ b/patches/expo-calendar+14.0.6.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/expo-calendar/ios/CalendarModule.swift b/node_modules/expo-calendar/ios/CalendarModule.swift
+index f437cdd..4e2260a 100644
+--- a/node_modules/expo-calendar/ios/CalendarModule.swift
++++ b/node_modules/expo-calendar/ios/CalendarModule.swift
+@@ -303,7 +303,7 @@ public class CalendarModule: Module {
+     }
+ 
+     AsyncFunction("createEventInCalendarAsync") { (event: Event, promise: Promise) in
+-      try checkCalendarPermissions()
++    //   try checkCalendarPermissions()
+       guard calendarDialogDelegate == nil else {
+         throw EventDialogInProgressException()
+       }

--- a/src/components/volunteer/VolunteerEventRecord.tsx
+++ b/src/components/volunteer/VolunteerEventRecord.tsx
@@ -22,6 +22,7 @@ import { RegularText } from '../Text';
 import { Touchable } from '../Touchable';
 import { Wrapper, WrapperHorizontal } from '../Wrapper';
 
+import { createCalendarEvent } from '../../helpers/createCalendarEvent';
 import { VolunteerAppointmentsCard } from './VolunteerAppointmentsCard';
 import { VolunteerEventAttending } from './VolunteerEventAttending';
 
@@ -227,6 +228,21 @@ export const VolunteerEventRecord = ({
             invert={isAttendingEvent}
             onPress={attend}
           />
+          <Touchable
+            onPress={() =>
+              createCalendarEvent({
+                description,
+                endDatetime,
+                location,
+                startDatetime,
+                title
+              })
+            }
+          >
+            <RegularText primary center>
+              {texts.volunteer.calendarExport}
+            </RegularText>
+          </Touchable>
         </Wrapper>
       )}
     </View>

--- a/src/config/texts.js
+++ b/src/config/texts.js
@@ -107,6 +107,12 @@ export const texts = {
       'Es wurde noch nichts für die Lesezeichenliste markiert. Sobald etwas markiert wurde, wird es hier zu finden sein!',
     showAll: 'Alle anzeigen'
   },
+  calendarExport: {
+    abort: 'Abbrechen',
+    body: 'Um ein Event zu erstellen, müssen Sie den Kalenderzugriff erlauben.',
+    settings: 'Einstellungen',
+    title: 'Hinweis'
+  },
   calendarToggle: {
     calendar: 'Kalender',
     list: 'Liste'
@@ -1349,6 +1355,7 @@ export const texts = {
     birthday: 'Geburtstag',
     calendarMy: 'Mein Kalender',
     calendarNew: 'Termin erstellen',
+    calendarExport: 'In Kalender exportieren',
     city: 'Ort',
     contactGroupOwner: 'Gruppenbesitzer kontaktieren',
     conversationAllStart: 'Unterhaltung mit allen beginnen',

--- a/src/helpers/createCalendarEvent.ts
+++ b/src/helpers/createCalendarEvent.ts
@@ -1,0 +1,62 @@
+import * as Calendar from 'expo-calendar';
+import { Platform, Alert, Linking } from 'react-native';
+
+import appJson from '../../app.json';
+import { texts } from '../config';
+
+const isOlderIOS = (): boolean => {
+  if (Platform.OS !== 'ios') return false;
+
+  const versionString = Platform.Version;
+  const version = typeof versionString === 'string' ? parseFloat(versionString) : versionString;
+
+  return version < 17;
+};
+
+type Event = {
+  description?: string;
+  endDatetime: string;
+  location?: string;
+  startDatetime: string;
+  title: string;
+};
+
+export const createCalendarEvent = async (eventDetails: Event) => {
+  if (Platform.OS === 'ios' && isOlderIOS()) {
+    const { status } = await Calendar.requestCalendarPermissionsAsync();
+
+    if (status !== 'granted') {
+      Alert.alert(texts.calendarExport.title, texts.calendarExport.body, [
+        {
+          text: texts.calendarExport.abort,
+          style: 'cancel'
+        },
+        {
+          text: texts.calendarExport.settings,
+          onPress: () => Linking.openSettings()
+        }
+      ]);
+
+      return;
+    }
+  }
+
+  const defaultCalendarSource =
+    Platform.OS === 'ios' && isOlderIOS()
+      ? await Calendar.getDefaultCalendarAsync()
+      : {
+          isLocalAccount: true,
+          name: appJson.expo.name
+        };
+
+  const { description = '', endDatetime, location = '', startDatetime, title } = eventDetails;
+
+  await Calendar.createEventInCalendarAsync({
+    calendarId: defaultCalendarSource.id,
+    endDate: new Date(endDatetime).toISOString(),
+    location,
+    notes: description,
+    startDate: new Date(startDatetime).toISOString(),
+    title
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5389,6 +5389,11 @@ expo-build-properties@~0.13.3:
     ajv "^8.11.0"
     semver "^7.6.0"
 
+expo-calendar@~14.0.6:
+  version "14.0.6"
+  resolved "https://registry.yarnpkg.com/expo-calendar/-/expo-calendar-14.0.6.tgz#b72194e231f0ccdd0425f39ee08b93b1efcefbe7"
+  integrity sha512-aOby7ueR8lB9sWTHXkECZiPDZNVRsGQYhJTe05puNZicMWCV4c53Z/LRiCTTq3LBXV4zpBOB5rXiCyA1f082yA==
+
 expo-camera@~16.0.18:
   version "16.0.18"
   resolved "https://registry.yarnpkg.com/expo-camera/-/expo-camera-16.0.18.tgz#5b54dc1a929c12732c585b137b04cef2b01dee3b"


### PR DESCRIPTION
With this PR we can export events from the volunteer module via the expo-calendar package and save them in the operating system calendar.

A new build needs to be created to test this PR.

For versions older than iOS 17, access to the calendar is required due to a requirement from Apple.

For iOS 17 and newer, access permission is not required to add a new event to the calendar. However, there is currently an open PR on the Expo side to solve this problem. A patch has been added by to remove the calendar access permission requirement until this update is complete.

|ios permission dialog|ios calendar modal|android calendar|
|--|--|--|
<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/f1010b91-f937-43ff-bbf8-ce362fa57d1b" />|<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/23cc5545-5f3a-46c9-94d6-5302c79ec8cf" />|<img width="1440" height="3040" alt="image" src="https://github.com/user-attachments/assets/36c561d8-2be3-444b-b3dc-52a0f40a20d1" />

EP-81