### PR TITLE
feat(volunteer): enhance appointment handling

### DIFF
--- a/src/components/screens/OpeningTimesCard.js
+++ b/src/components/screens/OpeningTimesCard.js
@@ -12,9 +12,7 @@ import { WrapperHorizontal, WrapperRow, WrapperVertical } from '../Wrapper';
 
 const TimeBox = styled.View`
   flex-direction: row;
-  flex-wrap: wrap;
   flex: 1;
-  margin-bottom: ${normalize(5)}px;
 `;
 
 const DateBox = styled(TimeBox)`
@@ -103,7 +101,7 @@ export const OpeningTimesCard = ({
               )}
 
               {!!description && (
-                <WrapperRow style={styles.marginBottom}>
+                <WrapperRow style={styles.margin}>
                   <HtmlView html={description} />
                 </WrapperRow>
               )}
@@ -129,6 +127,10 @@ const styles = StyleSheet.create({
   divider: {
     borderBottomColor: colors.border,
     borderBottomWidth: StyleSheet.hairlineWidth
+  },
+  margin: {
+    marginBottom: normalize(3),
+    marginTop: normalize(5)
   },
   marginBottom: {
     marginBottom: normalize(3)

--- a/src/components/volunteer/VolunteerAppointmentsCard.tsx
+++ b/src/components/volunteer/VolunteerAppointmentsCard.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import styled from 'styled-components/native';
@@ -9,9 +10,7 @@ import { Wrapper, WrapperRow } from '../Wrapper';
 
 const TimeBox = styled.View`
   flex-direction: row;
-  flex-wrap: wrap;
   flex: 1;
-  margin-bottom: ${normalize(5)}px;
 `;
 
 const DateBox = styled(TimeBox)`
@@ -23,18 +22,31 @@ const DateBox = styled(TimeBox)`
 export const VolunteerAppointmentsCard = ({
   appointments
 }: {
-  appointments: { dateFrom: string; dateTo: string; timeFrom: string; timeTo: string }[];
+  appointments: {
+    allDay: boolean;
+    dateFrom: string;
+    dateTo: string;
+    timeFrom: string;
+    timeTo: string;
+  }[];
 }) => (
   <Wrapper>
     {appointments?.map((item, index) => {
-      const { dateFrom, dateTo, timeFrom, timeTo } = item;
+      const { allDay, dateFrom, dateTo, timeFrom, timeTo } = item;
       const returnFormatDate = 'DD.MM.YYYY';
-      const fullDay = timeFrom === '00:00' && timeTo === '00:00';
+      const fullDay = allDay || (timeFrom === '00:00' && timeTo === '00:00');
 
       return (
         <View key={index} style={index !== appointments.length - 1 ? styles.divider : null}>
           {(!!timeFrom || !!timeTo || !!dateFrom || !!dateTo) && (
             <WrapperRow>
+              {!fullDay && (!!timeFrom || !!timeTo) && (
+                <TimeBox>
+                  {!!timeFrom && <RegularText>{timeFrom}</RegularText>}
+                  {!!timeFrom && !!timeTo && <RegularText> -</RegularText>}
+                  {!!timeTo && <RegularText> {timeTo}</RegularText>}
+                </TimeBox>
+              )}
               {(!!dateFrom || !!dateTo) && (
                 <DateBox>
                   {!!dateFrom && (
@@ -47,17 +59,13 @@ export const VolunteerAppointmentsCard = ({
                   {!!dateTo && dateTo !== dateFrom && (
                     <RegularText>
                       <RegularText small>bis </RegularText>
-                      {momentFormat(dateTo, returnFormatDate)}
+                      {momentFormat(
+                        fullDay ? moment(dateTo).subtract(1, 'day').format('YYYY-MM-DD') : dateTo,
+                        returnFormatDate
+                      )}
                     </RegularText>
                   )}
                 </DateBox>
-              )}
-              {(!!timeFrom || !!timeTo) && !fullDay && (
-                <TimeBox>
-                  {!!timeFrom && <RegularText>{timeFrom}</RegularText>}
-                  {!!timeFrom && !!timeTo && <RegularText> -</RegularText>}
-                  {!!timeTo && <RegularText> {timeTo}</RegularText>}
-                </TimeBox>
               )}
             </WrapperRow>
           )}

--- a/src/components/volunteer/VolunteerEventRecord.tsx
+++ b/src/components/volunteer/VolunteerEventRecord.tsx
@@ -44,6 +44,7 @@ export const VolunteerEventRecord = ({
 }: { data: any; refetch: () => void } & StackScreenProps<any>) => {
   const {
     id,
+    all_day: allDay,
     content,
     description,
     location,
@@ -77,6 +78,7 @@ export const VolunteerEventRecord = ({
   const headerTitle = route.params?.title ?? '';
   const appointments = [
     {
+      allDay,
       dateFrom: momentFormat(startDatetime, 'YYYY-MM-DD'),
       dateTo: momentFormat(endDatetime, 'YYYY-MM-DD'),
       timeFrom: momentFormat(startDatetime, 'HH:mm'),


### PR DESCRIPTION
The presentation for all day appointments were a bit off. With the refactoring we will see the same alignment as if there would be some times for the dates. On the other hand, The end date were not presented correctly if it represents full days. Events from 08.08 - 09.08. were shown as 08.08 - 10.08. before.

<img width="371" height="158" alt="image" src="https://github.com/user-attachments/assets/6c614f9c-1d05-40d6-b588-514a508555bd" />
