### PR TITLE
fix(filter): the problem of date filter not being reset

### DIFF
--- a/src/components/filter/DateFilter.tsx
+++ b/src/components/filter/DateFilter.tsx
@@ -157,10 +157,10 @@ export const DateFilter = ({ containerStyle, data, filters, setFilters }: Props)
                 <RegularText
                   style={styles.buttonText}
                   placeholder={
-                    !filters[item.name] || filters.start_date === filters.initial_start_date
+                    !filters[item.name] || filters[item.name] === filters[`initial_${item.name}`]
                   }
                 >
-                  {filters[item.name] && filters.start_date !== filters.initial_start_date
+                  {filters[item.name] && filters[item.name] !== filters[`initial_${item.name}`]
                     ? momentFormat(filters[item.name], 'DD.MM.YYYY')
                     : item.placeholder}
                 </RegularText>

--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -101,15 +101,18 @@ export const Filter = ({
       }, 500);
     } else {
       setIsCollapsed(!isCollapsed);
+
+      const { dateRange, ...rest } = initialQueryVariables || {};
+
       setFilters((prev) => ({
         saveable: false,
         search: prev.search || '',
-        ...(initialQueryVariables || {})
+        ...(rest || {})
       }));
       setQueryVariables((prev) => ({
         saveable: false,
         search: prev.search || '',
-        ...(initialQueryVariables || {})
+        ...(rest || {})
       }));
     }
   };


### PR DESCRIPTION
This PR resolves errors found in the OverlayFilter component:

- only `endDate` cannot be selected
- filter cannot be reset

## before:

https://github.com/user-attachments/assets/9ebaa298-f4df-427c-aa63-7d762c173180

## after:

https://github.com/user-attachments/assets/68443afb-bc4a-4d52-a6dc-75718d9c8671

SVA-1640