### PR TITLE
fix(tiles): errors in customizable

### DIFF
--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -116,7 +116,7 @@ export const ServiceTile = ({
       dimensions={dimensions}
       numberOfTiles={item?.numberOfTiles}
       orientation={orientation}
-      style={[normalizedTileStyle, isLastRow && styles.marginLeft]}
+      style={[normalizedTileStyle, isEditMode && styles.editModeServiceBox]}
     >
       <TouchableOpacity
         style={[hasTileStyle && styles.button]}
@@ -214,8 +214,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: '100%'
   },
-  marginLeft: {
-    marginLeft: normalize(8)
+  editModeServiceBox: {
+    flex: 1,
+    marginBottom: 0
   },
   serviceIcon: {
     alignSelf: 'center',
@@ -229,8 +230,8 @@ const styles = StyleSheet.create({
   toggleVisibilityIcon: {
     backgroundColor: colors.surface,
     position: 'absolute',
-    right: 0,
-    top: normalize(-14),
+    right: normalize(-1),
+    top: normalize(-1),
     zIndex: 1
   },
   toggleVisibilityIconBigTile: {


### PR DESCRIPTION
With this PR, it solves the problem that tiles are not displayed correctly on the tile edit page

|before|after|before|after|
|--|--|--|--|
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 16 17 01" src="https://github.com/user-attachments/assets/c3442092-c077-476d-9be0-e128f60d7ead" />|<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 16 11 34" src="https://github.com/user-attachments/assets/f9497171-9ab5-4fc6-b1c0-548db09007b6" />|<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 16 17 03" src="https://github.com/user-attachments/assets/d4bb7a58-3b04-47c9-a787-b4fca0a4e2cb" />|<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 16 11 37" src="https://github.com/user-attachments/assets/e0b9a8c7-275d-42c2-b340-9e6b4231d8cb" />

custom tiles:

|before|after|before|after|
|--|--|--|--|
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 16 17 16" src="https://github.com/user-attachments/assets/1e1145d6-5854-4479-8947-73fe22678016" />|<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 16 11 18" src="https://github.com/user-attachments/assets/b9c60a33-ebd0-4e80-9aed-38fb498b1766" />|<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 16 17 19" src="https://github.com/user-attachments/assets/91a609f9-1c76-400f-bfb1-8723a9f20974" />|<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/d72ed8af-0585-4f59-a626-71aa6d2c5fa4" />

SVA-1638