### PR TITLE
fix: the problem of invisibility in non-customizable tiles

### DIFF
--- a/src/hooks/personalizedTiles.ts
+++ b/src/hooks/personalizedTiles.ts
@@ -13,8 +13,8 @@ export const usePersonalizedTiles = (
   isEditMode = false,
   staticJsonName: string
 ) => {
-  const [isLoading, setIsLoading] = useState(true);
-  const [tiles, setTiles] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(isPersonalizable);
+  const [tiles, setTiles] = useState<any[]>(!isPersonalizable ? data : []);
 
   const getPersonalizedTiles = useCallback(async () => {
     setIsLoading(true);


### PR DESCRIPTION
Solves the problem of non-display of non-customizable tiles with this PR

|before|after|
|--|--|
<img width="295" height="640" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-11 at 15 09 16" src="https://github.com/user-attachments/assets/6af38329-0e7d-4ac9-b99f-a714391d45ef" />|<img width="295" height="640" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-11 at 15 08 36" src="https://github.com/user-attachments/assets/05870f78-03ee-4b40-9a47-718de136983b" />

SVASD-196