### PR TITLE
feat(tiles): add space between tiles in last row

### DIFF
--- a/src/components/screens/ServiceTile.tsx
+++ b/src/components/screens/ServiceTile.tsx
@@ -116,7 +116,11 @@ export const ServiceTile = ({
       dimensions={dimensions}
       numberOfTiles={item?.numberOfTiles}
       orientation={orientation}
-      style={[normalizedTileStyle, isEditMode && styles.editModeServiceBox]}
+      style={[
+        normalizedTileStyle,
+        isEditMode && styles.editModeServiceBox,
+        isLastRow && styles.marginLeft
+      ]}
     >
       <TouchableOpacity
         style={[hasTileStyle && styles.button]}
@@ -217,6 +221,9 @@ const styles = StyleSheet.create({
   editModeServiceBox: {
     flex: 1,
     marginBottom: 0
+  },
+  marginLeft: {
+    marginLeft: normalize(8)
   },
   serviceIcon: {
     alignSelf: 'center',


### PR DESCRIPTION
This PR solves the problem that the space between the tiles in the last row is not visible

|before|after|
|--|--|
![Bildschirmfoto 2025-08-20 um 11 29 12-1](https://github.com/user-attachments/assets/31f6c8e1-cfdd-4ce8-9942-5636419005fe)|![Bildschirmfoto 2025-08-20 um 11 29 07](https://github.com/user-attachments/assets/7f24fc82-bf32-472f-8ad6-b5f10545a00f)


SVA-1384