### PR TITLE
feat(waste): add navigation for notifications

### DIFF
--- a/src/helpers/queryHelper.ts
+++ b/src/helpers/queryHelper.ts
@@ -28,6 +28,8 @@ export const routeNameFromQuery = (query: string) => {
       return ScreenName.VolunteerDetail;
     case QUERY_TYPES.VOLUNTEER.GROUP:
       return ScreenName.VolunteerDetail;
+    case QUERY_TYPES.WASTE_ADDRESSES:
+      return ScreenName.WasteCollection;
     default:
       return ScreenName.Detail;
   }

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -114,13 +114,14 @@ export const QUERY_TYPES = {
 export const getQueryType = (input: string) => {
   const camelCaseInput = _camelCase(input);
   const availableTypes = [
-    QUERY_TYPES.TOUR,
-    QUERY_TYPES.POINTS_OF_INTEREST,
-    QUERY_TYPES.NEWS_ITEM,
     QUERY_TYPES.EVENT_RECORD,
-    QUERY_TYPES.VOLUNTEER.HOME,
+    QUERY_TYPES.NEWS_ITEM,
+    QUERY_TYPES.POINTS_OF_INTEREST,
+    QUERY_TYPES.TOUR,
     QUERY_TYPES.VOLUNTEER.CONVERSATION,
-    QUERY_TYPES.VOLUNTEER.GROUP
+    QUERY_TYPES.VOLUNTEER.GROUP,
+    QUERY_TYPES.VOLUNTEER.HOME,
+    QUERY_TYPES.WASTE_ADDRESSES
   ];
 
   // special condition used for push notifications coming from messaging


### PR DESCRIPTION
With this PR, clicking on the notification for the waste collection calendar automatically adds a redirect to `WasteCollectionScreen`.

SVAK-169