### PR TITLE
feat: add configurable cache expiration scopes

### DIFF
--- a/__tests__/helpers/cacheHelper.test.js
+++ b/__tests__/helpers/cacheHelper.test.js
@@ -1,0 +1,136 @@
+import {
+  APOLLO_CACHE_PERSIST_KEY,
+  CACHE_SCOPES,
+  createEndOfDayExpiringStorage,
+  millisecondsUntilCacheExpires
+} from '../../src/helpers/cacheHelper';
+
+describe('cacheHelper', () => {
+  const expiresAtKey = `${APOLLO_CACHE_PERSIST_KEY}:expires-at`;
+
+  const createStorage = (initialValues = {}) => {
+    const values = new Map(Object.entries(initialValues));
+
+    return {
+      getItem: jest.fn(async (key) => values.get(key) ?? null),
+      setItem: jest.fn(async (key, value) => {
+        values.set(key, value);
+      }),
+      removeItem: jest.fn(async (key) => {
+        values.delete(key);
+      })
+    };
+  };
+
+  it('returns persisted cache while its end-of-day expiration is valid', async () => {
+    const storage = createStorage({
+      [APOLLO_CACHE_PERSIST_KEY]: 'cache-data',
+      [expiresAtKey]: `${Date.now() + 1000}`
+    });
+    const expiringStorage = createEndOfDayExpiringStorage(storage);
+
+    await expect(expiringStorage.getItem(APOLLO_CACHE_PERSIST_KEY)).resolves.toBe('cache-data');
+    expect(storage.removeItem).not.toHaveBeenCalled();
+  });
+
+  it('purges persisted cache when expiration metadata is missing', async () => {
+    const storage = createStorage({
+      [APOLLO_CACHE_PERSIST_KEY]: 'cache-data'
+    });
+    const expiringStorage = createEndOfDayExpiringStorage(storage);
+
+    await expect(expiringStorage.getItem(APOLLO_CACHE_PERSIST_KEY)).resolves.toBeNull();
+    expect(storage.removeItem).toHaveBeenCalledWith(APOLLO_CACHE_PERSIST_KEY);
+    expect(storage.removeItem).toHaveBeenCalledWith(expiresAtKey);
+  });
+
+  it('purges persisted cache when it is expired', async () => {
+    const storage = createStorage({
+      [APOLLO_CACHE_PERSIST_KEY]: 'cache-data',
+      [expiresAtKey]: `${Date.now() - 1}`
+    });
+    const expiringStorage = createEndOfDayExpiringStorage(storage);
+
+    await expect(expiringStorage.getItem(APOLLO_CACHE_PERSIST_KEY)).resolves.toBeNull();
+    expect(storage.removeItem).toHaveBeenCalledWith(APOLLO_CACHE_PERSIST_KEY);
+    expect(storage.removeItem).toHaveBeenCalledWith(expiresAtKey);
+  });
+
+  it('writes expiration metadata when Apollo cache is persisted', async () => {
+    const storage = createStorage();
+    const expiringStorage = createEndOfDayExpiringStorage(storage);
+
+    await expiringStorage.setItem(APOLLO_CACHE_PERSIST_KEY, 'cache-data');
+
+    expect(storage.setItem).toHaveBeenCalledWith(APOLLO_CACHE_PERSIST_KEY, 'cache-data');
+    expect(storage.setItem).toHaveBeenCalledWith(expiresAtKey, expect.any(String));
+  });
+
+  it('uses configured cache hours from general settings', () => {
+    expect(
+      millisecondsUntilCacheExpires({
+        settings: {
+          cache: {
+            general: 6
+          }
+        }
+      })
+    ).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it('uses configured cache hours from scoped settings', () => {
+    expect(
+      millisecondsUntilCacheExpires(
+        {
+          settings: {
+            cache: {
+              general: 6,
+              sue: 14
+            }
+          }
+        },
+        CACHE_SCOPES.SUE
+      )
+    ).toBe(14 * 60 * 60 * 1000);
+  });
+
+  it('falls back to general settings when scoped settings are missing', () => {
+    expect(
+      millisecondsUntilCacheExpires(
+        {
+          settings: {
+            cache: {
+              general: 6
+            }
+          }
+        },
+        CACHE_SCOPES.SUE
+      )
+    ).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it('supports zero cache hours', () => {
+    expect(
+      millisecondsUntilCacheExpires({
+        settings: {
+          cache: {
+            general: 0
+          }
+        }
+      })
+    ).toBe(0);
+  });
+
+  it('supports moment-style end-of-day settings', () => {
+    const milliseconds = millisecondsUntilCacheExpires({
+      settings: {
+        cache: {
+          general: 'endDay'
+        }
+      }
+    });
+
+    expect(milliseconds).toBeGreaterThanOrEqual(0);
+    expect(milliseconds).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+  });
+});

--- a/__tests__/helpers/cacheHelper.test.js
+++ b/__tests__/helpers/cacheHelper.test.js
@@ -109,6 +109,22 @@ describe('cacheHelper', () => {
     ).toBe(6 * 60 * 60 * 1000);
   });
 
+  it('falls back to general settings when scoped settings are invalid', () => {
+    expect(
+      millisecondsUntilCacheExpires(
+        {
+          settings: {
+            cache: {
+              general: 6,
+              sue: -1
+            }
+          }
+        },
+        CACHE_SCOPES.SUE
+      )
+    ).toBe(6 * 60 * 60 * 1000);
+  });
+
   it('supports zero cache hours', () => {
     expect(
       millisecondsUntilCacheExpires({

--- a/__tests__/helpers/cacheHelper.test.js
+++ b/__tests__/helpers/cacheHelper.test.js
@@ -33,15 +33,15 @@ describe('cacheHelper', () => {
     expect(storage.removeItem).not.toHaveBeenCalled();
   });
 
-  it('purges persisted cache when expiration metadata is missing', async () => {
+  it('migrates persisted cache when expiration metadata is missing', async () => {
     const storage = createStorage({
       [APOLLO_CACHE_PERSIST_KEY]: 'cache-data'
     });
     const expiringStorage = createEndOfDayExpiringStorage(storage);
 
-    await expect(expiringStorage.getItem(APOLLO_CACHE_PERSIST_KEY)).resolves.toBeNull();
-    expect(storage.removeItem).toHaveBeenCalledWith(APOLLO_CACHE_PERSIST_KEY);
-    expect(storage.removeItem).toHaveBeenCalledWith(expiresAtKey);
+    await expect(expiringStorage.getItem(APOLLO_CACHE_PERSIST_KEY)).resolves.toBe('cache-data');
+    expect(storage.setItem).toHaveBeenCalledWith(expiresAtKey, expect.any(String));
+    expect(storage.removeItem).not.toHaveBeenCalled();
   });
 
   it('purges persisted cache when it is expired', async () => {

--- a/docs/CACHE_CONFIGURATION.md
+++ b/docs/CACHE_CONFIGURATION.md
@@ -1,0 +1,151 @@
+# Cache Configuration
+
+## Overview
+
+The app cache lifetime can be configured through `globalSettings.settings.cache`. The configuration is loaded from the main server via the existing `globalSettings` public JSON flow and is also persisted locally with the rest of the global settings.
+
+If no cache configuration is provided, the app defaults to keeping cache until the end of the current day.
+
+## Configuration Format
+
+Add a `cache` object inside `globalSettings.settings`:
+
+```json
+"settings": {
+  "cache": {
+    "general": "endDay",
+    "sue": 14,
+    "home": "endOfDay",
+    "apollo": 6
+  }
+}
+```
+
+Each cache value can be either:
+
+- A number: interpreted as hours. For example, `14` means 14 hours.
+- A string: interpreted as a Moment-style `endOf(...)` value. For example, `"endDay"`, `"endOfDay"`, and `"endOf('day')"` all mean the end of the current day.
+
+Use `0` to expire a cache scope immediately.
+
+## Supported Scopes
+
+| Scope     | Affects                                                                 | Fallback |
+| --------- | ----------------------------------------------------------------------- | -------- |
+| `general` | Default React Query cache for app data and fallback for missing scopes. | End of current day |
+| `apollo`  | Persisted Apollo GraphQL cache restored from AsyncStorage.              | `general` |
+| `home`    | Home screen data sections rendered through `HomeSection`.               | `general` |
+| `sue`     | SUE request list data loaded through `SueListScreen`.                   | `general` |
+
+## Supported String Values
+
+The parser accepts compact aliases and Moment-style strings for `endOf(...)` units.
+
+Common examples:
+
+| Value            | Meaning |
+| ---------------- | ------- |
+| `"endDay"`       | End of the current day |
+| `"endOfDay"`     | End of the current day |
+| `"endOf('day')"` | End of the current day |
+| `"endWeek"`      | End of the current week |
+| `"endOfWeek"`    | End of the current week |
+| `"endMonth"`     | End of the current month |
+| `"endYear"`      | End of the current year |
+
+Supported units are `hour`, `day`, `week`, `isoWeek`, `month`, `quarter`, and `year`.
+
+## Fallback Rules
+
+The app resolves cache configuration in this order:
+
+1. Use the requested scope value, for example `settings.cache.sue`.
+2. If the requested scope is missing, use `settings.cache.general`.
+3. If `general` is missing or invalid, use the built-in default: end of the current day.
+
+Example:
+
+```json
+"settings": {
+  "cache": {
+    "general": "endDay",
+    "sue": 14
+  }
+}
+```
+
+In this example:
+
+- SUE list cache expires after 14 hours.
+- Home cache uses `general`, so it expires at the end of the current day.
+- Apollo cache uses `general`, so it expires at the end of the current day.
+- Any other React Query cache uses `general`, so it expires at the end of the current day.
+
+## Examples
+
+### One Rule for the Whole App
+
+```json
+"settings": {
+  "cache": {
+    "general": 24
+  }
+}
+```
+
+All cache scopes use 24 hours unless a scope-specific value is added.
+
+### Refresh Everything at the End of the Day
+
+```json
+"settings": {
+  "cache": {
+    "general": "endDay"
+  }
+}
+```
+
+This is equivalent to the built-in default, but makes the behavior explicit in server configuration.
+
+### Custom SUE Cache
+
+```json
+"settings": {
+  "cache": {
+    "general": "endDay",
+    "sue": 14
+  }
+}
+```
+
+SUE request list data expires after 14 hours. Other cache scopes expire at the end of the day.
+
+### Separate Apollo and Home Cache
+
+```json
+"settings": {
+  "cache": {
+    "general": "endDay",
+    "apollo": 6,
+    "home": "endOfHour"
+  }
+}
+```
+
+Apollo persisted GraphQL cache expires after 6 hours. Home screen data sections expire at the end of the current hour. Missing scopes still use `general`.
+
+## Implementation Notes
+
+- Scope definitions live in `src/helpers/cacheHelper.js` as `CACHE_SCOPES`.
+- Apollo cache expiration metadata is stored next to the persisted cache under `apollo-cache-persist:expires-at`.
+- React Query uses the resolved `general` value as the default `cacheTime`.
+- Scope-specific React Query cache values are applied where the cache is created, for example `sue` in `SueListScreen` and `home` in `HomeSection`.
+- Invalid values are ignored and fall back to `general` or the built-in end-of-day default.
+
+## Validation Checklist
+
+- Confirm that `globalSettings` contains `settings.cache`.
+- Use numbers for hour-based cache durations.
+- Use supported `endOf` strings for calendar-bound expiration.
+- Add a scope-specific value only when that app area needs different behavior from `general`.
+- Test with no cache settings to verify the built-in end-of-day fallback.

--- a/docs/CACHE_CONFIGURATION.md
+++ b/docs/CACHE_CONFIGURATION.md
@@ -11,12 +11,14 @@ If no cache configuration is provided, the app defaults to keeping cache until t
 Add a `cache` object inside `globalSettings.settings`:
 
 ```json
-"settings": {
-  "cache": {
-    "general": "endDay",
-    "sue": 14,
-    "home": "endOfDay",
-    "apollo": 6
+{
+  "settings": {
+    "cache": {
+      "general": "endDay",
+      "sue": 14,
+      "home": "endOfDay",
+      "apollo": 6
+    }
   }
 }
 ```
@@ -60,16 +62,18 @@ Supported units are `hour`, `day`, `week`, `isoWeek`, `month`, `quarter`, and `y
 The app resolves cache configuration in this order:
 
 1. Use the requested scope value, for example `settings.cache.sue`.
-2. If the requested scope is missing, use `settings.cache.general`.
+2. If the requested scope is missing or invalid, use `settings.cache.general`.
 3. If `general` is missing or invalid, use the built-in default: end of the current day.
 
 Example:
 
 ```json
-"settings": {
-  "cache": {
-    "general": "endDay",
-    "sue": 14
+{
+  "settings": {
+    "cache": {
+      "general": "endDay",
+      "sue": 14
+    }
   }
 }
 ```
@@ -86,9 +90,11 @@ In this example:
 ### One Rule for the Whole App
 
 ```json
-"settings": {
-  "cache": {
-    "general": 24
+{
+  "settings": {
+    "cache": {
+      "general": 24
+    }
   }
 }
 ```
@@ -98,9 +104,11 @@ All cache scopes use 24 hours unless a scope-specific value is added.
 ### Refresh Everything at the End of the Day
 
 ```json
-"settings": {
-  "cache": {
-    "general": "endDay"
+{
+  "settings": {
+    "cache": {
+      "general": "endDay"
+    }
   }
 }
 ```
@@ -110,10 +118,12 @@ This is equivalent to the built-in default, but makes the behavior explicit in s
 ### Custom SUE Cache
 
 ```json
-"settings": {
-  "cache": {
-    "general": "endDay",
-    "sue": 14
+{
+  "settings": {
+    "cache": {
+      "general": "endDay",
+      "sue": 14
+    }
   }
 }
 ```
@@ -123,11 +133,13 @@ SUE request list data expires after 14 hours. Other cache scopes expire at the e
 ### Separate Apollo and Home Cache
 
 ```json
-"settings": {
-  "cache": {
-    "general": "endDay",
-    "apollo": 6,
-    "home": "endOfHour"
+{
+  "settings": {
+    "cache": {
+      "general": "endDay",
+      "apollo": 6,
+      "home": "endOfHour"
+    }
   }
 }
 ```

--- a/src/ReactQueryProvider.tsx
+++ b/src/ReactQueryProvider.tsx
@@ -32,15 +32,22 @@ export const ReactQueryProvider = ({
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;
 
+    const expireCache = () => {
+      queryClient.removeQueries({ predicate: (query) => !query.isActive() });
+      queryClient.invalidateQueries();
+    };
+
     const scheduleEndOfDayCacheReset = () => {
-      const delay = Math.max(
-        millisecondsUntilCacheExpires(globalSettings, CACHE_SCOPES.GENERAL),
-        1000
-      );
+      const delay = millisecondsUntilCacheExpires(globalSettings, CACHE_SCOPES.GENERAL);
+
+      if (delay <= 0) {
+        expireCache();
+
+        return;
+      }
 
       timeoutId = setTimeout(() => {
-        queryClient.removeQueries({ inactive: true });
-        queryClient.invalidateQueries();
+        expireCache();
         scheduleEndOfDayCacheReset();
       }, delay);
     };

--- a/src/ReactQueryProvider.tsx
+++ b/src/ReactQueryProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { CACHE_SCOPES, millisecondsUntilCacheExpires } from './helpers/cacheHelper';
@@ -25,9 +25,13 @@ export const ReactQueryProvider = ({
 }) => {
   const [queryClient] = useState(() => createQueryClient(globalSettings));
 
-  useEffect(() => {
+  const applyQueryDefaults = useCallback(() => {
     queryClient.setDefaultOptions(queryDefaultOptions(globalSettings));
   }, [globalSettings, queryClient]);
+
+  useEffect(() => {
+    applyQueryDefaults();
+  }, [applyQueryDefaults]);
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -38,6 +42,8 @@ export const ReactQueryProvider = ({
     };
 
     const scheduleEndOfDayCacheReset = () => {
+      applyQueryDefaults();
+
       const delay = millisecondsUntilCacheExpires(globalSettings, CACHE_SCOPES.GENERAL);
 
       if (delay <= 0) {
@@ -55,7 +61,7 @@ export const ReactQueryProvider = ({
     scheduleEndOfDayCacheReset();
 
     return () => clearTimeout(timeoutId);
-  }, [globalSettings, queryClient]);
+  }, [applyQueryDefaults, globalSettings, queryClient]);
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };

--- a/src/ReactQueryProvider.tsx
+++ b/src/ReactQueryProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider, useQueryClient } from 'react-query';
 
 import { CACHE_SCOPES, millisecondsUntilCacheExpires } from './helpers/cacheHelper';
 
@@ -11,19 +11,17 @@ const queryDefaultOptions = (globalSettings?: Record<string, unknown>) => ({
   }
 });
 
-const createQueryClient = (globalSettings?: Record<string, unknown>) =>
+const createQueryClient = () =>
   new QueryClient({
-    defaultOptions: queryDefaultOptions(globalSettings)
+    defaultOptions: queryDefaultOptions()
   });
 
-export const ReactQueryProvider = ({
-  children,
+export const ReactQueryCacheSettings = ({
   globalSettings
 }: {
-  children?: React.ReactNode;
   globalSettings?: Record<string, unknown>;
 }) => {
-  const [queryClient] = useState(() => createQueryClient(globalSettings));
+  const queryClient = useQueryClient();
 
   const applyQueryDefaults = useCallback(() => {
     queryClient.setDefaultOptions(queryDefaultOptions(globalSettings));
@@ -62,6 +60,12 @@ export const ReactQueryProvider = ({
 
     return () => clearTimeout(timeoutId);
   }, [applyQueryDefaults, globalSettings, queryClient]);
+
+  return null;
+};
+
+export const ReactQueryProvider = ({ children }: { children?: React.ReactNode }) => {
+  const [queryClient] = useState(() => createQueryClient());
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };

--- a/src/ReactQueryProvider.tsx
+++ b/src/ReactQueryProvider.tsx
@@ -1,10 +1,54 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: 2, refetchOnMount: false } }
+import { CACHE_SCOPES, millisecondsUntilCacheExpires } from './helpers/cacheHelper';
+
+const queryDefaultOptions = (globalSettings?: Record<string, unknown>) => ({
+  queries: {
+    cacheTime: millisecondsUntilCacheExpires(globalSettings, CACHE_SCOPES.GENERAL),
+    retry: 2,
+    refetchOnMount: false
+  }
 });
 
-export const ReactQueryProvider = ({ children }: { children?: React.ReactNode }) => {
+const createQueryClient = (globalSettings?: Record<string, unknown>) =>
+  new QueryClient({
+    defaultOptions: queryDefaultOptions(globalSettings)
+  });
+
+export const ReactQueryProvider = ({
+  children,
+  globalSettings
+}: {
+  children?: React.ReactNode;
+  globalSettings?: Record<string, unknown>;
+}) => {
+  const [queryClient] = useState(() => createQueryClient(globalSettings));
+
+  useEffect(() => {
+    queryClient.setDefaultOptions(queryDefaultOptions(globalSettings));
+  }, [globalSettings, queryClient]);
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const scheduleEndOfDayCacheReset = () => {
+      const delay = Math.max(
+        millisecondsUntilCacheExpires(globalSettings, CACHE_SCOPES.GENERAL),
+        1000
+      );
+
+      timeoutId = setTimeout(() => {
+        queryClient.removeQueries({ inactive: true });
+        queryClient.invalidateQueries();
+        scheduleEndOfDayCacheReset();
+      }, delay);
+    };
+
+    scheduleEndOfDayCacheReset();
+
+    return () => clearTimeout(timeoutId);
+  }, [globalSettings, queryClient]);
+
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -1,10 +1,12 @@
 import { StackNavigationProp } from '@react-navigation/stack';
-import React from 'react';
+import React, { useContext } from 'react';
 import { useQuery } from 'react-query';
 
+import { CACHE_SCOPES, millisecondsUntilCacheExpires } from '../helpers/cacheHelper';
 import { useHomePointsOfInterestAndToursRefresh, useHomeRefresh, useVolunteerData } from '../hooks';
 import { getQuery, QUERY_TYPES } from '../queries';
 import { ReactQueryClient } from '../ReactQueryClient';
+import { SettingsContext } from '../SettingsProvider';
 
 import { DataListSection } from './DataListSection';
 
@@ -40,6 +42,7 @@ export const HomeSection = ({
   title,
   titleDetail
 }: Props) => {
+  const { globalSettings } = useContext(SettingsContext);
   const isPointsOfInterestAndTours = query === QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS;
   // `dataUpdatedAt` is provided by react-query and changes whenever a successful fetch updates data.
   const { data, dataUpdatedAt, isLoading, refetch } = useQuery(
@@ -51,6 +54,7 @@ export const HomeSection = ({
     },
     isPointsOfInterestAndTours
       ? {
+          cacheTime: millisecondsUntilCacheExpires(globalSettings, CACHE_SCOPES.HOME),
           // Keep one random selection stable across tab switches; manual refresh uses a separate event.
           staleTime: 60 * 60 * 1000,
           refetchOnWindowFocus: false,

--- a/src/helpers/cacheHelper.js
+++ b/src/helpers/cacheHelper.js
@@ -85,10 +85,15 @@ export const endOfDayTimestamp = () => moment().endOf('day').valueOf();
 
 export const endOfDayUnix = () => moment().endOf('day').unix();
 
-export const cacheExpiresAtTimestamp = (globalSettings, cacheScope = CACHE_SCOPES.GENERAL) =>
-  configuredCacheMaxAgeInMilliseconds(globalSettings, cacheScope) !== undefined
-    ? Date.now() + millisecondsUntilCacheExpires(globalSettings, cacheScope)
-    : endOfDayTimestamp();
+export const cacheExpiresAtTimestamp = (globalSettings, cacheScope = CACHE_SCOPES.GENERAL) => {
+  const configuredCacheMaxAge = configuredCacheMaxAgeInMilliseconds(globalSettings, cacheScope);
+
+  if (configuredCacheMaxAge === undefined) {
+    return endOfDayTimestamp();
+  }
+
+  return Date.now() + configuredCacheMaxAge;
+};
 
 export const createEndOfDayExpiringStorage = (
   storage,

--- a/src/helpers/cacheHelper.js
+++ b/src/helpers/cacheHelper.js
@@ -20,17 +20,6 @@ const HOURS_TO_MILLISECONDS = 60 * 60 * 1000;
 export const millisecondsUntilEndOfDay = () =>
   Math.max(moment().endOf('day').diff(moment(), 'milliseconds'), 0);
 
-const cacheConfigFor = (globalSettings, cacheScope = CACHE_SCOPES.GENERAL) => {
-  const cacheConfig = globalSettings?.settings?.cache;
-
-  if (!cacheConfig) {
-    return undefined;
-  }
-
-  // Scope-specific values override general; general remains the cross-app fallback.
-  return cacheConfig[cacheScope] ?? cacheConfig[CACHE_SCOPES.GENERAL];
-};
-
 const normalizeMomentEndOfUnit = (value) => {
   const normalizedValue = value.replace(/[\s_-]/g, '').toLowerCase();
   const endOfMatch = normalizedValue.match(/^endof['"]?\(?['"]?([a-z]+)['"]?\)?$/);
@@ -56,9 +45,7 @@ const normalizeMomentEndOfUnit = (value) => {
   return units[unit];
 };
 
-const configuredCacheMaxAgeInMilliseconds = (globalSettings, cacheScope) => {
-  const cacheConfig = cacheConfigFor(globalSettings, cacheScope);
-
+const cacheConfigValueInMilliseconds = (cacheConfig) => {
   if (typeof cacheConfig === 'number') {
     return Number.isFinite(cacheConfig) && cacheConfig >= 0
       ? cacheConfig * HOURS_TO_MILLISECONDS
@@ -76,6 +63,23 @@ const configuredCacheMaxAgeInMilliseconds = (globalSettings, cacheScope) => {
   }
 
   return Math.max(moment().endOf(momentEndOfUnit).diff(moment(), 'milliseconds'), 0);
+};
+
+const configuredCacheMaxAgeInMilliseconds = (globalSettings, cacheScope = CACHE_SCOPES.GENERAL) => {
+  const cacheConfig = globalSettings?.settings?.cache;
+
+  if (!cacheConfig) {
+    return undefined;
+  }
+
+  const scopedCacheMaxAge = cacheConfigValueInMilliseconds(cacheConfig[cacheScope]);
+
+  if (scopedCacheMaxAge !== undefined || cacheScope === CACHE_SCOPES.GENERAL) {
+    return scopedCacheMaxAge;
+  }
+
+  // Scope-specific values override general; invalid or missing scopes fall back to general.
+  return cacheConfigValueInMilliseconds(cacheConfig[CACHE_SCOPES.GENERAL]);
 };
 
 export const millisecondsUntilCacheExpires = (globalSettings, cacheScope = CACHE_SCOPES.GENERAL) =>

--- a/src/helpers/cacheHelper.js
+++ b/src/helpers/cacheHelper.js
@@ -1,0 +1,141 @@
+import moment from 'moment';
+
+export const APOLLO_CACHE_PERSIST_KEY = 'apollo-cache-persist';
+
+// Cache scopes map globalSettings.settings.cache entries to the app areas they control.
+// general: default React Query cache and fallback for every missing scope.
+// apollo: persisted Apollo GraphQL cache restored from AsyncStorage.
+// home: React Query cache for HomeSection data-driven sections.
+// sue: React Query cache for SUE request list data.
+export const CACHE_SCOPES = {
+  APOLLO: 'apollo',
+  GENERAL: 'general',
+  HOME: 'home',
+  SUE: 'sue'
+};
+
+const expiresAtKeyFor = (key) => `${key}:expires-at`;
+const HOURS_TO_MILLISECONDS = 60 * 60 * 1000;
+
+export const millisecondsUntilEndOfDay = () =>
+  Math.max(moment().endOf('day').diff(moment(), 'milliseconds'), 0);
+
+const cacheConfigFor = (globalSettings, cacheScope = CACHE_SCOPES.GENERAL) => {
+  const cacheConfig = globalSettings?.settings?.cache;
+
+  if (!cacheConfig) {
+    return undefined;
+  }
+
+  // Scope-specific values override general; general remains the cross-app fallback.
+  return cacheConfig[cacheScope] ?? cacheConfig[CACHE_SCOPES.GENERAL];
+};
+
+const normalizeMomentEndOfUnit = (value) => {
+  const normalizedValue = value.replace(/[\s_-]/g, '').toLowerCase();
+  const endOfMatch = normalizedValue.match(/^endof['"]?\(?['"]?([a-z]+)['"]?\)?$/);
+  const endMatch = normalizedValue.match(/^end([a-z]+)$/);
+  const unit = endOfMatch?.[1] ?? endMatch?.[1];
+
+  if (!unit) {
+    return undefined;
+  }
+
+  const units = {
+    date: 'day',
+    day: 'day',
+    hour: 'hour',
+    isoWeek: 'isoWeek',
+    isoweek: 'isoWeek',
+    month: 'month',
+    quarter: 'quarter',
+    week: 'week',
+    year: 'year'
+  };
+
+  return units[unit];
+};
+
+const configuredCacheMaxAgeInMilliseconds = (globalSettings, cacheScope) => {
+  const cacheConfig = cacheConfigFor(globalSettings, cacheScope);
+
+  if (typeof cacheConfig === 'number') {
+    return Number.isFinite(cacheConfig) && cacheConfig >= 0
+      ? cacheConfig * HOURS_TO_MILLISECONDS
+      : undefined;
+  }
+
+  if (typeof cacheConfig !== 'string') {
+    return undefined;
+  }
+
+  const momentEndOfUnit = normalizeMomentEndOfUnit(cacheConfig);
+
+  if (!momentEndOfUnit) {
+    return undefined;
+  }
+
+  return Math.max(moment().endOf(momentEndOfUnit).diff(moment(), 'milliseconds'), 0);
+};
+
+export const millisecondsUntilCacheExpires = (globalSettings, cacheScope = CACHE_SCOPES.GENERAL) =>
+  configuredCacheMaxAgeInMilliseconds(globalSettings, cacheScope) ?? millisecondsUntilEndOfDay();
+
+export const endOfDayTimestamp = () => moment().endOf('day').valueOf();
+
+export const endOfDayUnix = () => moment().endOf('day').unix();
+
+export const cacheExpiresAtTimestamp = (globalSettings, cacheScope = CACHE_SCOPES.GENERAL) =>
+  configuredCacheMaxAgeInMilliseconds(globalSettings, cacheScope) !== undefined
+    ? Date.now() + millisecondsUntilCacheExpires(globalSettings, cacheScope)
+    : endOfDayTimestamp();
+
+export const createEndOfDayExpiringStorage = (
+  storage,
+  { cacheKey = APOLLO_CACHE_PERSIST_KEY, cacheScope = CACHE_SCOPES.APOLLO, getGlobalSettings } = {}
+) => {
+  const expiresAtKey = expiresAtKeyFor(cacheKey);
+
+  const purgeCache = async () => {
+    await storage.removeItem(cacheKey);
+    await storage.removeItem(expiresAtKey);
+  };
+
+  return {
+    ...storage,
+    getItem: async (key) => {
+      if (key !== cacheKey) {
+        return storage.getItem(key);
+      }
+
+      const expiresAt = Number(await storage.getItem(expiresAtKey));
+
+      if (!expiresAt || Date.now() >= expiresAt) {
+        await purgeCache();
+
+        return null;
+      }
+
+      return storage.getItem(key);
+    },
+    setItem: async (key, value) => {
+      await storage.setItem(key, value);
+
+      if (key === cacheKey) {
+        const globalSettings = await getGlobalSettings?.();
+
+        await storage.setItem(
+          expiresAtKey,
+          `${cacheExpiresAtTimestamp(globalSettings, cacheScope)}`
+        );
+      }
+    },
+    removeItem: async (key) => {
+      await storage.removeItem(key);
+
+      if (key === cacheKey) {
+        await storage.removeItem(expiresAtKey);
+      }
+    }
+  };
+};

--- a/src/helpers/cacheHelper.js
+++ b/src/helpers/cacheHelper.js
@@ -110,6 +110,12 @@ export const createEndOfDayExpiringStorage = (
     await storage.removeItem(expiresAtKey);
   };
 
+  const writeExpiresAt = async () => {
+    const globalSettings = await getGlobalSettings?.();
+
+    await storage.setItem(expiresAtKey, `${cacheExpiresAtTimestamp(globalSettings, cacheScope)}`);
+  };
+
   return {
     ...storage,
     getItem: async (key) => {
@@ -117,26 +123,32 @@ export const createEndOfDayExpiringStorage = (
         return storage.getItem(key);
       }
 
+      const cache = await storage.getItem(key);
       const expiresAt = Number(await storage.getItem(expiresAtKey));
 
-      if (!expiresAt || Date.now() >= expiresAt) {
+      if (!cache) {
+        return null;
+      }
+
+      if (!expiresAt) {
+        await writeExpiresAt();
+
+        return cache;
+      }
+
+      if (Date.now() >= expiresAt) {
         await purgeCache();
 
         return null;
       }
 
-      return storage.getItem(key);
+      return cache;
     },
     setItem: async (key, value) => {
       await storage.setItem(key, value);
 
       if (key === cacheKey) {
-        const globalSettings = await getGlobalSettings?.();
-
-        await storage.setItem(
-          expiresAtKey,
-          `${cacheExpiresAtTimestamp(globalSettings, cacheScope)}`
-        );
+        await writeExpiresAt();
       }
     },
     removeItem: async (key) => {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -9,6 +9,7 @@ export * from './addressHelper';
 export * from './bookmarkHelper';
 export * from './calendarHelper';
 export * from './cameraHelper';
+export * from './cacheHelper';
 export * from './citySelectionHelper';
 export * from './colorHelper';
 export * from './dateTimeHelper';

--- a/src/helpers/refreshIntervalHelper.js
+++ b/src/helpers/refreshIntervalHelper.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 
 import { consts } from '../config/consts';
 
+import { endOfDayUnix } from './cacheHelper';
 import { addToStore, readFromStore } from './storageHelper';
 
 /**
@@ -19,8 +20,7 @@ import { addToStore, readFromStore } from './storageHelper';
  */
 export const refreshTimeFor = async (refreshTimeKey, refreshInterval) => {
   if (refreshInterval === consts.REFRESH_INTERVALS.NEVER) {
-    // always return tomorrow, so that we never refresh
-    return moment().add(1, 'days').unix();
+    return endOfDayUnix();
   }
 
   const refreshIntervals = await readFromStore('refresh-intervals');
@@ -32,7 +32,7 @@ export const refreshTimeFor = async (refreshTimeKey, refreshInterval) => {
 
   switch (refreshInterval) {
     case consts.REFRESH_INTERVALS.ONCE_A_DAY: {
-      const endOfDay = moment().endOf('day').unix();
+      const endOfDay = endOfDayUnix();
 
       if (endOfDay > refreshTime) {
         // store or update refresh time in AsyncStorage

--- a/src/helpers/refreshIntervalHelper.js
+++ b/src/helpers/refreshIntervalHelper.js
@@ -20,7 +20,7 @@ import { addToStore, readFromStore } from './storageHelper';
  */
 export const refreshTimeFor = async (refreshTimeKey, refreshInterval) => {
   if (refreshInterval === consts.REFRESH_INTERVALS.NEVER) {
-    return endOfDayUnix();
+    return Number.MAX_SAFE_INTEGER;
   }
 
   const refreshIntervals = await readFromStore('refresh-intervals');

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { BookmarkProvider } from './BookmarkProvider';
 import { consts, namespace, secrets } from './config';
 import { ConfigurationsProvider } from './ConfigurationsProvider';
 import {
+  createEndOfDayExpiringStorage,
   geoLocationToLocationObject,
   graphqlFetchPolicy,
   parsedImageAspectRatio,
@@ -76,7 +77,9 @@ const MainAppWithApolloProvider = () => {
     // const link = ApolloLink.from([authLink, restLink, errorLink, retryLink, httpLink]);
     const link = ApolloLink.from([authLink, httpLink]);
     const cache = new InMemoryCache();
-    const storage = AsyncStorage;
+    const storage = createEndOfDayExpiringStorage(AsyncStorage, {
+      getGlobalSettings: storageHelper.globalSettings
+    });
 
     try {
       // await before instantiating ApolloClient,
@@ -219,18 +222,20 @@ const MainAppWithApolloProvider = () => {
           initialConversationSettings
         }}
       >
-        <ConfigurationsProvider>
-          <OnboardingManager>
-            <ProfileProvider>
-              <UnreadMessagesProvider>
-                <RootView>
-                  <OtaUpdateManager />
-                  <Navigator navigationType={initialGlobalSettings.navigation} />
-                </RootView>
-              </UnreadMessagesProvider>
-            </ProfileProvider>
-          </OnboardingManager>
-        </ConfigurationsProvider>
+        <ReactQueryProvider globalSettings={initialGlobalSettings}>
+          <ConfigurationsProvider>
+            <OnboardingManager>
+              <ProfileProvider>
+                <UnreadMessagesProvider>
+                  <RootView>
+                    <OtaUpdateManager />
+                    <Navigator navigationType={initialGlobalSettings.navigation} />
+                  </RootView>
+                </UnreadMessagesProvider>
+              </ProfileProvider>
+            </OnboardingManager>
+          </ConfigurationsProvider>
+        </ReactQueryProvider>
       </SettingsProvider>
     </ApolloProvider>
   );
@@ -241,13 +246,11 @@ export const MainApp = () => (
     <OrientationProvider>
       <BookmarkProvider>
         <PermanentFilterProvider>
-          <ReactQueryProvider>
-            <SafeAreaProvider>
-              <AccessibilityProvider>
-                <MainAppWithApolloProvider />
-              </AccessibilityProvider>
-            </SafeAreaProvider>
-          </ReactQueryProvider>
+          <SafeAreaProvider>
+            <AccessibilityProvider>
+              <MainAppWithApolloProvider />
+            </AccessibilityProvider>
+          </SafeAreaProvider>
         </PermanentFilterProvider>
       </BookmarkProvider>
     </OrientationProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ import { OrientationProvider } from './OrientationProvider';
 import { PermanentFilterProvider } from './PermanentFilterProvider';
 import { ProfileProvider } from './ProfileProvider';
 import { getQuery, QUERY_TYPES } from './queries';
-import { ReactQueryProvider } from './ReactQueryProvider';
+import { ReactQueryCacheSettings, ReactQueryProvider } from './ReactQueryProvider';
 import RootView from './RootView';
 import { initialContext, SettingsContext, SettingsProvider } from './SettingsProvider';
 import { UnreadMessagesProvider } from './UnreadMessagesProvider';
@@ -46,7 +46,8 @@ const MainAppWithSettings = () => {
   const { globalSettings } = useContext(SettingsContext);
 
   return (
-    <ReactQueryProvider globalSettings={globalSettings}>
+    <>
+      <ReactQueryCacheSettings globalSettings={globalSettings} />
       <ConfigurationsProvider>
         <OnboardingManager>
           <ProfileProvider>
@@ -59,7 +60,7 @@ const MainAppWithSettings = () => {
           </ProfileProvider>
         </OnboardingManager>
       </ConfigurationsProvider>
-    </ReactQueryProvider>
+    </>
   );
 };
 
@@ -254,11 +255,13 @@ export const MainApp = () => (
     <OrientationProvider>
       <BookmarkProvider>
         <PermanentFilterProvider>
-          <SafeAreaProvider>
-            <AccessibilityProvider>
-              <MainAppWithApolloProvider />
-            </AccessibilityProvider>
-          </SafeAreaProvider>
+          <ReactQueryProvider>
+            <SafeAreaProvider>
+              <AccessibilityProvider>
+                <MainAppWithApolloProvider />
+              </AccessibilityProvider>
+            </SafeAreaProvider>
+          </ReactQueryProvider>
         </PermanentFilterProvider>
       </BookmarkProvider>
     </OrientationProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -36,11 +36,32 @@ import { ProfileProvider } from './ProfileProvider';
 import { getQuery, QUERY_TYPES } from './queries';
 import { ReactQueryProvider } from './ReactQueryProvider';
 import RootView from './RootView';
-import { initialContext, SettingsProvider } from './SettingsProvider';
+import { initialContext, SettingsContext, SettingsProvider } from './SettingsProvider';
 import { UnreadMessagesProvider } from './UnreadMessagesProvider';
 import { OtaUpdateManager } from './components';
 
 const { LIST_TYPES } = consts;
+
+const MainAppWithSettings = () => {
+  const { globalSettings } = useContext(SettingsContext);
+
+  return (
+    <ReactQueryProvider globalSettings={globalSettings}>
+      <ConfigurationsProvider>
+        <OnboardingManager>
+          <ProfileProvider>
+            <UnreadMessagesProvider>
+              <RootView>
+                <OtaUpdateManager />
+                <Navigator navigationType={globalSettings.navigation} />
+              </RootView>
+            </UnreadMessagesProvider>
+          </ProfileProvider>
+        </OnboardingManager>
+      </ConfigurationsProvider>
+    </ReactQueryProvider>
+  );
+};
 
 const MainAppWithApolloProvider = () => {
   const { isConnected, isMainserverUp } = useContext(NetworkContext);
@@ -222,20 +243,7 @@ const MainAppWithApolloProvider = () => {
           initialConversationSettings
         }}
       >
-        <ReactQueryProvider globalSettings={initialGlobalSettings}>
-          <ConfigurationsProvider>
-            <OnboardingManager>
-              <ProfileProvider>
-                <UnreadMessagesProvider>
-                  <RootView>
-                    <OtaUpdateManager />
-                    <Navigator navigationType={initialGlobalSettings.navigation} />
-                  </RootView>
-                </UnreadMessagesProvider>
-              </ProfileProvider>
-            </OnboardingManager>
-          </ConfigurationsProvider>
-        </ReactQueryProvider>
+        <MainAppWithSettings />
       </SettingsProvider>
     </ApolloProvider>
   );

--- a/src/screens/SUE/SueListScreen.tsx
+++ b/src/screens/SUE/SueListScreen.tsx
@@ -2,7 +2,6 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import _filter from 'lodash/filter';
-import moment from 'moment';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { RefreshControl, StyleSheet } from 'react-native';
 import { Divider } from 'react-native-elements';
@@ -10,6 +9,7 @@ import { useInfiniteQuery, useQuery } from 'react-query';
 
 import { ConfigurationsContext } from '../../ConfigurationsProvider';
 import { NetworkContext } from '../../NetworkProvider';
+import { SettingsContext } from '../../SettingsProvider';
 import {
   EmptyMessage,
   Filter,
@@ -23,6 +23,7 @@ import {
   WrapperVertical
 } from '../../components';
 import { colors, consts, normalize, texts } from '../../config';
+import { CACHE_SCOPES, millisecondsUntilCacheExpires } from '../../helpers/cacheHelper';
 import { parseListItemsFromQuery } from '../../helpers';
 import { getQuery, QUERY_TYPES } from '../../queries';
 import { StatusProps, SueViewType } from '../../types';
@@ -78,6 +79,7 @@ type Props = {
 
 export const SueListScreen = ({ navigation, route }: Props) => {
   const { isConnected } = useContext(NetworkContext);
+  const { globalSettings } = useContext(SettingsContext);
   const { appDesignSystem = {} } = useContext(ConfigurationsContext);
   const { sueStatus = {}, sueListItem = {} } = appDesignSystem;
   const { statuses }: { statuses: StatusProps[] } = sueStatus;
@@ -119,7 +121,7 @@ export const SueListScreen = ({ navigation, route }: Props) => {
 
         return allPages.length * limit;
       },
-      cacheTime: moment().endOf('day').diff(moment(), 'milliseconds')
+      cacheTime: millisecondsUntilCacheExpires(globalSettings, CACHE_SCOPES.SUE)
     }
   );
 


### PR DESCRIPTION
## Summary

- Added configurable cache expiration via `globalSettings.settings.cache`.
- Introduced cache scopes for `general`, `apollo`, `home`, and `sue`.
- Supported hour-based cache values and Moment-style end-of-period values like `endDay`.
- Documented cache configuration in `docs/CACHE_CONFIGURATION.md`.

## Details

This change keeps the existing end-of-day cache refresh behavior as the default, while allowing deployments to override cache lifetimes from the main-server `globalSettings`.

The new cache config supports both global and scope-specific settings:

```json
"settings": {
  "cache": {
    "general": "endDay",
    "apollo": 6,
    "home": "endOfHour",
    "sue": 14
  }
}
```

Scope behavior:

- `general`: default React Query cache and fallback for missing scopes
- `apollo`: persisted Apollo GraphQL cache restored from AsyncStorage
- `home`: Home screen data sections rendered through `HomeSection`
- `sue`: SUE request list data loaded through `SueListScreen`

Numeric values are interpreted as hours. String values are interpreted as Moment-style `endOf(...)` aliases, such as `endDay`, `endOfDay`, `endOfWeek`, or `endOfMonth`.

## Why

Previously, cache expiration was either implicit, hardcoded, or applied globally. This made it difficult to tune cache behavior for specific app areas without changing code.

With scoped cache settings, deployments can keep a broad default cache policy while adjusting high-change areas like SUE independently.

## Testing

- `yarn test __tests__/helpers/cacheHelper.test.js --runInBand`
- `./node_modules/.bin/eslint src/helpers/cacheHelper.js __tests__/helpers/cacheHelper.test.js src/ReactQueryProvider.tsx src/components/HomeSection.tsx`
