### PR TITLE
feat(events): integrate generic item event sources

### DIFF
--- a/__tests__/components/DataListSection.test.tsx
+++ b/__tests__/components/DataListSection.test.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { DataListSection } from '../../src/components/DataListSection';
+
+let mockListProps: Record<string, any>;
+
+jest.mock('../../src/helpers', () => ({
+  getTitleForQuery: jest.fn(() => 'Events'),
+  parseListItemsFromQuery: jest.fn(() => [])
+}));
+jest.mock('../../src/components/ListComponent', () => ({
+  ListComponent: (props: Record<string, any>) => {
+    mockListProps = props;
+    return null;
+  }
+}));
+
+describe('DataListSection', () => {
+  it('renders additional data when the main query has no records', () => {
+    const additionalEvent = {
+      id: 'generic-event-1',
+      listDate: '2030-01-01T10:00:00.000Z',
+      title: 'Generic Item Event'
+    };
+
+    render(
+      <DataListSection
+        additionalData={[additionalEvent]}
+        navigation={{} as any}
+        query="eventRecords"
+        sectionData={[]}
+      />
+    );
+
+    expect(mockListProps.data).toEqual([additionalEvent]);
+  });
+
+  it('removes the divider from the last visible mixed-source item', () => {
+    const events = [
+      { id: 'main', listDate: '2030-01-01', title: 'Main Event' },
+      { id: 'generic', listDate: '2030-01-02', title: 'Generic Event' },
+      { id: 'later', listDate: '2030-01-03', title: 'Later Event' }
+    ];
+
+    render(
+      <DataListSection
+        additionalData={events}
+        limit={2}
+        navigation={{} as any}
+        query="eventRecords"
+        sectionData={[]}
+        skipLastDivider
+      />
+    );
+
+    expect(mockListProps.data).toEqual([events[0], { ...events[1], bottomDivider: false }]);
+  });
+});

--- a/__tests__/components/GenericItemEventConsumers.test.tsx
+++ b/__tests__/components/GenericItemEventConsumers.test.tsx
@@ -1,0 +1,429 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-var-requires */
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import moment from 'moment';
+
+import { Calendar } from '../../src/components/Calendar';
+import { HomeSection } from '../../src/components/HomeSection';
+import { EventRecords } from '../../src/components/screens/EventRecords';
+import { EventWidget } from '../../src/components/widgets/EventWidget';
+import { NetworkContext } from '../../src/NetworkProvider';
+import { SettingsContext } from '../../src/SettingsProvider';
+
+const mockUseGenericItemEvents = jest.fn();
+const mockUseHomeRefresh = jest.fn();
+let mockDataListProps: Record<string, any>;
+let mockWidgetProps: Record<string, any>;
+let mockListProps: Record<string, any>;
+let mockNativeCalendarProps: Record<string, any>;
+let mockQueryResult: Record<string, any>;
+let mockInfiniteResult: Record<string, any>;
+const mockMainRefetch = jest.fn(async () => undefined);
+const mockGenericRefetch = jest.fn(async () => undefined);
+
+jest.mock('../../src/NetworkProvider', () => {
+  const ReactInMock = require('react');
+  return {
+    NetworkContext: ReactInMock.createContext({ isConnected: true, isMainserverUp: true })
+  };
+});
+
+jest.mock('@react-navigation/core', () => ({
+  useNavigation: jest.fn(() => ({ navigate: jest.fn() }))
+}));
+jest.mock('@react-navigation/native', () => ({ useFocusEffect: jest.fn() }));
+jest.mock('react-native-calendars', () => ({
+  Calendar: (props: Record<string, any>) => {
+    mockNativeCalendarProps = props;
+    return null;
+  }
+}));
+jest.mock('react-apollo', () => ({
+  useQuery: jest.fn(() => ({ data: {}, loading: false }))
+}));
+
+jest.mock('react-query', () => ({
+  useQuery: jest.fn(() => mockQueryResult),
+  useInfiniteQuery: jest.fn(() => mockInfiniteResult)
+}));
+jest.mock('../../src/hooks', () => ({
+  useGenericItemEvents: (options: unknown) => mockUseGenericItemEvents(options),
+  useHomePointsOfInterestAndToursRefresh: jest.fn(),
+  useHomeRefresh: (callback: unknown) => mockUseHomeRefresh(callback),
+  useLastKnownPosition: jest.fn(() => ({})),
+  useLocationSettings: jest.fn(() => ({ locationSettings: {} })),
+  useOpenWebScreen: jest.fn(),
+  usePosition: jest.fn(() => ({})),
+  useSystemPermission: jest.fn(() => ({})),
+  useTheme: jest.fn(() => ({
+    colors: { calendarSelected: '#456', primary: '#123', refreshControl: '#000' }
+  })),
+  useThemeStyles: jest.fn((factory) => factory()),
+  useVolunteerData: jest.fn(() => ({ data: [], isLoading: false, refetch: jest.fn() }))
+}));
+jest.mock('../../src/helpers', () => ({
+  filterTypesHelper: jest.fn(() => []),
+  geoLocationFilteredListItem: jest.fn(({ listItem }) => listItem),
+  openLink: jest.fn(),
+  parseListItemsFromQuery: jest.fn((query, data) =>
+    (data?.[query] || []).map((item: Record<string, any>) => ({ ...item }))
+  )
+}));
+jest.mock('../../src/helpers/calendarHelper', () => ({
+  getCalendarTheme: jest.fn(() => ({})),
+  setupLocales: jest.fn()
+}));
+jest.mock('../../src/helpers/updateResourceFiltersStateHelper', () => ({
+  updateResourceFiltersStateHelper: jest.fn()
+}));
+jest.mock('../../src/components/filter', () => ({ Filter: () => null }));
+jest.mock('../../src/components/calendarArrows', () => ({ renderArrow: jest.fn() }));
+jest.mock('../../src/components/DataListSection', () => ({
+  DataListSection: (props: Record<string, any>) => {
+    mockDataListProps = props;
+    const ReactInMock = require('react');
+    const { Text: TextInMock } = require('react-native');
+    return ReactInMock.createElement(TextInMock, null, 'section');
+  }
+}));
+jest.mock('../../src/components/widgets/DefaultWidget', () => ({
+  DefaultWidget: (props: Record<string, any>) => {
+    mockWidgetProps = props;
+    const ReactInMock = require('react');
+    const { Text: TextInMock } = require('react-native');
+    return ReactInMock.createElement(TextInMock, null, 'widget');
+  }
+}));
+jest.mock('../../src/components/ListComponent', () => ({
+  ListComponent: (props: Record<string, any>) => {
+    mockListProps = props;
+    const ReactInMock = require('react');
+    const { Text: TextInMock } = require('react-native');
+    return ReactInMock.createElement(
+      ReactInMock.Fragment,
+      null,
+      ReactInMock.createElement(
+        TextInMock,
+        { onPress: props.refreshControl?.props?.onRefresh },
+        'list'
+      ),
+      props.data?.length === 0 ? props.ListEmptyComponent : null
+    );
+  }
+}));
+jest.mock('../../src/components/CalendarListToggle', () => ({
+  CalendarListToggle: ({ setShowCalendar }: Record<string, any>) => {
+    const ReactInMock = require('react');
+    const { Text: TextInMock } = require('react-native');
+    return ReactInMock.createElement(
+      TextInMock,
+      { onPress: () => setShowCalendar(true) },
+      'toggle'
+    );
+  }
+}));
+jest.mock('../../src/components/LoadingContainer', () => ({
+  LoadingContainer: ({ children }: Record<string, any>) => children || null
+}));
+jest.mock('../../src/components/EmptyMessage', () => ({ EmptyMessage: () => null }));
+jest.mock('../../src/queries', () => ({
+  QUERY_TYPES: {
+    EVENT_RECORDS: 'eventRecords',
+    EVENT_RECORDS_COUNT: 'eventRecordsCount',
+    POINTS_OF_INTEREST: 'pointsOfInterest',
+    POINTS_OF_INTEREST_AND_TOURS: 'pointsOfInterestAndTours',
+    TOURS: 'tours',
+    VOLUNTEER: { CALENDAR_ALL: 'volunteerCalendar' }
+  },
+  getQuery: jest.fn()
+}));
+jest.mock('../../src/config', () => ({
+  colors: {
+    calendarSelected: '#456',
+    darkText: '#111',
+    primary: '#123',
+    refreshControl: '#000',
+    surface: '#fff'
+  },
+  consts: {
+    CALENDAR: { DOT_SIZE: 4, MAX_DOTS_PER_DAY: 3 },
+    EVENT_SUGGESTION_BUTTON: { BOTTOM_FLOATING: 'bottom', TOP: 'top' },
+    ROOT_ROUTE_NAMES: { EVENT_RECORDS: 'Events' }
+  },
+  Icon: { Calendar: () => null },
+  normalize: (value: number) => value,
+  texts: {
+    empty: { list: 'Empty' },
+    homeTitles: { events: 'Events' },
+    widgets: { events: 'Events' }
+  }
+}));
+
+const settingsValue = {
+  globalSettings: {
+    hdvt: {},
+    settings: {
+      eventCalendar: {
+        genericItemEventSources: [{ genericType: 'ParticipationProject' }]
+      }
+    }
+  }
+} as any;
+const occurrence = { id: 'event', listDate: '2030-01-01', startTime: '10:00', title: 'Event' };
+
+const renderEventRecords = (queryVariables: Record<string, unknown> = {}) =>
+  render(
+    <NetworkContext.Provider value={{ isConnected: true, isMainserverUp: true }}>
+      <SettingsContext.Provider value={settingsValue}>
+        <EventRecords
+          navigation={{ navigate: jest.fn() }}
+          route={{
+            params: {
+              query: 'eventRecords',
+              queryVariables: { limit: 15, ...queryVariables },
+              title: 'Events'
+            }
+          }}
+        />
+      </SettingsContext.Provider>
+    </NetworkContext.Provider>
+  );
+
+describe('Generic Item event consumers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseGenericItemEvents.mockReturnValue({
+      data: [occurrence],
+      isLoading: false,
+      isRefetching: false,
+      refetch: mockGenericRefetch
+    });
+    mockQueryResult = {
+      data: { eventRecords: [] },
+      isLoading: false,
+      isRefetching: false,
+      refetch: mockMainRefetch
+    };
+    mockInfiniteResult = {
+      data: { pages: [{ eventRecords: [] }] },
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+      isRefetching: false,
+      refetch: mockMainRefetch
+    };
+    mockListProps = undefined as any;
+    mockNativeCalendarProps = undefined as any;
+  });
+
+  it('merges Generic Item occurrences into EventRecords list data and refreshes them', async () => {
+    mockInfiniteResult.data = {
+      pages: [{ eventRecords: [{ id: 'main', listDate: '2029-12-31', title: 'Main' }] }]
+    };
+    const view = renderEventRecords();
+    expect(mockListProps.data.map(({ id }: { id: string }) => id)).toEqual(['main', 'event']);
+    await act(async () => fireEvent.press(view.getByText('list')));
+    expect(mockMainRefetch).toHaveBeenCalled();
+    expect(mockGenericRefetch).toHaveBeenCalled();
+  });
+
+  it('suppresses Generic Item occurrences for native category filters', () => {
+    renderEventRecords({ categoryId: 'native-category' });
+    expect(mockListProps.data).toEqual([]);
+  });
+
+  it('includes Generic Item loading in the EventRecords empty loading state', () => {
+    mockUseGenericItemEvents.mockReturnValue({
+      data: [],
+      isLoading: true,
+      isRefetching: false,
+      refetch: mockGenericRefetch
+    });
+    renderEventRecords();
+    expect(mockListProps).toBeUndefined();
+  });
+
+  it('passes occurrences into active calendar view', () => {
+    const calendarSettings = {
+      globalSettings: {
+        hdvt: {},
+        settings: {
+          calendarToggle: true,
+          eventCalendar: { genericItemEventSources: [{ genericType: 'ParticipationProject' }] }
+        }
+      }
+    } as any;
+    const view = render(
+      <NetworkContext.Provider value={{ isConnected: true, isMainserverUp: true }}>
+        <SettingsContext.Provider value={calendarSettings}>
+          <EventRecords
+            navigation={{ navigate: jest.fn() }}
+            route={{ params: { query: 'eventRecords', queryVariables: { limit: 15 } } }}
+          />
+        </SettingsContext.Provider>
+      </NetworkContext.Provider>
+    );
+    fireEvent.press(view.getByText('toggle'));
+    expect(mockNativeCalendarProps.markedDates['2030-01-01'].dots).toHaveLength(1);
+  });
+
+  it('does not mutate cached main records while marking and listing additional events', () => {
+    const cachedRecords = [{ id: 'main', listDate: '2030-01-02', color: '#abc' }];
+    mockQueryResult = {
+      data: { eventRecords: cachedRecords },
+      isLoading: false,
+      isRefetching: false,
+      refetch: mockMainRefetch
+    };
+    render(
+      <NetworkContext.Provider value={{ isConnected: true, isMainserverUp: true }}>
+        <SettingsContext.Provider value={settingsValue}>
+          <Calendar
+            additionalData={[occurrence]}
+            isListRefreshing={false}
+            navigation={{ push: jest.fn() } as any}
+            query="eventRecords"
+            queryVariables={{}}
+          />
+        </SettingsContext.Provider>
+      </NetworkContext.Provider>
+    );
+    expect(cachedRecords).toEqual([{ id: 'main', listDate: '2030-01-02', color: '#abc' }]);
+    expect(mockNativeCalendarProps.markedDates).toEqual(
+      expect.objectContaining({
+        '2030-01-01': expect.objectContaining({ marked: true }),
+        '2030-01-02': expect.objectContaining({ marked: true })
+      })
+    );
+  });
+
+  it('adds configured occurrences to the home event section and enables its button', () => {
+    render(
+      <SettingsContext.Provider value={settingsValue}>
+        <HomeSection
+          buttonTitle="all"
+          isIndexStartingAt1={false}
+          navigate={jest.fn()}
+          navigation={{} as any}
+          query="eventRecords"
+          queryVariables={{ limit: 3 }}
+          skipLastDivider
+          title="Events"
+        />
+      </SettingsContext.Provider>
+    );
+    expect(mockDataListProps.additionalData).toEqual([
+      { ...occurrence, overtitle: '01.01.2030, 10:00 Uhr' }
+    ]);
+    expect(mockDataListProps.showButton).toBe(true);
+    expect(mockDataListProps.skipLastDivider).toBe(true);
+    expect(mockUseGenericItemEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true })
+    );
+  });
+
+  it('refreshes Generic Item occurrences with the home event section', async () => {
+    render(
+      <SettingsContext.Provider value={settingsValue}>
+        <HomeSection
+          buttonTitle="all"
+          isIndexStartingAt1={false}
+          navigate={jest.fn()}
+          navigation={{} as any}
+          query="eventRecords"
+          queryVariables={{ limit: 3 }}
+          title="Events"
+        />
+      </SettingsContext.Provider>
+    );
+    const refresh = mockUseHomeRefresh.mock.calls[0][0];
+    await act(async () => refresh());
+    expect(mockMainRefetch).toHaveBeenCalled();
+    expect(mockGenericRefetch).toHaveBeenCalled();
+  });
+
+  it('adds configured occurrences to the event widget count', () => {
+    render(
+      <SettingsContext.Provider value={settingsValue}>
+        <EventWidget additionalProps={{ noFilterByDailyEvents: true }} />
+      </SettingsContext.Provider>
+    );
+    expect(mockWidgetProps.count).toBe(1);
+    expect(mockUseGenericItemEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ dateRange: undefined, enabled: true })
+    );
+  });
+
+  it('uses today by default and all upcoming occurrences in unfiltered mode', () => {
+    const today = moment().format('YYYY-MM-DD');
+    const defaultView = render(
+      <SettingsContext.Provider value={settingsValue}>
+        <EventWidget />
+      </SettingsContext.Provider>
+    );
+    expect(mockUseGenericItemEvents).toHaveBeenLastCalledWith(
+      expect.objectContaining({ dateRange: [today, today] })
+    );
+    defaultView.unmount();
+    render(
+      <SettingsContext.Provider value={settingsValue}>
+        <EventWidget additionalProps={{ noFilterByDailyEvents: true }} />
+      </SettingsContext.Provider>
+    );
+    expect(mockUseGenericItemEvents).toHaveBeenLastCalledWith(
+      expect.objectContaining({ dateRange: undefined })
+    );
+  });
+
+  it('hides the widget count while Generic Item events load or no-count is configured', () => {
+    mockUseGenericItemEvents.mockReturnValue({
+      data: [],
+      isLoading: true,
+      isRefetching: false,
+      refetch: mockGenericRefetch
+    });
+    const loadingView = render(
+      <SettingsContext.Provider value={settingsValue}>
+        <EventWidget />
+      </SettingsContext.Provider>
+    );
+    expect(mockWidgetProps.count).toBeUndefined();
+    loadingView.unmount();
+    mockUseGenericItemEvents.mockReturnValue({
+      data: [occurrence],
+      isLoading: false,
+      isRefetching: false,
+      refetch: mockGenericRefetch
+    });
+    render(
+      <SettingsContext.Provider value={settingsValue}>
+        <EventWidget additionalProps={{ noCount: true }} />
+      </SettingsContext.Provider>
+    );
+    expect(mockWidgetProps.count).toBeUndefined();
+  });
+
+  it('refreshes Generic Item occurrences with the event widget', async () => {
+    render(
+      <SettingsContext.Provider value={settingsValue}>
+        <EventWidget />
+      </SettingsContext.Provider>
+    );
+    const refresh = mockUseHomeRefresh.mock.calls[0][0];
+    await act(async () => refresh());
+    expect(mockMainRefetch).toHaveBeenCalled();
+    expect(mockGenericRefetch).toHaveBeenCalled();
+  });
+
+  it('disables Generic Item queries without configuration', () => {
+    render(
+      <SettingsContext.Provider value={{ globalSettings: { hdvt: {}, settings: {} } } as any}>
+        <EventWidget />
+      </SettingsContext.Provider>
+    );
+    expect(mockUseGenericItemEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false })
+    );
+  });
+});

--- a/__tests__/components/SectionHeaderAccessibility.test.tsx
+++ b/__tests__/components/SectionHeaderAccessibility.test.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+jest.mock('../../src/config', () => {
+  const MockIcon = () => null;
+
+  return {
+    colors: { darkText: '#111111' },
+    consts: { a11yLabel: { button: '(Taste)', heading: '(Überschrift)' } },
+    device: { platform: 'ios' },
+    Icon: { ArrowRight: MockIcon },
+    normalize: (value: number) => value
+  };
+});
+
+jest.mock('../../src/SettingsProvider', () => {
+  const ReactLocal = require('react');
+
+  return {
+    SettingsContext: ReactLocal.createContext({ globalSettings: { settings: {} } })
+  };
+});
+
+jest.mock('../../src/components/Title', () => {
+  const ReactLocal = require('react');
+
+  return {
+    Title: ({ children, ...props }) => ReactLocal.createElement('mock-title', props, children),
+    TitleContainer: ({ children }) =>
+      ReactLocal.createElement('mock-title-container', {}, children),
+    TitleShadow: () => null
+  };
+});
+
+jest.mock('../../src/components/Wrapper', () => {
+  const ReactLocal = require('react');
+
+  return {
+    WrapperRow: ({ children }) => ReactLocal.createElement('mock-wrapper-row', {}, children)
+  };
+});
+
+import { SectionHeader } from '../../src/components/SectionHeader';
+
+describe('SectionHeader accessibility', () => {
+  it('exposes a non-interactive visually bold section title as a native header', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    renderer.act(() => {
+      tree = renderer.create(<SectionHeader title="Nachrichten" />);
+    });
+
+    const title = tree!.root.findByType('mock-title');
+
+    expect(title.props.accessibilityRole).toBe('header');
+    expect(title.props.accessibilityLabel).toBe('(Nachrichten) (Überschrift)');
+  });
+
+  it('keeps an interactive section title exposed as a button', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    renderer.act(() => {
+      tree = renderer.create(<SectionHeader onPress={jest.fn()} title="Nachrichten" />);
+    });
+
+    const touchable = tree!.root.find((node) => node.props.activeOpacity === 0.6);
+    const title = tree!.root.findByType('mock-title');
+
+    expect(touchable.props.accessibilityLabel).toBe('(Nachrichten) (Überschrift) (Taste)');
+    expect(touchable.props.accessibilityRole).toBe('button');
+    expect(title.props.accessibilityRole).toBeUndefined();
+    expect(title.props.onPress).toBeUndefined();
+    expect(title.props.$interactive).toBe(true);
+  });
+});

--- a/__tests__/helpers/genericItemEventHelper.test.ts
+++ b/__tests__/helpers/genericItemEventHelper.test.ts
@@ -1,0 +1,145 @@
+import moment from 'moment';
+
+import {
+  normalizeGenericItemEventStatus,
+  parseGenericItemEvents
+} from '../../src/helpers/genericItemEventHelper';
+import { GenericItemEventSource } from '../../src/types';
+
+jest.mock('../../src/queries', () => ({
+  QUERY_TYPES: { GENERIC_ITEM: 'genericItem' }
+}));
+jest.mock('../../src/helpers/genericTypeHelper', () => ({
+  getGenericItemDetailTitle: jest.fn(() => 'Beteiligung'),
+  getGenericItemRootRouteName: jest.fn(() => 'ParticipationProjects')
+}));
+jest.mock('../../src/config', () => ({
+  consts: { ROOT_ROUTE_NAMES: { PARTICIPATION_PROJECTS: 'ParticipationProjects' } },
+  texts: { participationProject: { participationProject: 'Beteiligung' } }
+}));
+
+const source: GenericItemEventSource = {
+  genericType: 'ParticipationProject',
+  filterTypes: [' Veranstaltung '],
+  filterStatuses: ['active']
+};
+const item = (overrides: Record<string, unknown> = {}) => ({
+  addresses: [{ city: 'Magdeburg' }],
+  categories: [{ name: 'Veranstaltung' }],
+  contentBlocks: [{ body: '<p>Beschreibung</p>' }],
+  dates: [{ id: 'a', dateStart: '2030-05-03', timeStart: '10:00' }],
+  genericType: 'ParticipationProject',
+  id: '42',
+  mediaContents: [],
+  payload: { status: 'Aktiv', type: 'Termin' },
+  title: 'Dialog',
+  webUrls: [],
+  ...overrides
+});
+
+describe('parseGenericItemEvents', () => {
+  it('matches types from payload or any category and canonical statuses', () => {
+    const result = parseGenericItemEvents([item()], source, ['2030-05-03']);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'ParticipationProject:42:a:2030-05-03',
+      listDate: '2030-05-03',
+      overtitle: '10:00 Uhr',
+      routeName: 'Detail',
+      params: { query: 'genericItem', queryVariables: { id: '42' } }
+    });
+    expect(result[0]).not.toHaveProperty('subtitle');
+    expect(normalizeGenericItemEventStatus(' Abgeschlossen ')).toBe('completed');
+  });
+
+  it('supports empty filters and structured status/color values', () => {
+    const record = item({ payload: { color: '', status: { label: 'Aktiv', color: '#123' } } });
+    expect(
+      parseGenericItemEvents([record], { genericType: 'ParticipationProject' }, ['2030-05-03'])
+    ).toEqual(expect.arrayContaining([expect.objectContaining({ color: '#123' })]));
+  });
+
+  it('excludes type and status mismatches', () => {
+    expect(
+      parseGenericItemEvents([item()], { ...source, filterTypes: ['Workshop'] }, ['2030-05-03'])
+    ).toEqual([]);
+    expect(
+      parseGenericItemEvents([item()], { ...source, filterStatuses: ['ended'] }, ['2030-05-03'])
+    ).toEqual([]);
+  });
+
+  it('creates distinct sorted occurrences and skips invalid dates', () => {
+    const dates = [
+      { id: 'b', dateStart: '2030-05-04', timeStart: '09:00' },
+      { id: 'a', dateFrom: '2030-05-03', timeFrom: '12:00' },
+      { id: 'bad', dateStart: 'not-a-date' }
+    ];
+    const result = parseGenericItemEvents([item({ dates })], source, ['2030-05-03', '2030-05-04']);
+    expect(result.map(({ id }) => id)).toEqual([
+      'ParticipationProject:42:a:2030-05-03',
+      'ParticipationProject:42:b:2030-05-04'
+    ]);
+  });
+
+  it('uses a stable index fallback and orders equal-day occurrences by time then title', () => {
+    const first = item({
+      id: 'first',
+      title: 'Zulu',
+      dates: [{ dateStart: '2030-05-03', timeStart: '12:00' }]
+    });
+    const second = item({
+      id: 'second',
+      title: 'Alpha',
+      dates: [
+        { dateStart: '2030-05-03', timeStart: '09:00' },
+        { dateStart: '2030-05-03', timeStart: '12:00' }
+      ]
+    });
+    const result = parseGenericItemEvents([first, second], source, ['2030-05-03']);
+    expect(result.map(({ title }) => title)).toEqual(['Alpha', 'Alpha', 'Zulu']);
+    expect(result.map(({ id }) => id)).toEqual([
+      'ParticipationProject:second:0:2030-05-03',
+      'ParticipationProject:second:1:2030-05-03',
+      'ParticipationProject:first:0:2030-05-03'
+    ]);
+  });
+
+  it('builds the complete Generic Item detail navigation contract', () => {
+    const record = item();
+    expect(parseGenericItemEvents([record], source, ['2030-05-03'])[0].params).toEqual(
+      expect.objectContaining({
+        details: record,
+        query: 'genericItem',
+        queryVariables: { id: '42' },
+        rootRouteName: 'ParticipationProjects',
+        title: 'Beteiligung'
+      })
+    );
+  });
+
+  it('uses inclusive ranges and excludes past dates without a range', () => {
+    expect(parseGenericItemEvents([item()], source, ['2030-05-03'])).toHaveLength(1);
+    expect(parseGenericItemEvents([item()], source, ['2030-05-04', '2030-05-05'])).toEqual([]);
+    const yesterday = moment().subtract(1, 'day').format('YYYY-MM-DD');
+    expect(
+      parseGenericItemEvents([item({ dates: [{ id: 'past', dateStart: yesterday }] })], source)
+    ).toEqual([]);
+  });
+
+  it('handles malformed records and configuration safely', () => {
+    expect(parseGenericItemEvents(null, source)).toEqual([]);
+    expect(parseGenericItemEvents([null, { payload: null }], source)).toEqual([]);
+    expect(parseGenericItemEvents([item()], {} as GenericItemEventSource)).toEqual([]);
+    expect(
+      parseGenericItemEvents(
+        [item()],
+        {
+          genericType: 'ParticipationProject',
+          filterTypes: null,
+          filterStatuses: null
+        } as unknown as GenericItemEventSource,
+        ['2030-05-03']
+      )
+    ).toHaveLength(1);
+  });
+});

--- a/__tests__/helpers/textHelper.test.js
+++ b/__tests__/helpers/textHelper.test.js
@@ -1,0 +1,13 @@
+import { subtitle } from '../../src/helpers/textHelper';
+
+describe('subtitle', () => {
+  it('keeps the time when formatting a date without a third detail', () => {
+    expect(subtitle('01.01.2030', undefined, '10:00')).toBe('01.01.2030, 10:00 Uhr');
+  });
+
+  it('preserves the existing combinations', () => {
+    expect(subtitle('01.01.2030', 'Magdeburg', '10:00')).toBe('01.01.2030, 10:00 Uhr | Magdeburg');
+    expect(subtitle('01.01.2030', 'Magdeburg')).toBe('01.01.2030 | Magdeburg');
+    expect(subtitle(undefined, 'Magdeburg', '10:00')).toBe('10:00 Uhr | Magdeburg');
+  });
+});

--- a/__tests__/hooks/genericItemEvents.test.tsx
+++ b/__tests__/hooks/genericItemEvents.test.tsx
@@ -74,6 +74,26 @@ describe('useGenericItemEvents', () => {
     });
   });
 
+  it('normalizes generic type whitespace before querying and parsing', async () => {
+    mockUseQueries.mockReturnValue([{ data: { genericItems: [{}] } }]);
+    render(<Probe sources={[{ genericType: ' Project ' }]} />);
+
+    const query = mockUseQueries.mock.calls[0][0][0];
+    mockRequest.mockResolvedValue({ genericItems: [] });
+    await query.queryFn();
+
+    expect(query.queryKey).toEqual(['genericItems', { genericType: 'Project' }]);
+    expect(mockRequest).toHaveBeenCalledWith('query', {
+      genericType: 'Project',
+      limit: undefined
+    });
+    expect(mockParse).toHaveBeenCalledWith(
+      [{}],
+      expect.objectContaining({ genericType: 'Project' }),
+      undefined
+    );
+  });
+
   it('disables raw queries when the integration is disabled', () => {
     render(<Probe enabled={false} />);
     expect(mockUseQueries.mock.calls[0][0][0].enabled).toBe(false);

--- a/__tests__/hooks/genericItemEvents.test.tsx
+++ b/__tests__/hooks/genericItemEvents.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { useGenericItemEvents } from '../../src/hooks/genericItemEvents';
+import { GenericItemEventSource } from '../../src/types';
+
+const mockUseQueries = jest.fn();
+const mockRequest = jest.fn();
+const mockParse = jest.fn();
+
+jest.mock('react-query', () => ({ useQueries: (options: unknown) => mockUseQueries(options) }));
+jest.mock('../../src/ReactQueryClient', () => ({
+  ReactQueryClient: jest.fn(async () => ({ request: mockRequest }))
+}));
+jest.mock('../../src/helpers/genericItemEventHelper', () => ({
+  parseGenericItemEvents: (...args: unknown[]) => mockParse(...args)
+}));
+jest.mock('../../src/queries', () => ({
+  getQuery: jest.fn(() => 'query')
+}));
+jest.mock('../../src/queries/types', () => ({
+  QUERY_TYPES: { GENERIC_ITEMS: 'genericItems' }
+}));
+
+const defaultSources = [
+  { genericType: 'Project', filterTypes: ['Event'] },
+  { genericType: 'Project', filterStatuses: ['active'] }
+];
+const Probe = ({
+  enabled = true,
+  onResult,
+  sources = defaultSources
+}: {
+  enabled?: boolean;
+  onResult?: (result: ReturnType<typeof useGenericItemEvents>) => void;
+  sources?: GenericItemEventSource[];
+}) => {
+  const result = useGenericItemEvents({
+    enabled,
+    sources
+  });
+  React.useEffect(() => onResult?.(result), [onResult, result]);
+  return (
+    <Text testID="value">{`${result.data.length}:${result.isLoading}:${result.isRefetching}`}</Text>
+  );
+};
+
+describe('useGenericItemEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParse.mockReturnValue([]);
+    mockUseQueries.mockReturnValue([]);
+  });
+
+  it('groups duplicate generic types under one stable raw query', () => {
+    render(<Probe />);
+    expect(mockUseQueries).toHaveBeenCalledWith([
+      expect.objectContaining({
+        enabled: true,
+        queryKey: ['genericItems', { genericType: 'Project' }]
+      })
+    ]);
+  });
+
+  it('requests the raw Generic Item dataset with the configured generic type', async () => {
+    render(<Probe />);
+    const query = mockUseQueries.mock.calls[0][0][0];
+    mockRequest.mockResolvedValue({ genericItems: [] });
+    await expect(query.queryFn()).resolves.toEqual({ genericItems: [] });
+    expect(mockRequest).toHaveBeenCalledWith('query', {
+      genericType: 'Project',
+      limit: undefined
+    });
+  });
+
+  it('disables raw queries when the integration is disabled', () => {
+    render(<Probe enabled={false} />);
+    expect(mockUseQueries.mock.calls[0][0][0].enabled).toBe(false);
+    expect(mockParse).not.toHaveBeenCalled();
+  });
+
+  it('merges and deduplicates transformed occurrences and combines loading state', () => {
+    mockUseQueries.mockReturnValue([
+      { data: { genericItems: [{}] }, isLoading: true, isRefetching: true }
+    ]);
+    mockParse.mockReturnValue([{ id: 'one', listDate: '2030-01-01' }]);
+    const view = render(<Probe />);
+    expect(view.getByTestId('value').props.children).toBe('1:true:true');
+    expect(mockParse).toHaveBeenCalledTimes(2);
+  });
+
+  it('awaits every enabled raw query refetch', async () => {
+    const first = jest.fn(async () => 'first');
+    const second = jest.fn(async () => 'second');
+    mockUseQueries.mockReturnValue([
+      { data: {}, refetch: first },
+      { data: {}, refetch: second }
+    ]);
+    let latestResult: ReturnType<typeof useGenericItemEvents> | undefined;
+    render(
+      <Probe
+        onResult={(result) => {
+          latestResult = result;
+        }}
+        sources={[{ genericType: 'Project' }, { genericType: 'Meeting' }]}
+      />
+    );
+    if (!latestResult) throw new Error('Hook result was not reported');
+    await expect(latestResult.refetch()).resolves.toEqual(['first', 'second']);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/GENERIC_ITEM_EVENTS.md
+++ b/docs/GENERIC_ITEM_EVENTS.md
@@ -1,0 +1,40 @@
+# Generic Item events
+
+Generic Items can be included as additional entries in the event list, calendar, home event
+section, and event widget. Configure one or more sources in the tenant settings:
+
+```json
+{
+  "settings": {
+    "eventCalendar": {
+      "genericItemEventSources": [
+        {
+          "genericType": "ParticipationProject",
+          "filterTypes": ["Veranstaltung"],
+          "filterStatuses": ["active", "announced"]
+        }
+      ]
+    }
+  }
+}
+```
+
+`genericType` selects the Generic Item dataset. `filterTypes` and `filterStatuses` are optional;
+missing or empty arrays disable the corresponding filter. Matches ignore surrounding whitespace
+and letter case. A type is read from `payload.type` and every `categories[].name`. A status can be
+a primitive `payload.status` or a structured value using, in order, `label`, `text`, `title`,
+`name`, `status`, or `value`. Known localized status aliases are canonicalized.
+
+Each valid element in `dates[]` creates one occurrence on `dateStart` (or `dateFrom`). Date ranges
+are not expanded. Without an explicit calendar range, past occurrences are excluded. Missing or
+malformed payload, filter, and date fields fail safely and do not create occurrences.
+
+The resulting occurrences are merged with main-server and other external events in the full event
+list, calendar dots and selected-day sublist, home section, and widget count. Selecting a native
+EventRecord category or location filter suppresses all external sources because those filters do
+not describe their datasets.
+
+Generic Items currently have no server-side `dateRange`. The client therefore fetches and caches
+the returned dataset once per `genericType`, then filters it locally. If the server applies an
+undocumented default limit or a dataset grows substantially, backend date filtering or explicit
+pagination is required so events are not silently omitted.

--- a/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
+++ b/docs/HOME_SCREEN_SECTION_CONFIGURATION.md
@@ -105,6 +105,7 @@ The following example shows a full `homeScreenConfig` that controls the complete
       "limit": 3
     },
     "show": true,
+    "skipLastDivider": true,
     "title": "Veranstaltungen",
     "buttonTitle": "Alle Veranstaltungen anzeigen"
   },
@@ -137,6 +138,9 @@ For data-driven sections (`query`-based entries), the following fields are **opt
 | `eventRecords`             | `title`                         | `sections.headlineEvents`                                |
 | `eventRecords`             | `buttonTitle`                   | `sections.buttonEvents`                                  |
 | `eventRecords`             | `limitEvents`                   | `sections.limitEvents` (default: `15`)                   |
+
+All query-based sections support `skipLastDivider: true`. It removes the divider below the last
+visible item after all sources have been merged and the configured limit has been applied.
 
 ### Backward Compatibility
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -65,3 +65,6 @@ For detailed documentation see [the auth docs](./AUTH.md).
 ## Augmented Reality
 
 For detailed documentation see [the ar docs](./AR.md).
+## Generic Item events
+
+For configuring Generic Items as additional calendar events, see [the Generic Item event docs](./GENERIC_ITEM_EVENTS.md).

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -182,11 +182,7 @@ export const Calendar = ({
 
   const markedDates = useMemo(() => {
     const dates: CalendarProps['markedDates'] = {};
-    const eventRecords = data?.[query] || [];
-
-    if (additionalData?.length) {
-      eventRecords?.push(...additionalData);
-    }
+    const eventRecords = [...(data?.[query] || []), ...(additionalData || [])];
 
     if (eventRecords?.length) {
       eventRecords.forEach((item: { listDate: string; color: string }) => {
@@ -211,7 +207,7 @@ export const Calendar = ({
     };
 
     return dates;
-  }, [additionalData, data, dotCount, query, queryVariablesWithDateRange, selectedDay]);
+  }, [additionalData, colors.calendarSelected, colors.primary, data, dotCount, query, selectedDay]);
 
   const listItems = useMemo(() => {
     if (!subList) return [];

--- a/src/components/DataListSection.tsx
+++ b/src/components/DataListSection.tsx
@@ -56,7 +56,15 @@ type Props = {
   sectionTitleDetail?: string;
   showButton?: boolean;
   showLink?: boolean;
+  skipLastDivider?: boolean;
 };
+
+const removeLastDivider = (data: unknown[]) =>
+  data.map((item, index) =>
+    index === data.length - 1 && item && typeof item === 'object'
+      ? { ...item, bottomDivider: false }
+      : item
+  );
 
 /* eslint-disable complexity */
 export const DataListSection = ({
@@ -81,7 +89,8 @@ export const DataListSection = ({
   sectionTitle = getTitleForQuery(query),
   sectionTitleDetail,
   showButton,
-  showLink
+  showLink,
+  skipLastDivider = false
 }: Props) => {
   const renderSectionHeader = () => {
     if (!sectionTitle) return null;
@@ -126,18 +135,20 @@ export const DataListSection = ({
     }
   }
 
-  if (listData?.length && additionalData?.length) {
-    listData.push(...additionalData);
-    listData = _sortBy(listData, (item) => item.listDate);
+  if (additionalData?.length) {
+    listData = _sortBy([...(listData || []), ...additionalData], (item) => item.listDate);
   }
 
   if (listData?.length) {
+    const visibleData = (isRandom ? _shuffle(listData) : listData).slice(0, limit);
+    const renderedData = skipLastDivider ? removeLastDivider(visibleData) : visibleData;
+
     return (
       <View>
         {renderSectionHeader()}
 
         <ListComponent
-          data={isRandom ? _shuffle(listData).slice(0, limit) : listData.slice(0, limit)}
+          data={renderedData}
           horizontal={horizontal}
           navigation={navigation}
           listType={listType}

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -1,10 +1,18 @@
 import { StackNavigationProp } from '@react-navigation/stack';
-import React from 'react';
+import React, { useContext } from 'react';
 import { useQuery } from 'react-query';
 
-import { useHomePointsOfInterestAndToursRefresh, useHomeRefresh, useVolunteerData } from '../hooks';
+import {
+  useGenericItemEvents,
+  useHomePointsOfInterestAndToursRefresh,
+  useHomeRefresh,
+  useVolunteerData
+} from '../hooks';
+import { eventDate } from '../helpers/dateTimeHelper';
+import { subtitle } from '../helpers/textHelper';
 import { getQuery, QUERY_TYPES } from '../queries';
 import { ReactQueryClient } from '../ReactQueryClient';
+import { SettingsContext } from '../SettingsProvider';
 
 import { DataListSection } from './DataListSection';
 
@@ -24,10 +32,12 @@ type Props = {
   query: string;
   queryVariables: { limit?: number; take?: number };
   showVolunteerEvents?: boolean;
+  skipLastDivider?: boolean;
   title: string;
   titleDetail?: string;
 };
 
+/* eslint-disable complexity */
 export const HomeSection = ({
   buttonTitle,
   isIndexStartingAt1 = false,
@@ -37,9 +47,13 @@ export const HomeSection = ({
   query,
   queryVariables,
   showVolunteerEvents = false,
+  skipLastDivider = false,
   title,
   titleDetail
 }: Props) => {
+  const { globalSettings } = useContext(SettingsContext);
+  const genericItemEventSources =
+    globalSettings?.settings?.eventCalendar?.genericItemEventSources || [];
   const isPointsOfInterestAndTours = query === QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS;
   // `dataUpdatedAt` is provided by react-query and changes whenever a successful fetch updates data.
   const { data, dataUpdatedAt, isLoading, refetch } = useQuery(
@@ -71,6 +85,15 @@ export const HomeSection = ({
     isCalendar: isCalendarWithVolunteerEvents,
     isSectioned: false
   });
+  const isEventCalendar = query === QUERY_TYPES.EVENT_RECORDS;
+  const {
+    data: genericItemEvents,
+    isLoading: isLoadingGenericItemEvents,
+    refetch: refetchGenericItemEvents
+  } = useGenericItemEvents({
+    enabled: isEventCalendar && genericItemEventSources.length > 0,
+    sources: genericItemEventSources
+  });
 
   useHomeRefresh(
     isPointsOfInterestAndTours
@@ -78,6 +101,7 @@ export const HomeSection = ({
       : () => {
           refetch();
           isCalendarWithVolunteerEvents && refetchVolunteerEvents();
+          isEventCalendar && genericItemEventSources.length && refetchGenericItemEvents();
         }
   );
 
@@ -92,13 +116,26 @@ export const HomeSection = ({
 
   let showButton = !!data?.[query]?.length;
 
+  if (isEventCalendar) {
+    showButton = showButton || !!dataVolunteerEvents?.length || !!genericItemEvents.length;
+  }
+
   if (isPointsOfInterestAndTours) {
     showButton =
       !!data?.[QUERY_TYPES.POINTS_OF_INTEREST]?.length || !!data?.[QUERY_TYPES.TOURS]?.length;
   }
 
-  const loading = isLoading || isLoadingVolunteerEvents;
-  const additionalData = isCalendarWithVolunteerEvents ? dataVolunteerEvents : undefined;
+  const loading = isLoading || isLoadingVolunteerEvents || isLoadingGenericItemEvents;
+  const genericItemEventsWithDate = genericItemEvents.map((item) => ({
+    ...item,
+    overtitle: subtitle(eventDate(item.listDate), undefined, item.startTime)
+  }));
+  const additionalData = isEventCalendar
+    ? [
+        ...(isCalendarWithVolunteerEvents ? dataVolunteerEvents || [] : []),
+        ...genericItemEventsWithDate
+      ]
+    : undefined;
 
   return (
     <DataListSection
@@ -117,6 +154,8 @@ export const HomeSection = ({
       sectionTitle={title}
       sectionTitleDetail={titleDetail}
       showButton={showButton}
+      skipLastDivider={skipLastDivider}
     />
   );
 };
+/* eslint-enable complexity */

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,17 +1,16 @@
 import React, { useContext } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleProp, StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
 
 import { colors, consts, device, Icon, normalize } from '../config';
 import { SettingsContext } from '../SettingsProvider';
 
 import { Title, TitleContainer, TitleShadow } from './Title';
-import { Touchable } from './Touchable';
 import { WrapperRow } from './Wrapper';
 
 type Props = {
   big?: boolean;
   center?: boolean;
-  containerStyle?: any;
+  containerStyle?: StyleProp<ViewStyle>;
   small?: boolean;
   onPress?: () => void;
   title: string;
@@ -30,13 +29,15 @@ export const SectionHeader = ({
   const { flat = true, uppercase = false } = settings;
 
   if (!title) return null;
+  const headingAccessibilityLabel = `(${title}) ${consts.a11yLabel.heading}`;
+  const pressableAccessibilityLabel = `${headingAccessibilityLabel} ${consts.a11yLabel.button}`;
 
   const innerComponent = (
     <WrapperRow spaceBetween>
       <Title
-        accessibilityLabel={`(${title}) ${consts.a11yLabel.heading} ${
-          onPress ? consts.a11yLabel.button : ''
-        } `}
+        accessibilityLabel={onPress ? pressableAccessibilityLabel : headingAccessibilityLabel}
+        accessibilityRole={onPress ? undefined : 'header'}
+        $interactive={!!onPress}
         big={big}
         center={center}
         small={small}
@@ -53,7 +54,18 @@ export const SectionHeader = ({
   return (
     <>
       <TitleContainer flat={flat} style={containerStyle}>
-        {onPress ? <Touchable onPress={onPress}>{innerComponent}</Touchable> : innerComponent}
+        {onPress ? (
+          <TouchableOpacity
+            accessibilityLabel={pressableAccessibilityLabel}
+            accessibilityRole="button"
+            activeOpacity={0.6}
+            onPress={onPress}
+          >
+            {innerComponent}
+          </TouchableOpacity>
+        ) : (
+          innerComponent
+        )}
       </TitleContainer>
       {!flat && device.platform === 'ios' && <TitleShadow />}
     </>

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -11,6 +11,12 @@ export const Title = styled(Text)`
   line-height: ${normalize(26)};
 
   ${(props) =>
+    (props.onPress || props.$interactive) &&
+    css`
+      color: ${colors.primary};
+    `};
+
+  ${(props) =>
     props.uppercase &&
     css`
       text-transform: uppercase;

--- a/src/components/screens/EventRecords.js
+++ b/src/components/screens/EventRecords.js
@@ -29,6 +29,7 @@ import {
   useOpenWebScreen,
   usePosition,
   useSystemPermission,
+  useGenericItemEvents,
   useVolunteerData
 } from '../../hooks';
 import { NetworkContext } from '../../NetworkProvider';
@@ -72,6 +73,7 @@ export const EventRecords = ({ navigation, route }) => {
   const { eventLocations: showEventLocationsFilter = false } = filter;
   const { events: showVolunteerEvents = false } = hdvt;
   const { calendarToggle = false } = settings;
+  const genericItemEventSources = settings.eventCalendar?.genericItemEventSources || [];
   const { eventListIntro } = sections;
   const query = route.params?.query ?? '';
   const initialQueryVariables = route.params?.queryVariables || {};
@@ -140,14 +142,28 @@ export const EventRecords = ({ navigation, route }) => {
     isSectioned: true
   });
 
+  const {
+    data: genericItemEvents,
+    isLoading: isLoadingGenericItemEvents,
+    refetch: refetchGenericItemEvents
+  } = useGenericItemEvents({
+    dateRange: queryVariables.dateRange,
+    enabled: genericItemEventSources.length > 0,
+    sources: genericItemEventSources
+  });
+
   // apply additional data if volunteer events should be presented and no filter selection is made,
   // because filtered data for category or location has nothing to do with volunteer data
-  const additionalData =
-    showVolunteerEvents &&
-    !hasFilterSelection(false, queryVariables) &&
-    !(showEventLocationsFilter && hasFilterSelection(true, queryVariables))
-      ? dataVolunteerEvents
-      : undefined;
+  const hasNativeFilterSelection =
+    hasFilterSelection(false, queryVariables) ||
+    (showEventLocationsFilter && hasFilterSelection(true, queryVariables));
+  const additionalData = useMemo(
+    () =>
+      hasNativeFilterSelection
+        ? []
+        : [...(showVolunteerEvents ? dataVolunteerEvents || [] : []), ...genericItemEvents],
+    [dataVolunteerEvents, genericItemEvents, hasNativeFilterSelection, showVolunteerEvents]
+  );
 
   const listItems = useMemo(() => {
     let parsedListItems =
@@ -208,15 +224,18 @@ export const EventRecords = ({ navigation, route }) => {
       showCalendar && DeviceEventEmitter.emit(REFRESH_CALENDAR);
       await refetch();
       showVolunteerEvents && refetchVolunteerEvents();
+      genericItemEventSources.length && refetchGenericItemEvents();
     }
     setRefreshing(false);
   }, [
     isConnected,
     refetch,
     refetchVolunteerEvents,
+    refetchGenericItemEvents,
     setRefreshing,
     showCalendar,
-    showVolunteerEvents
+    showVolunteerEvents,
+    genericItemEventSources.length
   ]);
 
   const filterTypes = useMemo(() => {
@@ -256,20 +275,25 @@ export const EventRecords = ({ navigation, route }) => {
     return {};
   }, [fetchNextPage, showCalendar, hasNextPage, query]);
 
+  const eventListIntroUrl = eventListIntro?.url;
+  const eventListIntroFormIntroText = eventListIntro?.formIntroText;
   const eventSuggestionOnPress = useCallback(() => {
-    if (eventListIntro.url) {
-      openLink(eventListIntro.url, openWebScreen);
+    if (eventListIntroUrl) {
+      openLink(eventListIntroUrl, openWebScreen);
     } else {
       navigation.navigate(ScreenName.EventSuggestion, {
-        formIntroText: eventListIntro.formIntroText
+        formIntroText: eventListIntroFormIntroText
       });
     }
-  }, [eventListIntro?.url, eventListIntro?.formIntroText, navigation, openWebScreen]);
+  }, [eventListIntroFormIntroText, eventListIntroUrl, navigation, openWebScreen]);
 
   if (!query) return null;
 
   if (
-    (!listItems && isLoading && !isRefetching && !isFetchingNextPage) ||
+    (!listItems?.length &&
+      (isLoading || isLoadingGenericItemEvents) &&
+      !isRefetching &&
+      !isFetchingNextPage) ||
     eventRecordsAddressesLoading ||
     eventRecordsCategoriesLoading
   ) {
@@ -295,7 +319,7 @@ export const EventRecords = ({ navigation, route }) => {
       )}
       <ListComponent
         ListHeaderComponent={
-          <View style={{ paddingHorizontal: showCalendar ? normalize(8) : 0 }}>
+          <View style={showCalendar ? styles.headerCalendar : styles.header}>
             {!!eventListIntro && (
               <>
                 {!!eventListIntro.introText && (
@@ -318,7 +342,7 @@ export const EventRecords = ({ navigation, route }) => {
           </View>
         }
         ListEmptyComponent={
-          isLoading ? (
+          isLoading || isLoadingGenericItemEvents ? (
             <LoadingContainer>
               <ActivityIndicator color={colors.refreshControl} />
             </LoadingContainer>
@@ -364,6 +388,13 @@ export const EventRecords = ({ navigation, route }) => {
 /* eslint-enable complexity */
 
 const styles = StyleSheet.create({
+  header: {
+    paddingHorizontal: 0
+  },
+
+  headerCalendar: {
+    paddingHorizontal: normalize(8)
+  },
   noPaddingHorizontal: {
     paddingHorizontal: 0
   }

--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useContext, useState } from 'react';
 import { useQuery } from 'react-query';
 
 import { consts, Icon, texts } from '../../config';
-import { useHomeRefresh, useVolunteerData } from '../../hooks';
+import { useGenericItemEvents, useHomeRefresh, useVolunteerData } from '../../hooks';
 import { getQuery, QUERY_TYPES } from '../../queries';
 import { ReactQueryClient } from '../../ReactQueryClient';
 import { SettingsContext } from '../../SettingsProvider';
@@ -19,8 +19,11 @@ const today = moment().format('YYYY-MM-DD');
 export const EventWidget = ({ text, additionalProps, widgetStyle }: WidgetProps) => {
   const navigation = useNavigation();
   const { globalSettings } = useContext(SettingsContext);
-  const { hdvt = {} } = globalSettings;
+  const { hdvt = {}, settings = {} } = globalSettings;
   const { events: showVolunteerEvents = false } = hdvt as { events?: boolean };
+  const genericItemEventSources =
+    (settings as { eventCalendar?: { genericItemEventSources?: [] } }).eventCalendar
+      ?.genericItemEventSources || [];
   const [queryVariables] = useState<{ dateRange?: string[]; order?: string }>(
     additionalProps?.noFilterByDailyEvents
       ? { order: 'listDate_ASC' }
@@ -47,6 +50,15 @@ export const EventWidget = ({ text, additionalProps, widgetStyle }: WidgetProps)
     isCalendar: true,
     isSectioned: true
   });
+  const {
+    data: genericItemEvents,
+    isLoading: isLoadingGenericItemEvents,
+    refetch: refetchGenericItemEvents
+  } = useGenericItemEvents({
+    dateRange: queryVariables.dateRange,
+    enabled: genericItemEventSources.length > 0,
+    sources: genericItemEventSources
+  });
 
   const onPress = useCallback(() => {
     navigation.navigate(ScreenName.Index, {
@@ -59,18 +71,28 @@ export const EventWidget = ({ text, additionalProps, widgetStyle }: WidgetProps)
       rootRouteName: ROOT_ROUTE_NAMES.EVENT_RECORDS,
       filterByDailyEvents: additionalProps?.noFilterByDailyEvents ? false : true
     });
-  }, [navigation, text, queryVariables]);
+  }, [
+    additionalProps?.limit,
+    additionalProps?.noFilterByDailyEvents,
+    navigation,
+    text,
+    queryVariables
+  ]);
 
   useHomeRefresh(() => {
     refetch();
     showVolunteerEvents && refetchVolunteerEvents();
+    genericItemEventSources.length && refetchGenericItemEvents();
   });
 
-  const count = (data?.eventRecords?.length || 0) + (dataVolunteerEvents?.length || 0);
+  const count =
+    (data?.eventRecords?.length || 0) +
+    (dataVolunteerEvents?.length || 0) +
+    genericItemEvents.length;
 
   return (
     <DefaultWidget
-      count={additionalProps?.noCount || loading ? undefined : count}
+      count={additionalProps?.noCount || loading || isLoadingGenericItemEvents ? undefined : count}
       Icon={Icon.Calendar}
       image={additionalProps?.image}
       onPress={onPress}

--- a/src/components/widgets/EventWidget.tsx
+++ b/src/components/widgets/EventWidget.tsx
@@ -8,7 +8,7 @@ import { useGenericItemEvents, useHomeRefresh, useVolunteerData } from '../../ho
 import { getQuery, QUERY_TYPES } from '../../queries';
 import { ReactQueryClient } from '../../ReactQueryClient';
 import { SettingsContext } from '../../SettingsProvider';
-import { ScreenName, WidgetProps } from '../../types';
+import { GenericItemEventSource, ScreenName, WidgetProps } from '../../types';
 
 import { DefaultWidget } from './DefaultWidget';
 
@@ -22,8 +22,11 @@ export const EventWidget = ({ text, additionalProps, widgetStyle }: WidgetProps)
   const { hdvt = {}, settings = {} } = globalSettings;
   const { events: showVolunteerEvents = false } = hdvt as { events?: boolean };
   const genericItemEventSources =
-    (settings as { eventCalendar?: { genericItemEventSources?: [] } }).eventCalendar
-      ?.genericItemEventSources || [];
+    (
+      settings as {
+        eventCalendar?: { genericItemEventSources?: GenericItemEventSource[] };
+      }
+    ).eventCalendar?.genericItemEventSources || [];
   const [queryVariables] = useState<{ dateRange?: string[]; order?: string }>(
     additionalProps?.noFilterByDailyEvents
       ? { order: 'listDate_ASC' }

--- a/src/helpers/genericItemEventHelper.ts
+++ b/src/helpers/genericItemEventHelper.ts
@@ -1,0 +1,146 @@
+import moment from 'moment';
+
+import { QUERY_TYPES } from '../queries/types';
+import {
+  GenericItem,
+  GenericItemEventListItem,
+  GenericItemEventSource,
+  GenericType,
+  ScreenName,
+  SVA_Date
+} from '../types';
+
+import { getGenericItemDetailTitle, getGenericItemRootRouteName } from './genericTypeHelper';
+import { mainImageOfMediaContents } from './imageHelper';
+import { subtitle } from './textHelper';
+
+const STATUS_FIELDS = ['label', 'text', 'title', 'name', 'status', 'value'] as const;
+const STATUS_ALIASES: Record<string, string> = {
+  abgeschlossen: 'completed',
+  aktiv: 'active',
+  beendet: 'ended',
+  finished: 'ended',
+  'kürzlich abgeschlossen': 'recently_ended',
+  'kürzlich beendet': 'recently_ended',
+  'kuerzlich abgeschlossen': 'recently_ended',
+  'kuerzlich beendet': 'recently_ended',
+  'recently completed': 'recently_ended',
+  'recently ended': 'recently_ended',
+  'recently-completed': 'recently_ended',
+  'recently-ended': 'recently_ended',
+  recently_completed: 'recently_ended',
+  recently_ended: 'recently_ended',
+  recentlycompleted: 'recently_ended'
+};
+
+export const normalizeGenericItemEventValue = (value?: unknown) => {
+  if (value === undefined || value === null) return;
+  const normalized = `${value}`.trim().toLowerCase();
+  return !normalized || normalized === 'null' || normalized === 'undefined'
+    ? undefined
+    : normalized;
+};
+
+export const normalizeGenericItemEventStatus = (value?: unknown) => {
+  const normalized = normalizeGenericItemEventValue(value);
+  return normalized ? STATUS_ALIASES[normalized] || normalized : undefined;
+};
+
+const getStatus = (payload: Record<string, unknown>) => {
+  const status = payload.status;
+  if (!status || typeof status !== 'object') return status;
+  return STATUS_FIELDS.map((field) => (status as Record<string, unknown>)[field]).find(
+    (value) => value !== undefined && value !== null
+  );
+};
+
+const dateValue = (date?: SVA_Date) => {
+  const value = date?.dateStart || date?.dateFrom;
+  if (!value || !moment(value, moment.ISO_8601, true).isValid()) return;
+  return moment(value).format('YYYY-MM-DD');
+};
+
+const isInRange = (date: string, dateRange?: string[]) => {
+  if (!dateRange?.length) return !moment(date).isBefore(moment(), 'day');
+  const from = dateRange[0];
+  const to = dateRange[1] || from;
+  return !moment(date).isBefore(from, 'day') && !moment(date).isAfter(to, 'day');
+};
+
+/* eslint-disable complexity */
+export const parseGenericItemEvents = (
+  records: unknown,
+  source: GenericItemEventSource,
+  dateRange?: string[]
+): GenericItemEventListItem[] => {
+  if (!Array.isArray(records) || !source || !normalizeGenericItemEventValue(source.genericType)) {
+    return [];
+  }
+
+  const typeFilters = Array.isArray(source.filterTypes)
+    ? source.filterTypes.map(normalizeGenericItemEventValue).filter(Boolean)
+    : [];
+  const statusFilters = Array.isArray(source.filterStatuses)
+    ? source.filterStatuses.map(normalizeGenericItemEventStatus).filter(Boolean)
+    : [];
+
+  const occurrences = records.flatMap((rawItem) => {
+    if (!rawItem || typeof rawItem !== 'object') return [];
+    const item = rawItem as GenericItem<Record<string, unknown>>;
+    const payload = item.payload && typeof item.payload === 'object' ? item.payload : {};
+    const types = [
+      payload.type,
+      ...(Array.isArray(item.categories) ? item.categories.map((c) => c?.name) : [])
+    ]
+      .map(normalizeGenericItemEventValue)
+      .filter(Boolean);
+    const status = normalizeGenericItemEventStatus(getStatus(payload));
+    if (typeFilters.length && !types.some((type) => typeFilters.includes(type))) return [];
+    if (statusFilters.length && (!status || !statusFilters.includes(status))) return [];
+
+    const statusRecord =
+      payload.status && typeof payload.status === 'object'
+        ? (payload.status as Record<string, unknown>)
+        : undefined;
+    const color = `${payload.color || statusRecord?.color || ''}`.trim() || undefined;
+
+    return (Array.isArray(item.dates) ? item.dates : []).flatMap((date, index) => {
+      const listDate = dateValue(date);
+      if (!listDate || !isInRange(listDate, dateRange)) return [];
+      const time = `${date.timeStart || date.timeFrom || ''}`.trim() || undefined;
+      const occurrenceId = `${source.genericType}:${item.id}:${date.id || index}:${listDate}`;
+      return [
+        {
+          addresses: item.addresses,
+          color,
+          id: occurrenceId,
+          listDate,
+          overtitle: subtitle(undefined, undefined, time),
+          params: {
+            title: getGenericItemDetailTitle(
+              item.genericType as GenericType,
+              {},
+              item.categories?.[0]?.name || ''
+            ),
+            query: QUERY_TYPES.GENERIC_ITEM,
+            queryVariables: { id: `${item.id}` },
+            rootRouteName: getGenericItemRootRouteName(item.genericType as GenericType),
+            details: item
+          },
+          picture: { url: mainImageOfMediaContents(item.mediaContents) },
+          routeName: ScreenName.Detail,
+          startTime: time,
+          title: item.title || ''
+        }
+      ];
+    });
+  });
+
+  return Array.from(new Map(occurrences.map((item) => [item.id, item])).values()).sort(
+    (first, second) =>
+      first.listDate.localeCompare(second.listDate) ||
+      `${first.startTime || ''}`.localeCompare(`${second.startTime || ''}`) ||
+      first.title.localeCompare(second.title)
+  );
+};
+/* eslint-enable complexity */

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -21,6 +21,7 @@ export * from './filterObjectHelper';
 export * from './filterTypesHelper';
 export * from './formatHelper';
 export * from './genericTypeHelper';
+export * from './genericItemEventHelper';
 export * from './geolocationRadiusFilterHelper';
 export * from './graphqlHelper';
 export * from './headerHelper';

--- a/src/helpers/textHelper.js
+++ b/src/helpers/textHelper.js
@@ -9,15 +9,14 @@
  */
 export const subtitle = (first, last, time) => {
   let formattedText = '';
+  const firstWithTime = first && time ? `${first}, ${time} Uhr` : first;
 
-  if (first && time && last) {
-    formattedText = `${first}, ${time} Uhr | ${last}`;
-  } else if (first && last) {
-    formattedText = `${first} | ${last}`;
+  if (firstWithTime && last) {
+    formattedText = `${firstWithTime} | ${last}`;
   } else if (time && last) {
     formattedText = `${time} Uhr | ${last}`;
-  } else if (first) {
-    formattedText = first;
+  } else if (firstWithTime) {
+    formattedText = firstWithTime;
   } else if (time) {
     formattedText = `${time} Uhr`;
   } else if (last) {

--- a/src/hooks/genericItemEvents.ts
+++ b/src/hooks/genericItemEvents.ts
@@ -1,0 +1,68 @@
+import { useMemo, useRef } from 'react';
+import { useQueries } from 'react-query';
+
+import { parseGenericItemEvents } from '../helpers/genericItemEventHelper';
+import { getQuery } from '../queries';
+import { QUERY_TYPES } from '../queries/types';
+import { ReactQueryClient } from '../ReactQueryClient';
+import { GenericItemEventListItem, GenericItemEventSource } from '../types';
+
+type Options = {
+  dateRange?: string[];
+  enabled?: boolean;
+  sources?: GenericItemEventSource[];
+};
+
+const EMPTY_DATA: GenericItemEventListItem[] = [];
+
+export const useGenericItemEvents = ({ dateRange, enabled = true, sources = [] }: Options) => {
+  const clientRef = useRef<Awaited<ReturnType<typeof ReactQueryClient>>>();
+  const validSources = useMemo(
+    () =>
+      (Array.isArray(sources) ? sources : []).filter(
+        (source) => source && `${source.genericType || ''}`.trim()
+      ),
+    [sources]
+  );
+  const genericTypes = useMemo(
+    () => Array.from(new Set(validSources.map(({ genericType }) => `${genericType}`))),
+    [validSources]
+  );
+  const queryEnabled = enabled && genericTypes.length > 0;
+  const queries = useQueries(
+    genericTypes.map((genericType) => ({
+      queryKey: [QUERY_TYPES.GENERIC_ITEMS, { genericType }],
+      queryFn: async () => {
+        if (!clientRef.current) clientRef.current = await ReactQueryClient();
+        return clientRef.current.request(getQuery(QUERY_TYPES.GENERIC_ITEMS), {
+          genericType,
+          limit: undefined
+        });
+      },
+      enabled: queryEnabled
+    }))
+  );
+
+  const data = useMemo(() => {
+    if (!queryEnabled) return EMPTY_DATA;
+    const merged = validSources.flatMap((source) => {
+      const index = genericTypes.indexOf(`${source.genericType}`);
+      const result = queries[index]?.data as Record<string, unknown[]> | undefined;
+      return parseGenericItemEvents(result?.[QUERY_TYPES.GENERIC_ITEMS], source, dateRange);
+    });
+    return Array.from(new Map(merged.map((item) => [item.id, item])).values()).sort(
+      (a, b) =>
+        a.listDate.localeCompare(b.listDate) ||
+        `${a.startTime || ''}`.localeCompare(`${b.startTime || ''}`) ||
+        a.title.localeCompare(b.title)
+    );
+  }, [dateRange, genericTypes, queries, queryEnabled, validSources]);
+
+  return {
+    data,
+    isLoading: queryEnabled && queries.some(({ isLoading }) => isLoading),
+    isRefetching: queryEnabled && queries.some(({ isRefetching }) => isRefetching),
+    refetch: async () =>
+      queryEnabled ? Promise.all(queries.map(({ refetch }) => refetch())) : Promise.resolve([])
+  };
+};

--- a/src/hooks/genericItemEvents.ts
+++ b/src/hooks/genericItemEvents.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import { useQueries } from 'react-query';
 
 import { parseGenericItemEvents } from '../helpers/genericItemEventHelper';
@@ -16,12 +16,12 @@ type Options = {
 const EMPTY_DATA: GenericItemEventListItem[] = [];
 
 export const useGenericItemEvents = ({ dateRange, enabled = true, sources = [] }: Options) => {
-  const clientRef = useRef<Awaited<ReturnType<typeof ReactQueryClient>>>();
   const validSources = useMemo(
     () =>
-      (Array.isArray(sources) ? sources : []).filter(
-        (source) => source && `${source.genericType || ''}`.trim()
-      ),
+      (Array.isArray(sources) ? sources : []).flatMap((source) => {
+        const genericType = `${source?.genericType || ''}`.trim();
+        return source && genericType ? [{ ...source, genericType }] : [];
+      }),
     [sources]
   );
   const genericTypes = useMemo(
@@ -33,8 +33,8 @@ export const useGenericItemEvents = ({ dateRange, enabled = true, sources = [] }
     genericTypes.map((genericType) => ({
       queryKey: [QUERY_TYPES.GENERIC_ITEMS, { genericType }],
       queryFn: async () => {
-        if (!clientRef.current) clientRef.current = await ReactQueryClient();
-        return clientRef.current.request(getQuery(QUERY_TYPES.GENERIC_ITEMS), {
+        const client = await ReactQueryClient();
+        return client.request(getQuery(QUERY_TYPES.GENERIC_ITEMS), {
           genericType,
           limit: undefined
         });

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -11,6 +11,7 @@ export * from './constructionSites';
 export * from './DetailRefresh';
 export * from './documentPicker';
 export * from './HomeRefresh';
+export * from './genericItemEvents';
 export * from './imagePicker';
 export * from './keyboardHeight';
 export * from './listHooks';

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -68,6 +68,7 @@ const renderItem = ({ item }) => {
     queryVariables,
     showData,
     showVolunteerEvents,
+    skipLastDivider,
     title,
     type,
     widgetConfigs,
@@ -198,6 +199,7 @@ const renderItem = ({ item }) => {
             query,
             queryVariables: { ...queryVariables, categoryId },
             showVolunteerEvents,
+            skipLastDivider,
             title,
             titleDetail
           }}
@@ -217,6 +219,7 @@ const renderItem = ({ item }) => {
         query,
         queryVariables,
         showVolunteerEvents,
+        skipLastDivider,
         title
       }}
     />
@@ -402,7 +405,8 @@ export const HomeScreen = ({ navigation, route }) => {
                   excludeMowasRegionalKeys,
                   ...section.queryVariables
                 },
-                showData: section.show !== false
+                showData: section.show !== false,
+                skipLastDivider: section.skipLastDivider === true
               };
             case QUERY_TYPES.POINTS_OF_INTEREST_AND_TOURS:
               return {
@@ -420,6 +424,7 @@ export const HomeScreen = ({ navigation, route }) => {
                   ...section.queryVariables
                 },
                 showData: section.show !== false,
+                skipLastDivider: section.skipLastDivider === true,
                 title: section.title || headlinePointsOfInterestAndTours
               };
             case QUERY_TYPES.EVENT_RECORDS:
@@ -437,6 +442,7 @@ export const HomeScreen = ({ navigation, route }) => {
                 },
                 showData: section.show !== false,
                 showVolunteerEvents,
+                skipLastDivider: section.skipLastDivider === true,
                 title: section.title || headlineEvents
               };
             default:

--- a/src/types/GenericItemEvent.ts
+++ b/src/types/GenericItemEvent.ts
@@ -1,0 +1,23 @@
+import { Address } from './Address';
+import { GenericType } from './GenericType';
+import { ScreenName } from './Navigation';
+
+export type GenericItemEventSource = {
+  genericType: GenericType | string;
+  filterTypes?: string[];
+  filterStatuses?: string[];
+};
+
+export type GenericItemEventListItem = {
+  id: string;
+  addresses?: Address[];
+  color?: string;
+  listDate: string;
+  overtitle?: string;
+  params: Record<string, unknown>;
+  picture: { url?: string };
+  routeName: ScreenName;
+  startTime?: string;
+  subtitle?: string;
+  title: string;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export * from './ConstructionSite';
 export * from './Contact';
 export * from './Date';
 export * from './GenericItem';
+export * from './GenericItemEvent';
 export * from './GenericType';
 export * from './LocationSettings';
 export * from './Map';


### PR DESCRIPTION
Example settings for st-md participation project entries:

```
"eventCalendar": {
  "genericItemEventSources": [
    {
      "genericType": "ParticipationProject",
      "filterTypes": [
        "Veranstaltung"
      ],
      "filterStatuses": [
        "active",
        "announced"
      ]
    }
  ]
}
```

SVA-1751