### PR TITLE
feat(opening-times): group recurring entries by weekday

### DIFF
--- a/__tests__/components/OpeningTimesCard.test.js
+++ b/__tests__/components/OpeningTimesCard.test.js
@@ -1,14 +1,38 @@
 /* eslint-disable @typescript-eslint/no-var-requires, react/prop-types */
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 
-import { OpeningTimesCard } from '../../src/components/screens/OpeningTimesCard';
+import {
+  groupRecurringWeekdayOpeningHours,
+  OpeningTimesCard
+} from '../../src/components/screens/OpeningTimesCard';
+import { isOpeningTimesGroupingEnabled } from '../../src/components/screens/openingTimesSettings';
 
 jest.mock('../../src/config', () => ({
   normalize: (value) => value,
   texts: {
+    accessibilityLabels: {
+      actions: {
+        loadMore: 'Weitere Einträge laden'
+      },
+      dropDownMenu: {
+        closed: 'geschlossen'
+      }
+    },
     eventRecord: {
       appointmentsShowMoreButton: 'Weitere Termine'
+    },
+    noticeboard: {
+      weekday: {
+        friday: 'Freitag',
+        monday: 'Montag',
+        saturday: 'Samstag',
+        sunday: 'Sonntag',
+        thursday: 'Donnerstag',
+        tuesday: 'Dienstag',
+        wednesday: 'Mittwoch'
+      }
     }
   }
 }));
@@ -25,26 +49,37 @@ jest.mock('../../src/hooks/useThemeStyles', () => ({
   useThemeStyles: (createStyles) => createStyles({ gray60: '#999999' })
 }));
 
-jest.mock('../../src/components/HtmlView', () => ({ HtmlView: () => null }));
+jest.mock('../../src/components/HtmlView', () => ({
+  HtmlView: ({ html }) => {
+    const { Text: MockText } = require('react-native');
+
+    return <MockText>{html}</MockText>;
+  }
+}));
+
 jest.mock('../../src/components/Text', () => {
   const ReactInMock = require('react');
   const { Text: MockText } = require('react-native');
-  const TextComponent = ({ children }) => ReactInMock.createElement(MockText, null, children);
+  const TextComponent = ({ children, ...props }) =>
+    ReactInMock.createElement(MockText, props, children);
 
   return { BoldText: TextComponent, RegularText: TextComponent };
 });
+
 jest.mock('../../src/components/Touchable', () => {
   const ReactInMock = require('react');
   const { View: MockView } = require('react-native');
 
   return {
-    Touchable: ({ children }) => ReactInMock.createElement(MockView, null, children)
+    Touchable: ({ children, ...props }) => ReactInMock.createElement(MockView, props, children)
   };
 });
+
 jest.mock('../../src/components/Wrapper', () => {
   const ReactInMock = require('react');
   const { View: MockView } = require('react-native');
-  const WrapperComponent = ({ children }) => ReactInMock.createElement(MockView, null, children);
+  const WrapperComponent = ({ children, ...props }) =>
+    ReactInMock.createElement(MockView, props, children);
 
   return {
     WrapperHorizontal: WrapperComponent,
@@ -53,9 +88,244 @@ jest.mock('../../src/components/Wrapper', () => {
   };
 });
 
-describe('OpeningTimesCard inline date and time', () => {
+const mondayMorning = {
+  id: 'monday-morning',
+  open: true,
+  timeFrom: '08:00',
+  timeTo: '12:00',
+  weekday: 'Montag'
+};
+
+const mondayAfternoon = {
+  id: 'monday-afternoon',
+  open: true,
+  timeFrom: '13:00',
+  timeTo: '17:00',
+  weekday: 'Montag'
+};
+
+const tuesdayMorning = {
+  id: 'tuesday-morning',
+  open: true,
+  timeFrom: '09:00',
+  timeTo: '11:00',
+  weekday: 'Dienstag'
+};
+
+const collectText = (node, values = []) => {
+  if (typeof node === 'string') {
+    values.push(node);
+    return values;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectText(child, values));
+    return values;
+  }
+
+  if (node?.children) {
+    node.children.forEach((child) => collectText(child, values));
+  }
+
+  return values;
+};
+
+const getHeaderTexts = (component) =>
+  component
+    .UNSAFE_getAllByType(Text)
+    .filter((node) => node.props.accessibilityRole === 'header')
+    .map((node) => collectText(node.props.children).join(''));
+
+const getDividerCount = (component) =>
+  component.UNSAFE_getAllByType(View).filter((node) => {
+    const style = StyleSheet.flatten(node.props.style);
+
+    return style?.borderBottomWidth === StyleSheet.hairlineWidth;
+  }).length;
+
+describe('isOpeningTimesGroupingEnabled', () => {
+  it('keeps the legacy view by default', () => {
+    expect(isOpeningTimesGroupingEnabled()).toBe(false);
+    expect(isOpeningTimesGroupingEnabled({})).toBe(false);
+    expect(isOpeningTimesGroupingEnabled({ openingTimes: {} })).toBe(false);
+  });
+
+  it('only enables grouping for an explicit boolean true setting', () => {
+    expect(isOpeningTimesGroupingEnabled({ openingTimes: { groupByWeekday: true } })).toBe(true);
+    expect(isOpeningTimesGroupingEnabled({ openingTimes: { groupByWeekday: false } })).toBe(false);
+    expect(isOpeningTimesGroupingEnabled({ openingTimes: { groupByWeekday: 'true' } })).toBe(false);
+  });
+});
+
+describe('groupRecurringWeekdayOpeningHours', () => {
+  it('groups adjacent recurring time windows while preserving their backend order', () => {
+    const groups = groupRecurringWeekdayOpeningHours([mondayMorning, mondayAfternoon]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].weekday).toBe('Montag');
+    expect(groups[0].openingHours).toEqual([mondayMorning, mondayAfternoon]);
+  });
+
+  it('supports numeric weekday values introduced on the target branch', () => {
+    const numericMondayMorning = { ...mondayMorning, weekday: 0 };
+    const numericMondayAfternoon = { ...mondayAfternoon, weekday: 0 };
+    const groups = groupRecurringWeekdayOpeningHours([
+      numericMondayMorning,
+      numericMondayAfternoon
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].openingHours).toEqual([numericMondayMorning, numericMondayAfternoon]);
+  });
+
+  it('keeps different weekdays and closed entries in independent groups', () => {
+    const closedMonday = { id: 'closed-monday', open: false, weekday: 'Montag' };
+    const groups = groupRecurringWeekdayOpeningHours([mondayMorning, closedMonday, tuesdayMorning]);
+
+    expect(groups.map((group) => group.openingHours)).toEqual([
+      [mondayMorning],
+      [closedMonday],
+      [tuesdayMorning]
+    ]);
+  });
+
+  it('does not group date-related special openings by weekday', () => {
+    const specialOpening = {
+      dateFrom: '2026-08-31',
+      dateTo: '2026-08-31',
+      description: 'Sonderöffnung',
+      id: 'special-opening',
+      open: true,
+      timeFrom: '18:00',
+      timeTo: '20:00',
+      weekday: 'Montag'
+    };
+    const groups = groupRecurringWeekdayOpeningHours([mondayMorning, specialOpening]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[1].openingHours).toEqual([specialOpening]);
+  });
+
+  it('keeps recurring entries with different descriptions in independent groups', () => {
+    const appointmentOnly = {
+      ...mondayAfternoon,
+      description: 'Nur nach Vereinbarung'
+    };
+    const groups = groupRecurringWeekdayOpeningHours([mondayMorning, appointmentOnly]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[1].openingHours).toEqual([appointmentOnly]);
+  });
+});
+
+describe('OpeningTimesCard', () => {
+  it('renders one weekday heading and no internal divider for multiple Monday windows', () => {
+    const component = render(
+      <OpeningTimesCard groupRecurringWeekdays openingHours={[mondayMorning, mondayAfternoon]} />
+    );
+    const renderedText = collectText(component.toJSON());
+    const accessibleRows = component
+      .UNSAFE_getAllByType(View)
+      .filter((node) => node.props.accessible);
+
+    expect(getHeaderTexts(component)).toEqual(['Montag']);
+    expect(renderedText.indexOf('08:00')).toBeLessThan(renderedText.indexOf('13:00'));
+    expect(accessibleRows).toHaveLength(2);
+    expect(getDividerCount(component)).toBe(0);
+  });
+
+  it('keeps different weekdays visually separated', () => {
+    const component = render(
+      <OpeningTimesCard
+        groupRecurringWeekdays
+        openingHours={[mondayMorning, mondayAfternoon, tuesdayMorning]}
+      />
+    );
+
+    expect(getHeaderTexts(component)).toEqual(['Montag', 'Dienstag']);
+    expect(getDividerCount(component)).toBe(1);
+  });
+
+  it('keeps a single time window unchanged when grouping is enabled', () => {
+    const grouped = render(
+      <OpeningTimesCard groupRecurringWeekdays openingHours={[mondayMorning]} />
+    );
+    const ungrouped = render(<OpeningTimesCard openingHours={[mondayMorning]} />);
+
+    expect(grouped.toJSON()).toEqual(ungrouped.toJSON());
+  });
+
+  it('does not group open and closed entries and keeps the closed state explicit', () => {
+    const component = render(
+      <OpeningTimesCard
+        groupRecurringWeekdays
+        openingHours={[mondayMorning, { id: 'closed-monday', open: false, weekday: 'Montag' }]}
+      />
+    );
+
+    expect(getHeaderTexts(component)).toEqual(['Montag', 'Montag']);
+    expect(component.getByText('geschlossen')).toBeTruthy();
+    expect(getDividerCount(component)).toBe(1);
+  });
+
+  it('preserves special-opening dates and descriptions in their own section', () => {
+    const component = render(
+      <OpeningTimesCard
+        groupRecurringWeekdays
+        openingHours={[
+          mondayMorning,
+          {
+            dateFrom: '2026-08-31',
+            dateTo: '2026-08-31',
+            description: 'Nur nach Vereinbarung',
+            id: 'special-opening',
+            open: true,
+            timeFrom: '18:00',
+            timeTo: '20:00',
+            weekday: 'Montag'
+          }
+        ]}
+      />
+    );
+
+    expect(getHeaderTexts(component)).toEqual(['Montag', 'Montag']);
+    expect(component.getByText('31.08.2026')).toBeTruthy();
+    expect(component.getByText('Nur nach Vereinbarung')).toBeTruthy();
+  });
+
+  it('merges a weekday across the load-more boundary without losing entries', () => {
+    const component = render(
+      <OpeningTimesCard
+        groupRecurringWeekdays
+        MAX_INITIAL_NUM_TO_RENDER={1}
+        openingHours={[mondayMorning, mondayAfternoon, tuesdayMorning]}
+      />
+    );
+
+    expect(getHeaderTexts(component)).toEqual(['Montag']);
+
+    fireEvent.press(component.getByText('Weitere Termine'));
+
+    expect(getHeaderTexts(component)).toEqual(['Montag']);
+    expect(component.getByText('08:00')).toBeTruthy();
+    expect(component.getByText('13:00')).toBeTruthy();
+
+    fireEvent.press(component.getByText('Weitere Termine'));
+
+    expect(getHeaderTexts(component)).toEqual(['Montag', 'Dienstag']);
+    expect(component.getByText('09:00')).toBeTruthy();
+    expect(component.queryByText('Weitere Termine')).toBeNull();
+  });
+
+  it('keeps grouping disabled for other OpeningTimesCard consumers by default', () => {
+    const component = render(<OpeningTimesCard openingHours={[mondayMorning, mondayAfternoon]} />);
+
+    expect(getHeaderTexts(component)).toEqual(['Montag', 'Montag']);
+    expect(getDividerCount(component)).toBe(1);
+  });
+
   it('renders the date before the start time with one clock suffix', () => {
-    const screen = render(
+    const component = render(
       <OpeningTimesCard
         inlineDateTime
         openingHours={[
@@ -69,11 +339,11 @@ describe('OpeningTimesCard inline date and time', () => {
       />
     );
 
-    expect(screen.getByText('01.09.2026 18:30 Uhr')).toBeTruthy();
+    expect(component.getByText('01.09.2026 18:30 Uhr')).toBeTruthy();
   });
 
   it('keeps date ranges readable when no time is available', () => {
-    const screen = render(
+    const component = render(
       <OpeningTimesCard
         inlineDateTime
         openingHours={[
@@ -87,6 +357,6 @@ describe('OpeningTimesCard inline date and time', () => {
       />
     );
 
-    expect(screen.getByText('14.08.2026 bis 18.09.2026')).toBeTruthy();
+    expect(component.getByText('14.08.2026 bis 18.09.2026')).toBeTruthy();
   });
 });

--- a/src/components/screens/OpeningTimesCard.js
+++ b/src/components/screens/OpeningTimesCard.js
@@ -88,17 +88,139 @@ const formatInlineDateTime = ({ dateFrom, datePrefix, dateTo, timeFrom, timeTo, 
   return [startDateTime, endDateTime].filter(Boolean).join(' bis ');
 };
 
+const isGroupableRecurringOpeningHour = ({ dateFrom, dateTo, open, timeFrom, timeTo, weekday }) =>
+  weekday !== null &&
+  weekday !== undefined &&
+  weekday !== '' &&
+  (!!timeFrom || !!timeTo) &&
+  !dateFrom &&
+  !dateTo &&
+  open !== false;
+
+const hasSameDescription = (openingHour, group) =>
+  (openingHour.description || null) === (group.openingHours[0].description || null);
+
+export const groupRecurringWeekdayOpeningHours = (openingHours) =>
+  openingHours.reduce((groups, openingHour) => {
+    const previousGroup = groups[groups.length - 1];
+    const canJoinPreviousGroup =
+      isGroupableRecurringOpeningHour(openingHour) &&
+      previousGroup?.groupable &&
+      previousGroup.weekday === openingHour.weekday &&
+      hasSameDescription(openingHour, previousGroup);
+
+    if (canJoinPreviousGroup) {
+      previousGroup.openingHours.push(openingHour);
+    } else {
+      groups.push({
+        groupable: isGroupableRecurringOpeningHour(openingHour),
+        openingHours: [openingHour],
+        weekday: openingHour.weekday
+      });
+    }
+
+    return groups;
+  }, []);
+
+const createIndividualOpeningHourGroups = (openingHours) =>
+  openingHours.map((openingHour) => ({
+    openingHours: [openingHour],
+    weekday: openingHour.weekday
+  }));
+
 /* eslint-disable complexity */
 /* NOTE: we need to check a lot for presence, so this is that complex */
+const OpeningHourDetails = ({ inlineDateTime, leftAligned, openingHour, styles }) => {
+  const {
+    dateFrom,
+    datePrefix,
+    dateTo,
+    description,
+    open,
+    timeFrom,
+    timeTo,
+    useYear = false
+  } = openingHour;
+  const returnFormatDate = useYear ? 'DD.MM.YYYY' : 'DD.MM.';
+  const hasDateOrTime = !!timeFrom || !!timeTo || !!dateFrom || !!dateTo;
+  const showInlineDateTime = inlineDateTime && open !== false;
+
+  return (
+    <>
+      {hasDateOrTime && showInlineDateTime && (
+        <RegularText>
+          {formatInlineDateTime({
+            dateFrom,
+            datePrefix,
+            dateTo,
+            timeFrom,
+            timeTo,
+            useYear
+          })}
+        </RegularText>
+      )}
+
+      {(hasDateOrTime || open === false) && !showInlineDateTime && (
+        <WrapperRow accessible>
+          {open !== false && (!!timeFrom || !!timeTo) && (
+            <TimeBox>
+              {!!timeFrom && <RegularText>{timeFrom}</RegularText>}
+              {!!timeFrom && !!timeTo && timeFrom !== timeTo && (
+                <>
+                  <RegularText> -</RegularText>
+                  <RegularText> {timeTo}</RegularText>
+                </>
+              )}
+            </TimeBox>
+          )}
+          {open === false && (
+            <TimeBox>
+              <RegularText>{texts.accessibilityLabels.dropDownMenu.closed}</RegularText>
+            </TimeBox>
+          )}
+          {(!!dateFrom || !!dateTo) && (
+            <DateBox leftAligned={leftAligned}>
+              {!!dateFrom && (
+                <RegularText>
+                  {!!datePrefix && <RegularText small>{datePrefix} </RegularText>}
+                  {momentFormat(dateFrom, returnFormatDate)}
+                </RegularText>
+              )}
+
+              {!!dateTo && dateTo !== dateFrom && (
+                <RegularText>
+                  <RegularText small>bis </RegularText>
+                  {momentFormat(dateTo, returnFormatDate)}
+                </RegularText>
+              )}
+            </DateBox>
+          )}
+        </WrapperRow>
+      )}
+
+      {!!description && (
+        <WrapperRow style={styles.margin}>
+          <HtmlView html={description} />
+        </WrapperRow>
+      )}
+    </>
+  );
+};
+
 export const OpeningTimesCard = ({
   appointmentsShowMoreButton = texts.eventRecord.appointmentsShowMoreButton,
   inlineDateTime = false,
   leftAligned = false,
   MAX_INITIAL_NUM_TO_RENDER = 15,
-  openingHours
+  openingHours,
+  groupRecurringWeekdays = false
 }) => {
   const styles = useThemeStyles(createStyles);
   const [moreData, setMoreData] = useState(1);
+  const visibleOpeningHours = openingHours.slice(0, moreData * MAX_INITIAL_NUM_TO_RENDER);
+  const openingHourGroups = groupRecurringWeekdays
+    ? groupRecurringWeekdayOpeningHours(visibleOpeningHours)
+    : createIndividualOpeningHourGroups(visibleOpeningHours);
 
   const loadMoreItems = () => {
     setMoreData((prev) => prev + 1);
@@ -106,98 +228,37 @@ export const OpeningTimesCard = ({
 
   return (
     <WrapperHorizontal>
-      {openingHours
-        .slice(0, moreData * MAX_INITIAL_NUM_TO_RENDER)
-        .map((item, index, slicedArray) => {
-          const {
-            weekday,
-            timeFrom,
-            timeTo,
-            dateFrom,
-            datePrefix,
-            dateTo,
-            description,
-            open,
-            useYear = false
-          } = item;
-          const returnFormatDate = useYear ? 'DD.MM.YYYY' : 'DD.MM.';
-          const readableWeekday = getReadableWeekday(weekday);
-          const hasDateOrTime = !!timeFrom || !!timeTo || !!dateFrom || !!dateTo;
-          const showInlineDateTime = inlineDateTime && open !== false;
+      {openingHourGroups.map((group, index, groups) => {
+        const readableWeekday = getReadableWeekday(group.weekday);
 
-          return (
-            <WrapperVertical
-              key={index}
-              style={[
-                index === 0 && styles.noMarginTop,
-                index === 0 && styles.noPaddingTop,
-                index !== slicedArray.length - 1 && styles.divider,
-                index === slicedArray.length - 1 && styles.noPaddingBottom
-              ]}
-            >
-              {!!readableWeekday && (
-                <BoldText style={styles.marginBottom}>{readableWeekday}</BoldText>
-              )}
+        return (
+          <WrapperVertical
+            key={group.openingHours[0].id ?? index}
+            style={[
+              index === 0 && styles.noMarginTop,
+              index === 0 && styles.noPaddingTop,
+              index !== groups.length - 1 && styles.divider,
+              index === groups.length - 1 && styles.noPaddingBottom
+            ]}
+          >
+            {!!readableWeekday && (
+              <BoldText accessibilityRole="header" style={styles.marginBottom}>
+                {readableWeekday}
+              </BoldText>
+            )}
 
-              {hasDateOrTime && showInlineDateTime && (
-                <RegularText>
-                  {formatInlineDateTime({
-                    dateFrom,
-                    datePrefix,
-                    dateTo,
-                    timeFrom,
-                    timeTo,
-                    useYear
-                  })}
-                </RegularText>
-              )}
-
-              {hasDateOrTime && !showInlineDateTime && (
-                <WrapperRow>
-                  {open !== false && (!!timeFrom || !!timeTo) && (
-                    <TimeBox>
-                      {!!timeFrom && <RegularText>{timeFrom}</RegularText>}
-                      {!!timeFrom && !!timeTo && timeFrom !== timeTo && (
-                        <>
-                          <RegularText> -</RegularText>
-                          <RegularText> {timeTo}</RegularText>
-                        </>
-                      )}
-                    </TimeBox>
-                  )}
-                  {open === false && (
-                    <TimeBox>
-                      <RegularText>geschlossen</RegularText>
-                    </TimeBox>
-                  )}
-                  {(!!dateFrom || !!dateTo) && (
-                    <DateBox leftAligned={leftAligned}>
-                      {!!dateFrom && (
-                        <RegularText>
-                          {!!datePrefix && <RegularText small>{datePrefix} </RegularText>}
-                          {momentFormat(dateFrom, returnFormatDate)}
-                        </RegularText>
-                      )}
-
-                      {!!dateTo && dateTo !== dateFrom && (
-                        <RegularText>
-                          <RegularText small>bis </RegularText>
-                          {momentFormat(dateTo, returnFormatDate)}
-                        </RegularText>
-                      )}
-                    </DateBox>
-                  )}
-                </WrapperRow>
-              )}
-
-              {!!description && (
-                <WrapperRow style={styles.margin}>
-                  <HtmlView html={description} />
-                </WrapperRow>
-              )}
-            </WrapperVertical>
-          );
-        })}
+            {group.openingHours.map((openingHour, openingHourIndex) => (
+              <OpeningHourDetails
+                inlineDateTime={inlineDateTime}
+                key={openingHour.id ?? openingHourIndex}
+                leftAligned={leftAligned}
+                openingHour={openingHour}
+                styles={styles}
+              />
+            ))}
+          </WrapperVertical>
+        );
+      })}
 
       {moreData * MAX_INITIAL_NUM_TO_RENDER < openingHours.length && (
         <WrapperVertical style={styles.noPaddingBottom}>
@@ -246,6 +307,7 @@ const createStyles = (colors) => ({
 
 OpeningTimesCard.propTypes = {
   appointmentsShowMoreButton: PropTypes.string,
+  groupRecurringWeekdays: PropTypes.bool,
   inlineDateTime: PropTypes.bool,
   leftAligned: PropTypes.bool,
   MAX_INITIAL_NUM_TO_RENDER: PropTypes.number,
@@ -262,4 +324,11 @@ OpeningTimesCard.propTypes = {
       weekday: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
     })
   )
+};
+
+OpeningHourDetails.propTypes = {
+  inlineDateTime: PropTypes.bool,
+  leftAligned: PropTypes.bool,
+  openingHour: PropTypes.object,
+  styles: PropTypes.object
 };

--- a/src/components/screens/PointOfInterest.tsx
+++ b/src/components/screens/PointOfInterest.tsx
@@ -37,6 +37,7 @@ import { OpeningTimesCard } from './OpeningTimesCard';
 import { OperatingCompany } from './OperatingCompany';
 import { PriceCard } from './PriceCard';
 import { TravelTimes } from './TravelTimes';
+import { isOpeningTimesGroupingEnabled } from './openingTimesSettings';
 
 const { MAP, MATOMO_TRACKING } = consts;
 export const INITIAL_VOUCHER_COUNT = 3;
@@ -67,6 +68,7 @@ export const PointOfInterest = ({
   const { globalSettings } = useContext(SettingsContext);
   const { settings = {} } = globalSettings;
   const { showOpeningTimes = true, showDistanceDirection = {} } = settings;
+  const groupOpeningTimesByWeekday = isOpeningTimesGroupingEnabled(settings);
   const [loadedVoucherDataCount, setLoadedVoucherDataCount] = useState(INITIAL_VOUCHER_COUNT);
   const [availableVehiclesData, setAvailableVehiclesData] = useState<VehicleStatusFeature[]>([]);
   const [availableVehiclesLoading, setAvailableVehiclesLoading] = useState(true);
@@ -321,7 +323,10 @@ export const PointOfInterest = ({
       {!!openingHours?.length && (
         <WrapperVertical>
           <SectionHeader title={texts.pointOfInterest.openingTime} />
-          <OpeningTimesCard openingHours={openingHours} />
+          <OpeningTimesCard
+            groupRecurringWeekdays={groupOpeningTimesByWeekday}
+            openingHours={openingHours}
+          />
         </WrapperVertical>
       )}
 

--- a/src/components/screens/openingTimesSettings.js
+++ b/src/components/screens/openingTimesSettings.js
@@ -1,0 +1,2 @@
+export const isOpeningTimesGroupingEnabled = (settings = {}) =>
+  settings?.openingTimes?.groupByWeekday === true;


### PR DESCRIPTION
With this PR, the business’s opening hours are grouped by day.

To enable this feature, you need to add the following statement to `globalSettings.settings`.

```
    "openingTimes": {
      "groupByWeekday": false
    },
```

|before|after|
|--|--|
<img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-28 at 11 45 57-20260828-094557" src="https://github.com/user-attachments/assets/bc3e0b22-e13c-463e-bedf-1f01c846dadb" />|<img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-28 at 11 45 15-20260828-094515" src="https://github.com/user-attachments/assets/4db21b1e-63cb-4847-a109-643a65e28295" />

SVA-1767
